### PR TITLE
docs(observability): correct the release's documentation drift and panel what it added

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -17,6 +17,15 @@ on:
       # step on four PRs that moved no pixel.
       - 'internal/notify/testdata/incident-card.golden.json'
       - 'hack/check-screenshots-fresh.sh'
+      # The alert manifests carry runbook_url annotations INTO the docs site, and
+      # SECURITY.md/ROADMAP.md link into it too. Those links are checked by the step
+      # below and by internal/docsguard, neither of which ran on a change confined to
+      # deploy/ — which is exactly how 24 runbook_urls went on pointing at a file
+      # deleted months earlier.
+      - 'deploy/observability/**'
+      - 'SECURITY.md'
+      - 'ROADMAP.md'
+      - 'internal/docsguard/**'
       - '.github/workflows/docs-check.yml'
   push:
     branches: [main]
@@ -32,6 +41,15 @@ on:
       # step on four PRs that moved no pixel.
       - 'internal/notify/testdata/incident-card.golden.json'
       - 'hack/check-screenshots-fresh.sh'
+      # The alert manifests carry runbook_url annotations INTO the docs site, and
+      # SECURITY.md/ROADMAP.md link into it too. Those links are checked by the step
+      # below and by internal/docsguard, neither of which ran on a change confined to
+      # deploy/ — which is exactly how 24 runbook_urls went on pointing at a file
+      # deleted months earlier.
+      - 'deploy/observability/**'
+      - 'SECURITY.md'
+      - 'ROADMAP.md'
+      - 'internal/docsguard/**'
       - '.github/workflows/docs-check.yml'
 
 permissions:
@@ -77,13 +95,27 @@ jobs:
         # at fragment links within a page. Runs against the HTML the step above rendered.
         run: hack/check-anchors.sh
 
-      - name: README/CONTRIBUTING must not link to raw docs/*.md
+      - name: No published surface may link to a raw docs/*.md
+        # docs/*.md moved into website/content and the old paths 404. This guard was
+        # scoped to two README files and to markdown-link syntax only, so it saw neither
+        # SECURITY.md's two dead links nor the 24 bare `blob/main/docs/observability.md`
+        # runbook_url annotations in the alert manifests. Both patterns, every published
+        # surface. dev/ and docs/superpowers/ are working notes, not published, and are
+        # deliberately out of scope.
         run: |
-          if grep -nE '\]\((\.?/)?docs/[a-z0-9/_-]+\.md' README.md CONTRIBUTING.md; then
-            echo "::error::README/CONTRIBUTING still link to raw docs/*.md — repoint to https://runlore.io/docs/…"
+          set -uo pipefail
+          if grep -rnE '\]\((\.?/)?docs/[a-z0-9/_-]+\.md|github\.com/Smana/runlore/blob/[^)"'"'"' ]*/docs/[a-z0-9/_-]+\.md' \
+               README.md CONTRIBUTING.md SECURITY.md ROADMAP.md website/content deploy; then
+            echo "::error::a published file still links to a raw docs/*.md path — that tree moved to website/content; repoint to https://runlore.io/docs/…"
             exit 1
           fi
-          echo "OK: no raw docs/*.md links in README/CONTRIBUTING"
+          echo "OK: no raw docs/*.md links in any published surface"
+
+      - name: Alert runbook_urls must resolve to a real heading
+        # The complement to the grep above: that one catches links to the OLD tree, this
+        # catches a runbook_url whose anchor simply does not exist on the page it names —
+        # including a newly added alert rule that shipped without a runbook section.
+        run: go test ./internal/docsguard/... -run 'Runbook|EveryAlert' -v
 
       - name: Screenshots must show the card RunLore actually draws
         # Compares a digest of the rendered card, so it needs no git history — the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,8 +7,8 @@ not in a public issue.
 
 For the technical architecture behind RunLore's defenses — the prompt-injection design,
 secret-redaction boundaries, and network guards — see
-[`docs/security-architecture.md`](docs/security-architecture.md) and the runtime
-[`docs/security-model.md`](docs/security-model.md).
+[LLM security architecture](https://runlore.io/docs/security/security-architecture/) and the runtime
+[security model](https://runlore.io/docs/security/security-model/).
 
 ## Reporting a vulnerability
 

--- a/deploy/observability/alerts/README.md
+++ b/deploy/observability/alerts/README.md
@@ -77,6 +77,9 @@ listed series must be present.
 | RunloreModelLatencyHigh                  | warning  | `runlore_model_request_duration_seconds_bucket`                               |
 | RunloreSlowResolution                    | info     | `runlore_incident_resolution_seconds_bucket`                                  |
 | RunloreInvestigationCostHigh             | warning  | `runlore_investigation_tokens_estimated_bucket`                               |
+| RunloreInvestigationsNudgedByCeiling     | warning  | `runlore_investigation_budget_trips_total{stage="nudge"}`, `runlore_investigations_completed_total` |
+| RunloreThreadMentionsDropped             | warning  | `runlore_mentions_dropped_on_saturation_total`                                 |
+| RunloreCurationWriteErrors               | warning  | `runlore_curations_total{result="error"}`                                      |
 
 All metrics are exposed on RunLore's Prometheus `/metrics` endpoint. Histograms
 additionally expose `_sum` and `_count` series alongside the `_bucket` series

--- a/deploy/observability/alerts/README.md
+++ b/deploy/observability/alerts/README.md
@@ -84,6 +84,13 @@ used by the quantile rules.
 
 ## Runbooks
 
-Each rule's `runbook_url` annotation points at
-`https://github.com/Smana/runlore/blob/main/docs/observability.md#<anchor>`
-(placeholders — the per-alert anchors live in that doc).
+Each rule's `runbook_url` annotation points at its own section under
+[Observability → Alert runbooks](https://runlore.io/docs/operations/observability/#alert-runbooks):
+`https://runlore.io/docs/operations/observability/#<lowercased-alert-name>`.
+
+These are not placeholders — every anchor is pinned by
+`TestRunbookURLsResolveToARealHeading` and `TestEveryAlertHasARunbookSection` in
+`internal/docsguard`, which fail CI if a rule is added without a runbook section, if an
+anchor stops resolving, or if a rule lands in only one of the two manifest flavours.
+Adding a rule therefore means adding a `### <AlertName>` section to that page in the
+same change.

--- a/deploy/observability/alerts/prometheusrule.yaml
+++ b/deploy/observability/alerts/prometheusrule.yaml
@@ -196,3 +196,53 @@ spec:
             summary: "RunLore investigation token cost is high"
             description: "p95 estimated tokens per investigation is {{ $value | humanize }} over the last 30m (>100k) — typical investigations are ending on a request at the per-request bound; review cost, max_tool_output_bytes and compaction."
             runbook_url: "https://runlore.io/docs/operations/observability/#runloreinvestigationcosthigh"
+
+        # 13. A spend ceiling is silently truncating investigations.
+        # THE one to alert on among the budget signals. A nudged investigation is
+        # forced to conclude early but still delivers findings and records
+        # result="resolved" like any other, so it is invisible in every other series:
+        # completion rate, error rate and duration all look healthy while answers get
+        # quietly shallower. Only this counter distinguishes "the ceiling is
+        # comfortable" from "the ceiling has been truncating investigations for a
+        # week". Ratio over completions, gated on >= 5 completions in the window so it
+        # is not noise on a quiet cluster. 10% is a starting point.
+        - alert: RunloreInvestigationsNudgedByCeiling
+          expr: sum(increase(runlore_investigation_budget_trips_total{stage="nudge"}[1h])) / clamp_min(sum(increase(runlore_investigations_completed_total[1h])), 1) > 0.1 and sum(increase(runlore_investigations_completed_total[1h])) >= 5
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore investigations are being cut short by a spend ceiling"
+            description: "{{ $value | humanizePercentage }} of investigations in the last hour were nudged to conclude early by a spend ceiling (>10%). They completed and reported findings, so nothing else shows this — but the findings are shallower than a full run would produce. Check sum by (reason) (rate(runlore_investigation_budget_trips_total[1h])) for which ceiling to raise."
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloreinvestigationsnudgedbyceiling"
+
+        # 14. A human's note was accepted and then lost.
+        # The handler pool was saturated when an @runlore mention arrived. The
+        # transport was already acked (Slack 200; Matrix's /sync token advanced), so
+        # it will never be redelivered and the note is permanently gone. RunLore tells
+        # the human to retry via a best-effort in-thread reply, but that is the only
+        # trace. Any occurrence is worth surfacing — this is data loss, not backpressure.
+        - alert: RunloreThreadMentionsDropped
+          expr: sum(increase(runlore_mentions_dropped_on_saturation_total[15m])) > 0
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore dropped a chat mention — the note is permanently lost"
+            description: "{{ $value | humanize }} chat mentions were dropped in the last 15m because the handler pool was saturated. The transport was already acked, so these are NOT retried: whatever a human tried to record is gone and they must send it again."
+            runbook_url: "https://runlore.io/docs/operations/observability/#runlorethreadmentionsdropped"
+
+        # 15. Knowledge is being produced and failing to land.
+        # A curation error means an investigation reached a finding and the forge write
+        # failed — so the learning loop stops compounding while every upstream metric
+        # (investigations completed, recall rate) still looks healthy. Usually GitHub
+        # App scopes, a wrong forge.kb_repo, or the App's installation losing access.
+        - alert: RunloreCurationWriteErrors
+          expr: sum(increase(runlore_curations_total{result="error"}[30m])) > 0
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore is failing to write curated knowledge to the forge"
+            description: "{{ $value | humanize }} curation writes failed in the last 30m — findings were produced but never reached the knowledge base, so the learning loop is not compounding. Check the GitHub App scopes and forge.kb_repo; look for msg=\"curate findings\" with err= in the logs."
+            runbook_url: "https://runlore.io/docs/operations/observability/#runlorecurationwriteerrors"

--- a/deploy/observability/alerts/prometheusrule.yaml
+++ b/deploy/observability/alerts/prometheusrule.yaml
@@ -41,7 +41,7 @@ spec:
           annotations:
             summary: "RunLore agent is down or not scraped"
             description: "No runlore_build_info series for 5m — the RunLore agent is down or its /metrics endpoint is not being scraped."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreagentdown"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloreagentdown"
 
         # 2. No active leader (HA): nobody is investigating.
         # In a multi-replica HA deployment exactly one replica should hold the
@@ -55,7 +55,7 @@ spec:
           annotations:
             summary: "RunLore has no active leader"
             description: "No RunLore replica holds leadership for 10m (max(runlore_leader) == 0) — no investigations are being processed."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runlorenoactiveleader"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runlorenoactiveleader"
 
         # 3. Split-brain: more than one leader at once.
         # Two replicas both believing they are leader can double-process and
@@ -68,7 +68,7 @@ spec:
           annotations:
             summary: "RunLore has multiple leaders (split-brain)"
             description: "{{ $value | humanize }} RunLore replicas report leadership simultaneously — possible split-brain; investigations may be duplicated."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloremultipleleaders"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloremultipleleaders"
 
         # 4. Investigations are being dropped.
         # Dropped means an alert was discarded without investigation (e.g. queue
@@ -82,7 +82,7 @@ spec:
           annotations:
             summary: "RunLore is dropping investigations"
             description: "{{ $value | humanize }} investigations dropped in the last 15m — alerts are being discarded without investigation (likely queue overflow or backpressure)."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreinvestigationsdropped"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloreinvestigationsdropped"
 
         # 5. Sustained throttling.
         # Brief throttling under a burst is normal; 30m of continuous throttling
@@ -96,7 +96,7 @@ spec:
           annotations:
             summary: "RunLore investigations throttled for a sustained period"
             description: "RunLore has been throttling investigations continuously for 30m (rate {{ $value | humanize }}/s) — capacity may be insufficient for the incoming alert volume."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreinvestigationthrottlingsustained"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloreinvestigationthrottlingsustained"
 
         # 6. Pipeline stalled: alerts arrive but nothing starts.
         # Alerts are landing (received increases) yet zero investigations start —
@@ -109,7 +109,7 @@ spec:
           annotations:
             summary: "RunLore pipeline stalled — alerts received but no investigations started"
             description: "{{ $value | humanize }} alerts received in the last 15m but zero investigations were started — the intake-to-investigation pipeline appears stalled."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runlorepipelinestalled"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runlorepipelinestalled"
 
         # 7. Investigations completing with an error result.
         # Investigations that finish in `result="error"` indicate the agent loop
@@ -123,7 +123,7 @@ spec:
           annotations:
             summary: "RunLore investigations are completing with errors"
             description: "{{ $value | humanize }} investigations completed with result=error in the last 15m — the investigation loop is failing for some incidents."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreinvestigationerrors"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloreinvestigationerrors"
 
         # 8. Tool-call error rate is high.
         # Error fraction across all tool calls > 20%, gated on a minimum call
@@ -137,7 +137,7 @@ spec:
           annotations:
             summary: "RunLore tool-call error rate is high"
             description: "Tool-call error fraction is {{ $value | humanizePercentage }} over the last 15m (>20%) — investigation tools are failing frequently; check {{ $labels.tool }} integrations."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloretoolerrorratehigh"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloretoolerrorratehigh"
 
         # 9. Model-request error rate is high.
         # Same shape as the tool-error rule but for the LLM provider, with a
@@ -151,7 +151,7 @@ spec:
           annotations:
             summary: "RunLore model-request error rate is high"
             description: "Model-request error fraction is {{ $value | humanizePercentage }} over the last 15m (>10%) — the LLM provider {{ $labels.provider }} is failing; investigations cannot complete."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloremodelerrorratehigh"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloremodelerrorratehigh"
 
         # 10. Model p95 latency high.
         # p95 of model_request_duration over 15m exceeds 30s. Slow model calls
@@ -165,7 +165,7 @@ spec:
           annotations:
             summary: "RunLore model p95 latency is high"
             description: "p95 model-request latency is {{ $value | humanizeDuration }} over the last 15m (>30s) — investigations are slowed by model response time."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloremodellatencyhigh"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloremodellatencyhigh"
 
         # 11. Slow incident resolution.
         # p95 open->resolve time over 1h exceeds 1h. Informational SLO signal,
@@ -179,7 +179,7 @@ spec:
           annotations:
             summary: "RunLore incident resolution is slow"
             description: "p95 incident resolution time (open -> resolved) is {{ $value | humanizeDuration }} over the last hour (>1h) — incidents are taking long to resolve."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreslowresolution"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloreslowresolution"
 
         # 12. Investigation token cost is high.
         # runlore_investigation_tokens_estimated records the size of the LAST request an
@@ -195,4 +195,4 @@ spec:
           annotations:
             summary: "RunLore investigation token cost is high"
             description: "p95 estimated tokens per investigation is {{ $value | humanize }} over the last 30m (>100k) — typical investigations are ending on a request at the per-request bound; review cost, max_tool_output_bytes and compaction."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreinvestigationcosthigh"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloreinvestigationcosthigh"

--- a/deploy/observability/alerts/vmrule.yaml
+++ b/deploy/observability/alerts/vmrule.yaml
@@ -192,3 +192,53 @@ spec:
             summary: "RunLore investigation token cost is high"
             description: "p95 estimated tokens per investigation is {{ $value | humanize }} over the last 30m (>100k) — typical investigations are ending on a request at the per-request bound; review cost, max_tool_output_bytes and compaction."
             runbook_url: "https://runlore.io/docs/operations/observability/#runloreinvestigationcosthigh"
+
+        # 13. A spend ceiling is silently truncating investigations.
+        # THE one to alert on among the budget signals. A nudged investigation is
+        # forced to conclude early but still delivers findings and records
+        # result="resolved" like any other, so it is invisible in every other series:
+        # completion rate, error rate and duration all look healthy while answers get
+        # quietly shallower. Only this counter distinguishes "the ceiling is
+        # comfortable" from "the ceiling has been truncating investigations for a
+        # week". Ratio over completions, gated on >= 5 completions in the window so it
+        # is not noise on a quiet cluster. 10% is a starting point.
+        - alert: RunloreInvestigationsNudgedByCeiling
+          expr: sum(increase(runlore_investigation_budget_trips_total{stage="nudge"}[1h])) / clamp_min(sum(increase(runlore_investigations_completed_total[1h])), 1) > 0.1 and sum(increase(runlore_investigations_completed_total[1h])) >= 5
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore investigations are being cut short by a spend ceiling"
+            description: "{{ $value | humanizePercentage }} of investigations in the last hour were nudged to conclude early by a spend ceiling (>10%). They completed and reported findings, so nothing else shows this — but the findings are shallower than a full run would produce. Check sum by (reason) (rate(runlore_investigation_budget_trips_total[1h])) for which ceiling to raise."
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloreinvestigationsnudgedbyceiling"
+
+        # 14. A human's note was accepted and then lost.
+        # The handler pool was saturated when an @runlore mention arrived. The
+        # transport was already acked (Slack 200; Matrix's /sync token advanced), so
+        # it will never be redelivered and the note is permanently gone. RunLore tells
+        # the human to retry via a best-effort in-thread reply, but that is the only
+        # trace. Any occurrence is worth surfacing — this is data loss, not backpressure.
+        - alert: RunloreThreadMentionsDropped
+          expr: sum(increase(runlore_mentions_dropped_on_saturation_total[15m])) > 0
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore dropped a chat mention — the note is permanently lost"
+            description: "{{ $value | humanize }} chat mentions were dropped in the last 15m because the handler pool was saturated. The transport was already acked, so these are NOT retried: whatever a human tried to record is gone and they must send it again."
+            runbook_url: "https://runlore.io/docs/operations/observability/#runlorethreadmentionsdropped"
+
+        # 15. Knowledge is being produced and failing to land.
+        # A curation error means an investigation reached a finding and the forge write
+        # failed — so the learning loop stops compounding while every upstream metric
+        # (investigations completed, recall rate) still looks healthy. Usually GitHub
+        # App scopes, a wrong forge.kb_repo, or the App's installation losing access.
+        - alert: RunloreCurationWriteErrors
+          expr: sum(increase(runlore_curations_total{result="error"}[30m])) > 0
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore is failing to write curated knowledge to the forge"
+            description: "{{ $value | humanize }} curation writes failed in the last 30m — findings were produced but never reached the knowledge base, so the learning loop is not compounding. Check the GitHub App scopes and forge.kb_repo; look for msg=\"curate findings\" with err= in the logs."
+            runbook_url: "https://runlore.io/docs/operations/observability/#runlorecurationwriteerrors"

--- a/deploy/observability/alerts/vmrule.yaml
+++ b/deploy/observability/alerts/vmrule.yaml
@@ -37,7 +37,7 @@ spec:
           annotations:
             summary: "RunLore agent is down or not scraped"
             description: "No runlore_build_info series for 5m — the RunLore agent is down or its /metrics endpoint is not being scraped."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreagentdown"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloreagentdown"
 
         # 2. No active leader (HA): nobody is investigating.
         # In a multi-replica HA deployment exactly one replica should hold the
@@ -51,7 +51,7 @@ spec:
           annotations:
             summary: "RunLore has no active leader"
             description: "No RunLore replica holds leadership for 10m (max(runlore_leader) == 0) — no investigations are being processed."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runlorenoactiveleader"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runlorenoactiveleader"
 
         # 3. Split-brain: more than one leader at once.
         # Two replicas both believing they are leader can double-process and
@@ -64,7 +64,7 @@ spec:
           annotations:
             summary: "RunLore has multiple leaders (split-brain)"
             description: "{{ $value | humanize }} RunLore replicas report leadership simultaneously — possible split-brain; investigations may be duplicated."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloremultipleleaders"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloremultipleleaders"
 
         # 4. Investigations are being dropped.
         # Dropped means an alert was discarded without investigation (e.g. queue
@@ -78,7 +78,7 @@ spec:
           annotations:
             summary: "RunLore is dropping investigations"
             description: "{{ $value | humanize }} investigations dropped in the last 15m — alerts are being discarded without investigation (likely queue overflow or backpressure)."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreinvestigationsdropped"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloreinvestigationsdropped"
 
         # 5. Sustained throttling.
         # Brief throttling under a burst is normal; 30m of continuous throttling
@@ -92,7 +92,7 @@ spec:
           annotations:
             summary: "RunLore investigations throttled for a sustained period"
             description: "RunLore has been throttling investigations continuously for 30m (rate {{ $value | humanize }}/s) — capacity may be insufficient for the incoming alert volume."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreinvestigationthrottlingsustained"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloreinvestigationthrottlingsustained"
 
         # 6. Pipeline stalled: alerts arrive but nothing starts.
         # Alerts are landing (received increases) yet zero investigations start —
@@ -105,7 +105,7 @@ spec:
           annotations:
             summary: "RunLore pipeline stalled — alerts received but no investigations started"
             description: "{{ $value | humanize }} alerts received in the last 15m but zero investigations were started — the intake-to-investigation pipeline appears stalled."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runlorepipelinestalled"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runlorepipelinestalled"
 
         # 7. Investigations completing with an error result.
         # Investigations that finish in `result="error"` indicate the agent loop
@@ -119,7 +119,7 @@ spec:
           annotations:
             summary: "RunLore investigations are completing with errors"
             description: "{{ $value | humanize }} investigations completed with result=error in the last 15m — the investigation loop is failing for some incidents."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreinvestigationerrors"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloreinvestigationerrors"
 
         # 8. Tool-call error rate is high.
         # Error fraction across all tool calls > 20%, gated on a minimum call
@@ -133,7 +133,7 @@ spec:
           annotations:
             summary: "RunLore tool-call error rate is high"
             description: "Tool-call error fraction is {{ $value | humanizePercentage }} over the last 15m (>20%) — investigation tools are failing frequently; check {{ $labels.tool }} integrations."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloretoolerrorratehigh"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloretoolerrorratehigh"
 
         # 9. Model-request error rate is high.
         # Same shape as the tool-error rule but for the LLM provider, with a
@@ -147,7 +147,7 @@ spec:
           annotations:
             summary: "RunLore model-request error rate is high"
             description: "Model-request error fraction is {{ $value | humanizePercentage }} over the last 15m (>10%) — the LLM provider {{ $labels.provider }} is failing; investigations cannot complete."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloremodelerrorratehigh"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloremodelerrorratehigh"
 
         # 10. Model p95 latency high.
         # p95 of model_request_duration over 15m exceeds 30s. Slow model calls
@@ -161,7 +161,7 @@ spec:
           annotations:
             summary: "RunLore model p95 latency is high"
             description: "p95 model-request latency is {{ $value | humanizeDuration }} over the last 15m (>30s) — investigations are slowed by model response time."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloremodellatencyhigh"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloremodellatencyhigh"
 
         # 11. Slow incident resolution.
         # p95 open->resolve time over 1h exceeds 1h. Informational SLO signal,
@@ -175,7 +175,7 @@ spec:
           annotations:
             summary: "RunLore incident resolution is slow"
             description: "p95 incident resolution time (open -> resolved) is {{ $value | humanizeDuration }} over the last hour (>1h) — incidents are taking long to resolve."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreslowresolution"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloreslowresolution"
 
         # 12. Investigation token cost is high.
         # runlore_investigation_tokens_estimated records the size of the LAST request an
@@ -191,4 +191,4 @@ spec:
           annotations:
             summary: "RunLore investigation token cost is high"
             description: "p95 estimated tokens per investigation is {{ $value | humanize }} over the last 30m (>100k) — typical investigations are ending on a request at the per-request bound; review cost, max_tool_output_bytes and compaction."
-            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreinvestigationcosthigh"
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloreinvestigationcosthigh"

--- a/deploy/observability/grafana/runlore.json
+++ b/deploy/observability/grafana/runlore.json
@@ -34,7 +34,7 @@
       },
       "id": 114,
       "panels": [],
-      "title": "\ud83e\udde0 Learning loop \u2014 is it working?",
+      "title": "🧠 Learning loop — is it working?",
       "type": "row"
     },
     {
@@ -42,7 +42,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Share of incidents answered INSTANTLY from the knowledge base (recall) vs a full investigation. The headline learning-loop KPI \u2014 it should climb as the catalog compounds.",
+      "description": "Share of incidents answered INSTANTLY from the knowledge base (recall) vs a full investigation. The headline learning-loop KPI — it should climb as the catalog compounds.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -113,7 +113,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Of the recalls that fired, the share the adversarial verify pass kept at full confidence (vs downgraded/rejected). A low value means recalls fire but don't hold up \u2014 check confirm evidence / entry quality.",
+      "description": "Of the recalls that fired, the share the adversarial verify pass kept at full confidence (vs downgraded/rejected). A low value means recalls fire but don't hold up — check confirm evidence / entry quality.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -255,7 +255,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Share of an investigation's model tokens that a delivered recall short-circuit avoids: 1 - (tokens per recall / tokens per full-loop investigation), both provider-reported over the dashboard range. MEASURED on both sides \u2014 not an assumed budget ceiling. Negative means a recall currently costs more than the loop it replaced (check the reranker and verify token counts). The \"Token cost: full loop vs recall\" panel shows the two raw means.",
+      "description": "Share of an investigation's model tokens that a delivered recall short-circuit avoids: 1 - (tokens per recall / tokens per full-loop investigation), both provider-reported over the dashboard range. MEASURED on both sides — not an assumed budget ceiling. Negative means a recall currently costs more than the loop it replaced (check the reranker and verify token counts). The \"Token cost: full loop vs recall\" panel shows the two raw means.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -325,7 +325,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Structurally-invalid entries at the MOST RECENT catalog index (6m window \u2248 one git-sync). >0 means entries are silently dropped from recall \u2014 fix them (see `lore validate-kb`).",
+      "description": "Structurally-invalid entries at the MOST RECENT catalog index (6m window ≈ one git-sync). >0 means entries are silently dropped from recall — fix them (see `lore validate-kb`).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -397,7 +397,7 @@
       },
       "id": 115,
       "panels": [],
-      "title": "\ud83d\udd0e Retrieve \u2014 instant recall",
+      "title": "🔎 Retrieve — instant recall",
       "type": "row"
     },
     {
@@ -405,7 +405,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Every fired recall by the verify pass's verdict: verified (kept), downgraded (confidence lowered), rejected (withdrawn \u2192 fell through to a full investigation). Watch the downgraded share.",
+      "description": "Every fired recall by the verify pass's verdict: verified (kept), downgraded (confidence lowered), rejected (withdrawn → fell through to a full investigation). Watch the downgraded share.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -778,7 +778,7 @@
       },
       "id": 116,
       "panels": [],
-      "title": "\ud83e\uddea Capture & trust \u2014 outcome ledger",
+      "title": "🧪 Capture & trust — outcome ledger",
       "type": "row"
     },
     {
@@ -1069,7 +1069,7 @@
       },
       "id": 117,
       "panels": [],
-      "title": "\ud83d\udcdd Curate \u2014 knowledge growth",
+      "title": "📝 Curate — knowledge growth",
       "type": "row"
     },
     {
@@ -1255,7 +1255,7 @@
       },
       "id": 118,
       "panels": [],
-      "title": "\ud83d\udcb8 Cost & efficiency",
+      "title": "💸 Cost & efficiency",
       "type": "row"
     },
     {
@@ -1263,7 +1263,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Mean provider-reported tokens (input incl. cached + output) per investigation, split by whether a recall short-circuited it. The GAP between the two lines IS the saving \u2014 both are measured the same way, over the same window, per investigation. The full-loop line filters {result!=\"recall\"} so it excludes the very runs it is being compared against; without that filter it would contain them and the apparent saving would shrink as recall improved. A window with no investigations of a given kind reads as no-data, not zero.",
+      "description": "Mean provider-reported tokens (input incl. cached + output) per investigation, split by whether a recall short-circuited it. The GAP between the two lines IS the saving — both are measured the same way, over the same window, per investigation. The full-loop line filters {result!=\"recall\"} so it excludes the very runs it is being compared against; without that filter it would contain them and the apparent saving would shrink as recall improved. A window with no investigations of a given kind reads as no-data, not zero.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1473,7 +1473,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Share of input tokens served from the provider prompt cache \u2014 higher is cheaper/faster.",
+      "description": "Share of input tokens served from the provider prompt cache — higher is cheaper/faster.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1565,16 +1565,208 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "nudge = the run was forced to conclude early but still delivered findings; kill = hard-stopped (result=budget_exceeded). A nudged investigation completes and records result=resolved like any other, so it is invisible in every other series — this is the only panel that shows a ceiling silently truncating investigations. Alert on the nudge series.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 58
+      },
+      "id": 130,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (stage) (rate(runlore_investigation_budget_trips_total[$__rate_interval]))",
+          "legendFormat": "{{stage}}",
+          "refId": "A",
+          "instant": false
+        }
+      ],
+      "title": "Spend-ceiling trips by stage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "tokens_request = the next single request alone exceeded a quarter of max_tokens_per_investigation; tokens_total = the run's cumulative tokens did; cost = max_cost_per_investigation (needs model.pricing). One run reports one reason — the ceiling that first engaged the ladder is latched from nudge through kill — so this names the knob to raise.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 58
+      },
+      "id": 131,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (reason) (rate(runlore_investigation_budget_trips_total[$__rate_interval]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A",
+          "instant": false
+        }
+      ],
+      "title": "Which ceiling is binding (by reason)",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 58
+        "y": 66
       },
       "id": 119,
       "panels": [],
-      "title": "\ud83d\udd2c Investigations",
+      "title": "🔬 Investigations",
       "type": "row"
     },
     {
@@ -1636,7 +1828,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 59
+        "y": 67
       },
       "id": 21,
       "options": {
@@ -1749,7 +1941,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 59
+        "y": 67
       },
       "id": 22,
       "options": {
@@ -1862,7 +2054,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 59
+        "y": 67
       },
       "id": 23,
       "options": {
@@ -1902,11 +2094,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 67
+        "y": 75
       },
       "id": 120,
       "panels": [],
-      "title": "\ud83d\udee0 Tools & model",
+      "title": "🛠 Tools & model",
       "type": "row"
     },
     {
@@ -1968,7 +2160,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 68
+        "y": 76
       },
       "id": 31,
       "options": {
@@ -2071,7 +2263,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 68
+        "y": 76
       },
       "id": 32,
       "options": {
@@ -2164,7 +2356,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 68
+        "y": 76
       },
       "id": 33,
       "options": {
@@ -2257,7 +2449,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 76
+        "y": 84
       },
       "id": 34,
       "options": {
@@ -2360,7 +2552,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 76
+        "y": 84
       },
       "id": 35,
       "options": {
@@ -2453,7 +2645,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 76
+        "y": 84
       },
       "id": 36,
       "options": {
@@ -2546,7 +2738,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 84
+        "y": 92
       },
       "id": 12,
       "options": {
@@ -2586,11 +2778,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 92
+        "y": 100
       },
       "id": 121,
       "panels": [],
-      "title": "\ud83d\udce5 Alert intake",
+      "title": "📥 Alert intake",
       "type": "row"
     },
     {
@@ -2652,7 +2844,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 93
+        "y": 101
       },
       "id": 11,
       "options": {
@@ -2731,7 +2923,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 93
+        "y": 101
       },
       "id": 13,
       "options": {
@@ -2792,11 +2984,430 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 101
+        "y": 109
+      },
+      "id": 132,
+      "panels": [],
+      "title": "💬 Thread capture & chat",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Where an `@runlore note:` landed. comment = added to the curated PR this thread came from, and is DISCARDED when that PR merges; open_pr = a standalone Concept entry PR; append = added to the entry file of the standalone PR an earlier note in this thread opened. open_pr + append are the notes that become durable catalog knowledge.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 110
+      },
+      "id": 133,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (route) (rate(runlore_thread_notes_written_total[$__rate_interval]))",
+          "legendFormat": "{{route}}",
+          "refId": "A",
+          "instant": false
+        }
+      ],
+      "title": "Knowledge writes by route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Note writes denied by the global per-hour forge-write window and told to retry. This is the feature's one global cap and nothing else reports it — sustained non-zero means humans are being turned away mid-incident.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 110
+      },
+      "id": 134,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(runlore_thread_writes_throttled_total[$__rate_interval]))",
+          "legendFormat": "throttled",
+          "refId": "A",
+          "instant": false
+        }
+      ],
+      "title": "Thread writes throttled",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Model calls the chat layer made, against calls the per-hour budget refused. ceiling=tokens firing while call slots remain is the budget working as designed: the token ceiling is derived so a runaway of maximum-size calls is stopped by cost before it exhausts the call count.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 118
+      },
+      "id": 135,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(runlore_thread_chat_calls_total[$__rate_interval]))",
+          "legendFormat": "granted",
+          "refId": "A",
+          "instant": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (ceiling) (rate(runlore_thread_chat_denied_total[$__rate_interval]))",
+          "legendFormat": "denied — {{ceiling}}",
+          "refId": "B",
+          "instant": false
+        }
+      ],
+      "title": "Chat calls vs denials",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Chat tokens are provider-reported where available, otherwise a conservative estimate. NOTHING converts them to currency — model.chat.pricing is read by nothing — so do that yourself at your provider's rate. mentions_dropped is note LOSS: the handler pool was saturated, the transport was already acked, and the human's note is gone.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 118
+      },
+      "id": 136,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(runlore_thread_chat_tokens_total[$__rate_interval]))",
+          "legendFormat": "chat tokens/s",
+          "refId": "A",
+          "instant": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(runlore_mentions_dropped_on_saturation_total[$__rate_interval]))",
+          "legendFormat": "mentions dropped/s",
+          "refId": "B",
+          "instant": false
+        }
+      ],
+      "title": "Chat tokens spent / mentions dropped",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 126
       },
       "id": 122,
       "panels": [],
-      "title": "\ud83d\udda5 Fleet",
+      "title": "🖥 Fleet",
       "type": "row"
     },
     {
@@ -2828,7 +3439,7 @@
         "h": 5,
         "w": 8,
         "x": 0,
-        "y": 102
+        "y": 127
       },
       "id": 111,
       "options": {
@@ -2899,7 +3510,7 @@
         "h": 5,
         "w": 8,
         "x": 8,
-        "y": 102
+        "y": 127
       },
       "id": 112,
       "options": {
@@ -2966,7 +3577,7 @@
         "h": 5,
         "w": 8,
         "x": 16,
-        "y": 102
+        "y": 127
       },
       "id": 113,
       "options": {
@@ -3037,8 +3648,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "RunLore \u2014 SRE Agent",
+  "title": "RunLore — SRE Agent",
   "uid": "runlore-overview",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/internal/docsguard/metric_names_test.go
+++ b/internal/docsguard/metric_names_test.go
@@ -36,6 +36,11 @@ const (
 
 var metricNameRE = regexp.MustCompile(metricNamePattern)
 
+// metricTableRowRE matches a metric-table row: the metric name, backticked, as the
+// row's first cell. Anchored at the row start so a name appearing in a later cell (a
+// "see also" in the Meaning column) does not count as documenting it.
+var metricTableRowRE = regexp.MustCompile("^\\|\\s*`(" + metricNamePattern + ")`\\s*\\|")
+
 // TestPublishedMetricNamesExist pins every `runlore_*` series the Grafana dashboard
 // queries and the observability docs tabulate to a name the agent can actually emit.
 //
@@ -235,6 +240,24 @@ func markdownMetricRefs(_ *testing.T, body []byte) map[string][]string {
 	return refs
 }
 
+// markdownMetricTableRows pulls the metric named in the FIRST cell of each table row —
+// `| ` + "`runlore_x`" + ` | counter | … |` — and nothing else. This is deliberately stricter than
+// markdownMetricRefs, which scans the whole page: a series that appears only inside a
+// PromQL recipe is being *used*, not documented, and an operator scanning the tables to
+// learn what exists would still never find it. Requiring a row is what makes
+// TestEveryInstrumentIsDocumented mean what its name says.
+func markdownMetricTableRows(body []byte) map[string][]string {
+	refs := map[string][]string{}
+	for i, line := range strings.Split(string(body), "\n") {
+		m := metricTableRowRE.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		refs[m[1]] = appendUnique(refs[m[1]], "line "+strconv.Itoa(i+1))
+	}
+	return refs
+}
+
 func appendUnique(in []string, s string) []string {
 	for _, existing := range in {
 		if existing == s {
@@ -251,4 +274,58 @@ func sortedKeys(m map[string][]string) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// TestEveryInstrumentIsDocumented is the other direction, and the one that was
+// missing. TestPublishedMetricNamesExist walks docs -> instruments: it catches a doc
+// naming a series nothing emits (a rename, a typo). It cannot catch the opposite, which
+// is the far likelier drift: an instrument added and simply never written down. Nothing
+// referenced it, so nothing checked it, and it passed forever.
+//
+// That is not hypothetical — it is how this release shipped. Seven instruments were
+// added and four of them (thread_notes_written_total, thread_writes_throttled_total,
+// thread_chat_calls_total, thread_chat_tokens_total) appeared in no doc, no dashboard
+// and no alert. An operator watching the thread path had no way to learn the series
+// existed short of reading metrics.go or scraping /metrics and diffing by eye. Two
+// older ones (history_compactions_total, history_elided_bytes_total) had been
+// undocumented for far longer, for exactly the same reason.
+//
+// The bar is deliberately the metric TABLE, not "mentioned anywhere": an operator
+// looking for what RunLore exposes reads that page, and a series named only inside a
+// PromQL recipe is not documented, it is used. The source of truth is the real scrape,
+// same as above, so a new instrument is covered the day it is added rather than the day
+// someone remembers to list it here.
+func TestEveryInstrumentIsDocumented(t *testing.T) {
+	emitted := emittedSeries(t)
+
+	families := map[string]bool{}
+	for name := range emitted {
+		if !strings.HasPrefix(name, "runlore_") {
+			continue
+		}
+		families[strings.TrimSuffix(strings.TrimSuffix(strings.TrimSuffix(name, "_bucket"), "_sum"), "_count")] = true
+	}
+	if len(families) == 0 {
+		t.Fatal("no runlore_* families in the scrape — the exporter changed shape and this guard is inert")
+	}
+
+	body, err := os.ReadFile(filepath.Join(repoRoot(t), observabilityDoc))
+	if err != nil {
+		t.Fatalf("read %s: %v", observabilityDoc, err)
+	}
+	documented := markdownMetricTableRows(body)
+
+	for _, name := range sortedSet(families) {
+		if _, ok := documented[name]; ok {
+			continue
+		}
+		t.Errorf("%s has no metric-table row for %q, which the agent emits.\n"+
+			"  Add one — name, type, labels, and what a non-zero value means for an operator.\n"+
+			"  A mention in prose or inside a PromQL recipe does NOT count: that is the series "+
+			"being used, not documented, and someone scanning the tables to learn what RunLore "+
+			"exposes would still never find it.\n"+
+			"  An instrument nobody documented is one nobody can alert on — its existence depends "+
+			"on an operator scraping /metrics and noticing a name they have never seen.",
+			observabilityDoc, name)
+	}
 }

--- a/internal/docsguard/runbook_urls_test.go
+++ b/internal/docsguard/runbook_urls_test.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package docsguard
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The alert manifests are the one published surface that links INTO the docs site
+// from outside the site, which is exactly why their links rot unnoticed: Hugo's
+// refLinksErrorLevel only sees links written as relrefs inside content, and
+// hack/check-anchors.sh only reads rendered HTML. A runbook_url is neither. It is a
+// bare string in a YAML file that nothing parses.
+//
+// That gap already shipped: all 24 runbook_url annotations pointed at
+// https://github.com/Smana/runlore/blob/main/docs/observability.md#<anchor> long after
+// docs/observability.md was deleted in the move to website/. Every doc guard passed,
+// the site built clean, and an operator following the link from a firing alert got a
+// GitHub 404 — at the worst possible moment to go looking for a runbook.
+const (
+	alertsDir       = "deploy/observability/alerts"
+	runbookDoc      = "website/content/docs/operations/observability.md"
+	runbookBase     = "https://runlore.io/docs/operations/observability/"
+	minRunbookLinks = 24 // 12 alerts x 2 manifest flavours; raise as rules are added
+)
+
+var (
+	runbookURLRE = regexp.MustCompile(`runbook_url:\s*"([^"]+)"`)
+	alertNameRE  = regexp.MustCompile(`(?m)^\s*- alert:\s*(\S+)`)
+	headingRE    = regexp.MustCompile(`(?m)^#{2,6}\s+(.+?)\s*$`)
+)
+
+// TestRunbookURLsResolveToARealHeading pins every runbook_url in every shipped alert
+// manifest to a heading that actually exists in the observability page.
+//
+// It recomputes Hugo's anchor from the heading text rather than reading rendered HTML,
+// because this test must fail in `go test ./...` with no Hugo present. The recomputation
+// is deliberately narrow: it is only ever applied to headings this guard also requires to
+// be plain ASCII alphanumerics (the alert names), so the em-dash and emoji cases that make
+// a general Hugo anchor reimplementation wrong cannot arise here. hack/check-anchors.sh
+// remains the authority for anchors in prose.
+func TestRunbookURLsResolveToARealHeading(t *testing.T) {
+	root := repoRoot(t)
+
+	body, err := os.ReadFile(filepath.Join(root, runbookDoc))
+	if err != nil {
+		t.Fatalf("read %s: %v", runbookDoc, err)
+	}
+	anchors := map[string]string{}
+	for _, m := range headingRE.FindAllStringSubmatch(string(body), -1) {
+		anchors[hugoAnchor(m[1])] = m[1]
+	}
+	if len(anchors) == 0 {
+		t.Fatalf("no headings found in %s — the page moved or its shape changed, and this guard is inert", runbookDoc)
+	}
+
+	links := 0
+	for _, path := range alertManifests(t, root) {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		rel, _ := filepath.Rel(root, path)
+		for _, m := range runbookURLRE.FindAllStringSubmatch(string(raw), -1) {
+			links++
+			url := m[1]
+			if !strings.HasPrefix(url, runbookBase) {
+				t.Errorf("%s: runbook_url %q does not point at the published observability page.\n"+
+					"  want a %s#<anchor> URL.\n"+
+					"  A runbook_url is read by a human with a firing alert; nothing else validates it, "+
+					"so a stale host or a path from before the docs moved is invisible until then.",
+					rel, url, runbookBase)
+				continue
+			}
+			frag := strings.TrimPrefix(url, runbookBase)
+			if !strings.HasPrefix(frag, "#") {
+				t.Errorf("%s: runbook_url %q has no #anchor — it lands the operator at the top of a long page", rel, url)
+				continue
+			}
+			if _, ok := anchors[strings.TrimPrefix(frag, "#")]; !ok {
+				t.Errorf("%s: runbook_url %q points at an anchor no heading in %s produces.\n"+
+					"  Add a `### <AlertName>` runbook section for it, or fix the anchor.\n"+
+					"  known anchors: %s",
+					rel, url, runbookDoc, strings.Join(sortedSet(toSet(anchors)), ", "))
+			}
+		}
+	}
+	if links < minRunbookLinks {
+		t.Fatalf("found only %d runbook_url annotations across %s, want at least %d — "+
+			"the manifests moved or their shape changed, and this guard is checking almost nothing",
+			links, alertsDir, minRunbookLinks)
+	}
+}
+
+// TestEveryAlertHasARunbookSection is the other direction: a rule added without a
+// runbook section still ships a runbook_url, and the test above would catch a WRONG
+// anchor but not a rule whose author simply reused a neighbour's. Pinning alert name
+// to heading makes the section mandatory at the moment the rule is written.
+func TestEveryAlertHasARunbookSection(t *testing.T) {
+	root := repoRoot(t)
+
+	body, err := os.ReadFile(filepath.Join(root, runbookDoc))
+	if err != nil {
+		t.Fatalf("read %s: %v", runbookDoc, err)
+	}
+	headings := map[string]bool{}
+	for _, m := range headingRE.FindAllStringSubmatch(string(body), -1) {
+		headings[strings.TrimSpace(m[1])] = true
+	}
+
+	seen := map[string][]string{}
+	for _, path := range alertManifests(t, root) {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		rel, _ := filepath.Rel(root, path)
+		for _, m := range alertNameRE.FindAllStringSubmatch(string(raw), -1) {
+			seen[m[1]] = appendUnique(seen[m[1]], rel)
+		}
+	}
+	if len(seen) == 0 {
+		t.Fatalf("no `- alert:` entries found under %s — this guard is inert", alertsDir)
+	}
+
+	for _, name := range sortedKeys(seen) {
+		if !headings[name] {
+			t.Errorf("alert %s (in %s) has no `### %s` runbook section in %s.\n"+
+				"  Its runbook_url therefore cannot resolve. Every rule an operator can be paged by "+
+				"needs somewhere to land that says what to do.",
+				name, strings.Join(seen[name], ", "), name, runbookDoc)
+		}
+	}
+
+	// The two flavours must stay in lockstep: the manifests say so in their own header
+	// comments ("change one, change the other"), and a rule present in only one of them
+	// is a rule half the fleet never gets.
+	for _, name := range sortedKeys(seen) {
+		if len(seen[name]) != 2 {
+			t.Errorf("alert %s appears only in %s — the PrometheusRule and VMRule flavours must carry "+
+				"identical rules; whichever operator your cluster runs, it must get this alert.",
+				name, strings.Join(seen[name], ", "))
+		}
+	}
+}
+
+// alertManifests lists the shipped rule files. It fails loudly on an empty result so a
+// rename of the directory turns into a failure rather than a silently passing test.
+func alertManifests(t *testing.T, root string) []string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(root, alertsDir, "*.yaml"))
+	if err != nil {
+		t.Fatalf("glob %s: %v", alertsDir, err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("no *.yaml under %s — the manifests moved and this guard is inert", alertsDir)
+	}
+	sort.Strings(matches)
+	return matches
+}
+
+// hugoAnchor reproduces Hugo's "github" anchor style for the ASCII-alphanumeric
+// headings this guard applies it to: lowercase, runs of non-alphanumerics collapsed to
+// a single hyphen. See the doc comment on TestRunbookURLsResolveToARealHeading for why
+// the narrow scope is safe here and is not a general reimplementation.
+func hugoAnchor(heading string) string {
+	var b strings.Builder
+	prevHyphen := false
+	for _, r := range strings.ToLower(strings.TrimSpace(heading)) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			prevHyphen = false
+		default:
+			if !prevHyphen && b.Len() > 0 {
+				b.WriteByte('-')
+				prevHyphen = true
+			}
+		}
+	}
+	return strings.TrimSuffix(b.String(), "-")
+}
+
+func toSet(m map[string]string) map[string]bool {
+	out := make(map[string]bool, len(m))
+	for k := range m {
+		out[k] = true
+	}
+	return out
+}

--- a/internal/docsguard/runbook_urls_test.go
+++ b/internal/docsguard/runbook_urls_test.go
@@ -26,7 +26,7 @@ const (
 	alertsDir       = "deploy/observability/alerts"
 	runbookDoc      = "website/content/docs/operations/observability.md"
 	runbookBase     = "https://runlore.io/docs/operations/observability/"
-	minRunbookLinks = 24 // 12 alerts x 2 manifest flavours; raise as rules are added
+	minRunbookLinks = 30 // 15 alerts x 2 manifest flavours; raise as rules are added
 )
 
 var (

--- a/website/content/docs/configuration/configuration.md
+++ b/website/content/docs/configuration/configuration.md
@@ -242,7 +242,7 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`, `custom`.
   | The **dollar** cost of embeddings | The hybrid-recall query embed's *tokens* now count against `max_tokens_per_investigation`, but there is no `model.embeddings.pricing`, so RunLore has no rate to price them with and refuses to borrow a completion model's — that would put a fabricated figure on the notification footer and in `runlore_investigation_cost_usd`. `max_cost_per_investigation` therefore errs **low** by the embedding spend rather than quoting a number it cannot stand behind |
   | The adversarial verify pass's own cost | It runs after the last budget check, unconditionally, because verify is the honesty guarantee. A successful run can therefore deliver a `CostUSD` slightly above `max_cost_per_investigation` with no trip recorded |
   | A `lore eval` **campaign** as a whole | Each investigation it replays runs under the operator's configured `investigation.*` ceilings and `model.pricing` — the same limits production has — but a campaign is cases × n of them, so those ceilings multiply by the corpus size instead of capping the run. `--max-total-tokens` is the run-level ceiling; **unset, a campaign has none** |
-  | CLI-only model calls | `lore validate --semantic`, `lore kb import --model`, and the eval judge each make completions outside any investigation. None runs under `serve` |
+  | CLI-only model calls | `lore validate-kb --semantic`, `lore kb import --model`, and the eval judge each make completions outside any investigation. None runs under `serve` |
   | Non-model spend | Cloud API calls, git clones, metrics and logs queries are unpriced everywhere |
 - `compaction` — how mid-loop history compaction treats the older tool outputs it elides once the
   estimate crosses the compaction target — 0.7× the **per-request** budget, itself a quarter of
@@ -460,11 +460,25 @@ project path, e.g. `group/project`, nested groups allowed), `base_branch` (defau
 [Integrations → GitLab]({{< relref "/docs/integrations/forge/gitlab.md" >}}). `provider: gitlab` with no
 `gitlab.token_env`, or a `kb_repo` that isn't a valid GitLab project path, fails config load closed.
 
-`git_host` is the **one host the forge credential may be sent to** when RunLore clones — `what_changed`
-against your GitOps repo, `source_diff` against an allowlisted source repo, the catalog git-sync
-against the KB repo. A clone of any other host proceeds anonymously, because a GitOps
+`git_host` is the **one host the forge credential may be sent to** on the two clone paths whose repo
+URL comes from **cluster state** — `what_changed` against your GitOps repo, and `source_diff` against
+an allowlisted source repo. A clone of any other host proceeds anonymously, because a GitOps
 `spec.source.repoURL` is cluster state: anyone who can create an Argo CD `Application` picks it, and
-it must not be able to pick where your token goes. Leave it empty and it is derived — `github.com`
+it must not be able to pick where your token goes.
+
+> [!NOTE]
+> **The catalog git-sync is not confined by `git_host`.** `catalog.Syncer` has no host field at all
+> (`internal/catalog/sync.go`), so it attaches its credential to whatever `catalog.git.url` names —
+> the explicit `catalog.git.token_env` if you set one, otherwise the shared forge GitHub App
+> identity. Setting `git_host` does not change that; there is no mechanism on this path to change.
+>
+> The reason that is acceptable is a **different** reason from the one above, and it is worth knowing
+> which one you are relying on: `catalog.git.url` is *operator config*, not cluster state. It is a
+> value you write in `runlore.yaml`, so redirecting the token requires the ability to change your
+> config — which is already game over — rather than the ability to create an `Application` in some
+> namespace. What follows for you is practical: point `catalog.git.url` at a host you would hand the
+> forge credential to, and give it its own read-scoped `catalog.git.token_env` when the catalog lives
+> somewhere the forge App identity should not reach. Leave it empty and it is derived — `github.com`
 from `api.github.com`, the API host for GitHub Enterprise, `gitlab.base_url`'s host for GitLab. Set it
 only for **GitHub Enterprise with subdomain isolation** (API on `api.HOSTNAME`, git on `HOSTNAME`),
 which is the one shape the derivation cannot resolve; that config **fails load** until `git_host`
@@ -702,8 +716,8 @@ transport to ever fire, and startup **warns** (`… or this is dead config`) whe
       chat:
         model: claude-haiku-4-5      # REQUIRED — never inherited
         max_tokens: 1024             # optional; default 1024, NOT model.max_tokens
-        # provider, base_url, api_key_env, effort, thinking, pricing all inherit
-        # from `model` when omitted
+        # provider, base_url, api_key_env, effort inherit from `model` when omitted.
+        # thinking and pricing are accepted here but are INERT — see below.
     notify:
       thread:
         chat_calls_per_hour: 30      # default 30
@@ -718,6 +732,22 @@ transport to ever fire, and startup **warns** (`… or this is dead config`) whe
 > most expensive way to run it. `max_tokens` likewise falls back to a fixed **1024**, not to
 > `model.max_tokens`: a member-triggerable path staying cheap must not depend on how generously the
 > investigation model happens to be capped.
+
+> [!WARNING]
+> **`thinking` and `pricing` are accepted on `model.chat` and do nothing.** Config load validates
+> both — an invalid `thinking` mode or a negative rate is still rejected — so it is easy to read
+> their acceptance as them taking effect. They do not:
+>
+> - **`model.chat.thinking`** (or a `model.thinking` inherited onto it) takes effect on **no
+>   provider**. A chat reply is one call with a forced `submit_thread_reply` tool choice, which is
+>   what makes it a single call instead of an agent loop; the Anthropic client gates thinking on an
+>   *empty* tool choice, and the Gemini and OpenAI clients are never handed a thinking parameter at
+>   all.
+> - **`model.chat.pricing`** is read by **nothing**. Cost reporting — the notification footer and
+>   `runlore_investigation_cost_usd` — covers the investigation and verify passes only. The chat path
+>   emits `runlore_thread_chat_tokens_total` and stops there, so this is not merely "no cost ceiling":
+>   there is **no cost report**. You cannot graph what conversational replies spent in dollars; do
+>   that conversion yourself from the token counter.
 
 **What costs a model call, stated plainly.** With `model.chat` set, **every addressed message that is
 not a recognised command prefix costs exactly one model call** — one, structurally, not on average:
@@ -769,11 +799,15 @@ explicitly if you need a ceiling that stays put.
 > [!WARNING]
 > **What is NOT capped.** These are real edges, not caveats to reassure you past:
 >
-> - **There is no ceiling in currency.** `model.pricing` (and `model.chat.pricing`) remains a
->   *reporting* table — it turns token counts into a dollar estimate for display and for the
->   `investigation_cost_usd` metric. **Nothing compares a cost to a threshold and stops.** The only
->   spend ceilings are the call and token counts above; translate them into money yourself at your
->   provider's rate before enabling this.
+> - **There is no ceiling in currency *on this path*.** Note the scope — it narrowed this release.
+>   `investigation.max_cost_per_investigation` **is** a real ceiling now: RunLore compares an
+>   investigation's accumulated estimated cost against it and stops the run (`reason="cost"` on
+>   `runlore_investigation_budget_trips_total`), which is exactly what `model.pricing` makes
+>   enforceable. None of that reaches the **chat** layer. `model.chat.pricing` is read by nothing at
+>   all — there is no cost ceiling *and* no cost report for conversational replies, only the token
+>   counter `runlore_thread_chat_tokens_total`. The chat layer's only spend ceilings are the call and
+>   token counts above; translate them into money yourself at your provider's rate before enabling
+>   this.
 > - **The token ceiling runs partly on estimates, not only on reported usage.** Two cases. A call is
 >   charged an estimate the moment it is *admitted*, before the provider has said anything, so that
 >   calls running concurrently are visible to one another; when it returns, that reservation is

--- a/website/content/docs/integrations/data-sources/kubernetes.md
+++ b/website/content/docs/integrations/data-sources/kubernetes.md
@@ -48,9 +48,9 @@ kubectl -n runlore logs deploy/runlore | grep 'clientset unavailable'
   auto-defaults the app-layer allowlist to the RBAC namespace list, so the two stay in sync unless you
   override one.
 - **`resource_spec` reads one object's `.spec`/`.status` for any kind the cluster serves**, CRDs
-  included, resolving a bare `Kind` through discovery rather than a compiled-in table. Its four
-  endings are kept apart deliberately — `found`, `absent`, `forbidden`, `kind_unknown` — plus
-  `refused` and `kind_ambiguous`; **only `absent` is evidence that an object does not exist**. A
+  included, resolving a bare `Kind` through discovery rather than a compiled-in table. Its **six**
+  endings are kept apart deliberately — `found`, `absent`, `forbidden`, `kind_unknown`, `refused`
+  and `kind_ambiguous`; **only `absent` is evidence that an object does not exist**. A
   kind served by several API groups (`Event` everywhere, `NetworkPolicy` on a Calico cluster) reads
   nothing and names the candidates; pass `group` to pick one.
 - **`resource_spec` is bounded by an RBAC allowlist, not by a wildcard.** `rbac.resourceSpecRules`

--- a/website/content/docs/integrations/notifications/matrix.md
+++ b/website/content/docs/integrations/notifications/matrix.md
@@ -67,7 +67,8 @@ knowledge base:
 
 RunLore recognises being addressed via MSC3952 `m.mentions` when your client sends it, or — as a
 fallback — the bot's full Matrix ID or its localpart (`runlore` in `@runlore:example.org`)
-appearing anywhere in the message body. A reply is attributed to its thread via the MSC3440
+appearing in the message body **as a whole word**. The word boundary is not decoration: a plain
+substring match would read the localpart `sre` inside "misread" as addressing the bot. A reply is attributed to its thread via the MSC3440
 `m.thread` relation, falling back to `m.in_reply_to` for clients that only send the legacy
 non-threaded reply fallback.
 

--- a/website/content/docs/operations/observability.md
+++ b/website/content/docs/operations/observability.md
@@ -280,3 +280,110 @@ investigation errors), latency (model p95, slow resolution), and cost
 (`RunloreInvestigationCostHigh`). Thresholds are starting points — tune to your
 volume. See the [alerts README](https://github.com/Smana/runlore/blob/main/deploy/observability/alerts/README.md) for the
 per-alert metric dependencies and operator discovery notes.
+
+## Alert runbooks
+
+Every shipped rule's `runbook_url` points at its heading below. Each says what the
+alert means, what to look at first, and what actually fixes it — thresholds are
+starting points, so "the threshold is wrong for us" is a legitimate outcome for most
+of them.
+
+### RunloreAgentDown
+
+`absent(runlore_build_info)` for 5m: the series vanished from the TSDB entirely. Either
+the process is gone or the scrape broke — those need different fixes, so tell them
+apart first. Check the pod (`kubectl get pods -l app.kubernetes.io/name=runlore`) and
+then the scrape target's health in Prometheus/VMAgent. A `VMServiceScrape`/`ServiceMonitor`
+that stopped matching the Service produces this with a perfectly healthy agent.
+
+### RunloreNoActiveLeader
+
+`max(runlore_leader) == 0` for 10m: no replica holds the lease, so nothing is
+investigating and incoming alerts are accumulating or being dropped. Check the lease
+(`kubectl get lease -n <ns>`) and the logs of every replica for lease-renewal failures —
+usually RBAC on `coordination.k8s.io/leases`, or API-server latency causing repeated
+lease loss. Standbys are warm, so recovery is fast once one can acquire.
+
+### RunloreMultipleLeaders
+
+`sum(runlore_leader) > 1` for 5m: two replicas both believe they lead, so incidents can
+be investigated twice — double model spend and duplicate curation PRs. Brief overlap
+during failover is normal; five minutes is not. Check for clock skew and for a lease
+duration tuned shorter than your API-server latency.
+
+### RunloreInvestigationsDropped
+
+`runlore_investigations_dropped_total` increased: an incident was discarded without
+being investigated — the rate limiter exhausted its requeues, or a spend ceiling
+hard-killed the run. Split the two before reacting: a token-budget kill also shows on
+`runlore_investigation_budget_trips_total{stage="kill"}` and on
+`runlore_investigations_completed_total{result="budget_exceeded"}`. Rate-limiter drops
+mean `investigation.rate_limit` is too tight for your alert volume; budget kills mean
+`max_tokens_per_investigation` is.
+
+### RunloreInvestigationThrottlingSustained
+
+Throttling continuously for 30m. Brief throttling under a burst is the rate limiter
+working; half an hour of it means RunLore is structurally under-provisioned for its
+load. Either raise `investigation.rate_limit.max_per_window` and accept the spend, or
+reduce intake at the trigger gate. Check `RunloreInvestigationsDropped` alongside — a
+throttle that never becomes a drop is only latency.
+
+### RunlorePipelineStalled
+
+Alerts are arriving and zero investigations are starting: the intake-to-investigation
+handoff is broken, which no amount of alert volume will fix. Check leadership first
+(this fires whenever there is no leader, so rule that out via `RunloreNoActiveLeader`),
+then the coalescer — incidents sitting in a debounce or cooldown window that never
+flushes look exactly like this. `runlore_alerts_suppressed_total` and
+`runlore_incidents_debounced_total` tell you if intake is being filtered rather than
+stalled.
+
+### RunloreInvestigationErrors
+
+Investigations finishing with `result="error"` — the loop is failing mid-run rather than
+concluding. Read the investigation logs for the failing incidents; the common causes are
+a tool integration that is down (cross-check `RunloreToolErrorRateHigh` and
+`runlore_tool_calls_total{result="error"}` by `tool`) and provider errors
+(`RunloreModelErrorRateHigh`). A low background rate can be normal; a step change is
+not.
+
+### RunloreToolErrorRateHigh
+
+More than 20% of tool calls are failing over 15m, gated on a minimum call rate so the
+ratio is not noise at idle. Break down by tool: `sum by (tool) (rate(runlore_tool_calls_total{result="error"}[15m]))`.
+This is almost always one integration — expired credentials, a datasource that moved, or
+RBAC narrowed on the cluster reader — not a general fault.
+
+### RunloreModelErrorRateHigh
+
+More than 10% of model requests are failing. Model errors stop investigations cold,
+hence critical. Break down by `provider`, which distinguishes the main model from the
+synthetic `rerank` and `embed` tiers — an `embed` failure degrades recall to BM25-only
+(also visible as `runlore_catalog_embed_degraded_total`) but leaves investigations
+working, which is a much smaller problem than the main tier failing. Check quota,
+credentials, and provider status.
+
+### RunloreModelLatencyHigh
+
+p95 model latency above 30s over 15m. Every investigation is dragged out by this, and
+slow calls interact badly with `investigation.timeout`. Confirm against your provider's
+status and the `provider` label; if this is your model's genuine profile at your prompt
+sizes, raise the threshold rather than living with a permanently firing alert.
+
+### RunloreSlowResolution
+
+p95 open-to-resolve above 1h. Informational, not a paging condition — it measures your
+incident lifecycle, not RunLore's health, since the resolve event comes from
+Alertmanager. Useful as an SLO signal; align the threshold with your own target.
+
+### RunloreInvestigationCostHigh
+
+p95 of `runlore_investigation_tokens_estimated` above 100000 over 30m. Read the metric
+carefully: it records the size of the **last request** an investigation made, not its
+cumulative spend, and 100000 is the per-request bound the agent itself enforces (a
+quarter of the 400000 `max_tokens_per_investigation` default). p95 at that bound means
+typical runs are ending on a maximum-size request — evidence that prompts are being
+filled with tool output. Look at `investigation.max_tool_output_bytes` and the
+compaction settings before raising any ceiling, and scale this threshold if you retune
+`max_tokens_per_investigation`.

--- a/website/content/docs/operations/observability.md
+++ b/website/content/docs/operations/observability.md
@@ -277,8 +277,18 @@ The rule set covers liveness (`RunloreAgentDown`), HA (`RunloreNoActiveLeader`,
 `RunloreMultipleLeaders`), pipeline health (`RunlorePipelineStalled`,
 `RunloreInvestigationsDropped`, throttling), quality (tool/model error rates,
 investigation errors), latency (model p95, slow resolution), and cost
-(`RunloreInvestigationCostHigh`). Thresholds are starting points — tune to your
-volume. See the [alerts README](https://github.com/Smana/runlore/blob/main/deploy/observability/alerts/README.md) for the
+(`RunloreInvestigationCostHigh`).
+
+Three of them exist to catch failures that are **silent in every other series**, which
+is what makes them worth the alert slot:
+
+| Alert | What would otherwise hide it |
+|---|---|
+| `RunloreInvestigationsNudgedByCeiling` | a nudged run completes and records `result="resolved"`, so completion rate, error rate and duration all stay healthy while findings get shallower |
+| `RunloreThreadMentionsDropped` | the transport was acked before the work was queued, so a lost note leaves no retry, no error result, and no trace beyond this counter |
+| `RunloreCurationWriteErrors` | investigations keep succeeding; only the *write* fails, so the learning loop stops compounding with every upstream metric looking fine |
+
+Thresholds are starting points — tune to your volume. See the [alerts README](https://github.com/Smana/runlore/blob/main/deploy/observability/alerts/README.md) for the
 per-alert metric dependencies and operator discovery notes.
 
 ## Alert runbooks
@@ -376,6 +386,54 @@ sizes, raise the threshold rather than living with a permanently firing alert.
 p95 open-to-resolve above 1h. Informational, not a paging condition — it measures your
 incident lifecycle, not RunLore's health, since the resolve event comes from
 Alertmanager. Useful as an SLO signal; align the threshold with your own target.
+
+### RunloreInvestigationsNudgedByCeiling
+
+More than 10% of investigations in the last hour were nudged to conclude early by a
+spend ceiling. This is the one budget signal worth alerting on, for the reason given
+under [the budget-trip metric](#tools--model): a nudged investigation still delivers
+findings and records `result="resolved"`, so completion rate, error rate and duration
+all look healthy while the answers quietly get shallower. Nothing else distinguishes a
+comfortable ceiling from one that has been truncating investigations for a week.
+
+Find the binding ceiling with `sum by (reason) (rate(runlore_investigation_budget_trips_total[1h]))`.
+One run reports one `reason` — the ceiling that first engaged the ladder is latched from
+the nudge through to the kill — so the label names the knob to raise:
+`tokens_request` and `tokens_total` both point at
+`investigation.max_tokens_per_investigation`, `cost` at `max_cost_per_investigation`.
+Before raising either, check whether prompts are being filled with tool output
+(`investigation.max_tool_output_bytes`, the compaction settings) — that is the cheaper
+fix, and `RunloreInvestigationCostHigh` is the corroborating signal.
+
+### RunloreThreadMentionsDropped
+
+An `@runlore` mention arrived while the concurrent handler pool was saturated. This is
+**data loss, not backpressure**: the transport was acked before the work was queued
+(Slack got its `200`, Matrix's `/sync` position token advanced), so nothing will be
+redelivered. Whatever a human was trying to record is gone, and their only notice is a
+best-effort in-thread reply asking them to send it again.
+
+Any occurrence deserves a look, because it lands during incidents — the moment thread
+traffic peaks is exactly when someone is recording what actually fixed it. If it recurs,
+the handler pool is undersized for your channel volume. Cross-check
+`runlore_thread_writes_throttled_total`: throttled writes are refused politely and can
+be retried, dropped mentions cannot, and confusing the two leads to tuning the wrong
+limit.
+
+### RunloreCurationWriteErrors
+
+`runlore_curations_total{result="error"}` is non-zero: investigations reached findings
+and the forge write failed. The learning loop stops compounding here, and it does so
+invisibly — every upstream metric (investigations completed, recall rate, curation
+*attempts*) still looks healthy, and recall degrades only slowly as the catalog stops
+growing.
+
+Almost always a forge credential or scope problem: GitHub App permissions narrowed,
+`forge.kb_repo` pointing somewhere the installation cannot reach, or the App uninstalled
+from the KB repo. Grep `msg="curate findings"` with `err=` for the underlying error. Note
+that `result="error"` counts only genuine write failures — a finding that was chat-only
+(below `forge.min_confidence`) or deduplicated against an existing entry is a different
+`result` and is not an error.
 
 ### RunloreInvestigationCostHigh
 

--- a/website/content/docs/operations/observability.md
+++ b/website/content/docs/operations/observability.md
@@ -246,10 +246,20 @@ Prometheus **or** a VictoriaMetrics datasource with no edits. Import it via
 **Dashboards → Import → Upload JSON**, or provision it. See the
 [grafana README](https://github.com/Smana/runlore/blob/main/deploy/observability/grafana/README.md).
 
-It panels every `runlore_` series above, including the output-truncation rate
+It panels most of the `runlore_` series above — the learning loop, recall, curation,
+investigations, tools and model, cost, thread capture and fleet health. Notably it
+includes the spend-ceiling trips broken out **by `stage`** (a nudged investigation
+completes and records `result="resolved"`, so no other panel shows it) and **by
+`reason`** (which ceiling to raise), the thread knowledge-write routes and the
+throttle/denial counters, the output-truncation rate
 (`tool_output_truncated_bytes_total`), the coalesced-batch-size distribution
 (`coalesce_batch_size`, heatmap), and the curation dedup-score distribution
 (`curation_dedup_score`, heatmap).
+
+It is not exhaustive: the debounce counters, the history-compaction family and a few
+per-investigation usage histograms are documented above but have no panel. Query them
+ad hoc, or add a panel — the metric table is the authority on what exists, the
+dashboard on what is worth a glance.
 
 ## Alerting
 

--- a/website/content/docs/operations/observability.md
+++ b/website/content/docs/operations/observability.md
@@ -41,10 +41,49 @@ The seconds-scale latency histograms (`*_duration_seconds`,
 `incident_resolution_seconds`) carry explicit **SLO-aligned bucket boundaries**
 (seconds): `0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300`. The OTel SDK
 defaults are millisecond-scale and would collapse most calls into the first bucket,
-breaking `histogram_quantile`. The boundaries are defined in
-[`internal/telemetry/setup.go`](../internal/telemetry/setup.go) via an
-explicit-bucket-histogram view. Other histograms (scores, batch size, token
-estimate) keep the SDK defaults and are read as heatmaps, not percentiles.
+breaking `histogram_quantile`.
+
+### Score histogram buckets are the decision thresholds
+
+The two BM25-score histograms — `runlore_recall_score` and
+`runlore_curation_dedup_score` — carry their own explicit boundaries:
+`0.1, 0.25, 0.5, 0.75, 1, 1.5, 2, 3, 4, 5, 7.5, 10`. The SDK defaults start at 5, so
+an entire real corpus (an enriched BM25 score is roughly 0.1–1.2) lands in the first
+bucket and the panel renders as a single bar.
+
+The rescale is not the interesting part. **Every boundary that is also a decision
+threshold is one deliberately**, so a bucket count answers "how much of the corpus
+clears this gate?" with no arithmetic:
+
+| boundary | the gate it is | reading `le` at that boundary tells you |
+|---|---|---|
+| `0.1` | `instant_recall.rerank_min_score` | share of recall attempts too weak to spend a rerank call on — they reject as `rerank_no_signal` |
+| `1` | `instant_recall.min_score` / `margin_gap` | share below the legacy BM25 magnitude gate (live only under `instant_recall.rerank: false`) |
+| `4` | `instant_recall.solo_floor` | share below the confident bar for a single-hit recall |
+| `5` | `forge.dup_score` | on `curation_dedup_score`, the share **below** the dedup bar — i.e. the findings novel enough to file. At or above it, the finding is dropped as duplicating a catalog entry |
+
+So `runlore_recall_score_bucket{le="0.1"}` over `_count` is precisely the fraction of
+recall attempts that never reached the reranker, and
+`runlore_curation_dedup_score_bucket{le="5"}` over `_count` the fraction of findings
+that were novel. Boundaries above 5 exist for deployments that hand-tuned their
+thresholds to a differently-scaled corpus; `+Inf` captures anything past 10.
+
+> [!WARNING]
+> **Existing panels over these two `*_bucket` series change shape on upgrade.**
+> Histogram boundaries are not versioned and the rename-free change is invisible: the
+> series keep their names and simply begin reporting a different set of `le` values.
+> A panel, recording rule or `histogram_quantile` written against the old SDK ladder
+> (which began at 5, so nearly everything sat in one bucket) will re-bucket silently
+> and change value across the upgrade — no error, no missing series, just a different
+> number. Re-check anything reading `runlore_recall_score_bucket` or
+> `runlore_curation_dedup_score_bucket`, and treat comparisons spanning the upgrade as
+> meaningless rather than as a real shift in corpus quality.
+
+Both ladders are defined in
+[`internal/telemetry/setup.go`](../internal/telemetry/setup.go) via
+explicit-bucket-histogram views. The remaining histograms — `coalesce_batch_size`,
+`investigation_tokens_estimated` and the per-investigation call/token/cost
+distributions — keep the SDK defaults and are read as heatmaps, not percentiles.
 
 ### Pipeline & investigations
 | Metric | Type | Labels | Meaning |
@@ -62,6 +101,8 @@ estimate) keep the SDK defaults and are read as heatmaps, not percentiles.
 | `runlore_investigations_throttled_total` | counter | — | starts requeued by the rate limiter |
 | `runlore_investigations_dropped_total` | counter | — | dropped (rate-limiter max-requeues or token-budget kill) |
 | `runlore_investigations_cancelled_total` | counter | — | queued (not yet started) investigations cancelled because the incident resolved first (`triggers.incidents.cancel_queued_on_resolve`) |
+| `runlore_gitops_failures_debounced_total` | counter | — | GitOps failures dropped as transient: the failure cleared within the debounce window before an investigation started |
+| `runlore_coalesce_batch_size` | histogram | — | incidents per flushed batch (heatmap; SDK default buckets) |
 
 ### Tools & model
 | Metric | Type | Labels | Meaning |
@@ -76,6 +117,14 @@ estimate) keep the SDK defaults and are read as heatmaps, not percentiles.
 | `runlore_investigation_output_tokens` | histogram | `result` | provider-reported output tokens per investigation (loop + verify) |
 | `runlore_investigation_cached_input_tokens` | histogram | `result` | input tokens served from cache per investigation (loop + verify) |
 | `runlore_investigation_cost_usd` | histogram | `result` | estimated per-investigation cost in USD (only when `model.pricing` is configured) |
+| `runlore_model_responses_truncated_total` | counter | `provider` | completions cut off at the output-token ceiling (the provider's stop/finish reason indicated truncation) — a truncated answer is a degraded one, so a rising rate means `model.max_tokens` is too tight |
+| `runlore_model_input_tokens_total` | counter | `provider` | total LLM input tokens, including cached. Fleet-wide spend, as opposed to the per-investigation `investigation_input_tokens` distribution |
+| `runlore_model_cached_input_tokens_total` | counter | `provider` | LLM input tokens served from cache. Over `model_input_tokens_total` this is the cache hit rate, which is the single biggest lever on the bill |
+| `runlore_tool_output_truncated_bytes_total` | counter | — | bytes elided by per-call tool-output truncation (`investigation.max_tool_output_bytes`) |
+| `runlore_history_compactions_total` | counter | — | mid-loop tool-output history compaction events |
+| `runlore_history_elided_bytes_total` | counter | — | tool-output bytes elided by mid-loop compaction |
+| `runlore_history_summarizations_total` | counter | — | compaction events whose elided batch was replaced by a model-produced digest (`compaction: summarize`) |
+| `runlore_history_summarize_fallbacks_total` | counter | — | summarize-mode compactions that fell back to plain elision after a summariser error, refusal or truncation — the digest was not produced and the bodies were dropped instead |
 | `runlore_investigation_budget_trips_total` | counter | `reason`, `stage` | spend ceilings crossed during an investigation. `reason` = `tokens_request` (the next request alone exceeded `max_tokens_per_investigation`), `tokens_total` (the run's projected cumulative tokens did), or `cost` (`max_cost_per_investigation`). `stage` = `nudge` (forced to conclude early; findings still delivered) or `kill` (hard-stopped, `result="budget_exceeded"`) |
 
 **One run reports one `reason`.** The ceiling that first engaged the ladder is latched at the nudge
@@ -103,6 +152,45 @@ The five usage histograms carry the same `result` values as
 investigations a recall short-circuited and `{result!="recall"}` exactly those that ran
 the full loop. That split is what makes the recall saving measurable — see below.
 
+### Thread capture & conversational replies
+
+Emitted by the `@runlore …` thread path (`notify.*.thread_capture`, plus `model.chat`
+for the conversational half). Both halves are **member-triggerable** — anyone in the
+channel or room can cause a forge write or a model call — so these are the series that
+say what that path is costing and where it is being refused.
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `runlore_mentions_dropped_on_saturation_total` | counter | — | **note LOSS** — a Slack `app_mention` or an addressed Matrix thread message that arrived when the handler pool was saturated. Accepted and never processed (Slack was already acked and will not retry; Matrix's `/sync` token has advanced), so the human's note is gone. RunLore tells them to retry with a best-effort in-thread reply |
+| `runlore_thread_notes_written_total` | counter | `route` | knowledge writes that **landed** from an `@runlore note:` reply. `route` = `comment` (added to the curated PR this thread came from), `open_pr` (no PR to land on, so a standalone `Concept` entry PR was opened), or `append` (appended to the entry file of the standalone PR an earlier note in this same thread opened). `comment` and `append` are split deliberately: a comment is discarded when its PR merges, an appended entry becomes catalog knowledge, and with both labelled the same nothing distinguished them |
+| `runlore_thread_writes_throttled_total` | counter | — | note writes **denied** by the global per-hour forge-write window and told to retry. This is the feature's one global cap and is otherwise invisible to an operator — nothing else reports it |
+| `runlore_thread_chat_calls_total` | counter | — | model calls the chat layer made (granted by the per-hour budget) |
+| `runlore_thread_chat_tokens_total` | counter | — | tokens the chat layer spent, from provider-reported usage — or a conservative estimate when the provider reported none |
+| `runlore_thread_chat_denied_total` | counter | `ceiling` | chat calls the budget refused. `ceiling` = `calls` (`notify.thread.chat_calls_per_hour`) or `tokens` (`chat_tokens_per_hour`). The message falls back to the deterministic reply |
+
+> [!IMPORTANT]
+> **There is no cost report for the chat path.** `thread_chat_tokens_total` is a token
+> count and nothing anywhere converts it to currency: per-investigation cost reporting
+> (`runlore_investigation_cost_usd`, the notification footer) covers the main and verify
+> passes only, and `model.chat.pricing` is read by nothing at all. To know what
+> conversational replies cost, multiply this counter by your provider's rate yourself.
+
+`thread_chat_denied_total{ceiling="tokens"}` firing while call slots remain is the
+budget working as designed — the token ceiling is derived so that a runaway of
+maximum-size calls is stopped by **cost** before it exhausts the call count. Sustained
+denials mean the ceiling is genuinely too low for your traffic, not that something
+broke:
+
+```promql
+# share of chat attempts refused, by which ceiling bound first
+sum by (ceiling) (rate(runlore_thread_chat_denied_total[1h]))
+  / scalar(sum(rate(runlore_thread_chat_calls_total[1h]))
+         + sum(rate(runlore_thread_chat_denied_total[1h])))
+
+# notes that became durable knowledge vs. notes that will vanish at merge
+sum by (route) (rate(runlore_thread_notes_written_total[24h]))
+```
+
 ### Recall, learning loop & curation
 | Metric | Type | Labels | Meaning |
 |---|---|---|---|
@@ -116,6 +204,7 @@ the full loop. That split is what makes the recall saving measurable — see bel
 | `runlore_incident_resolution_seconds` | histogram | — | open→resolve duration |
 | `runlore_curations_total` | counter | `kind`, `result` | curation outcomes (`opened`/`coalesced`/`error`) |
 | `runlore_curation_dedup_score` | histogram | — | catalog top-hit BM25 score at the dedup decision |
+| `runlore_catalog_invalid_entries_total` | counter | — | structurally-invalid (but parseable) entries surfaced at catalog load. The entry is still indexed and served — one bad entry never empties the catalog — so this is the only signal that the CI merge gate let something through |
 | `runlore_catalog_embed_degraded_total` | counter | — | catalog reloads that left hybrid recall without vectors (embed failure — recall degrades to BM25-only until the next successful sync) |
 
 ### Measuring the recall saving

--- a/website/content/docs/operations/troubleshooting.md
+++ b/website/content/docs/operations/troubleshooting.md
@@ -148,6 +148,12 @@ Instant recall requires `catalog.instant_recall.enabled: true` **and** a confide
   | `rerank_low_confidence` | the reranker returned no match, a confidence under the bar, or an error | `instant_recall.rerank_threshold` (default 0.7) |
   | `low_margin` | **legacy gate only** (`rerank: false`) — top hit too close to the runner-up | `instant_recall.margin_gap` (default 1.0) |
   | `low_outcome` | the entry's real-world resolve-rate decayed below the floor | `instant_recall.outcome_floor` (default 0.5) |
+  | `rerank_over_budget` | the investigation's spend ceiling was **already crossed**, so the paid rerank call was declined before it was made — recall falls through to the full loop, which the budget ladder then stops with the same reason | `investigation.max_tokens_per_investigation` / `max_cost_per_investigation` |
+- **`rerank_over_budget` is not a recall problem** — no `instant_recall.*` knob fixes it. It means
+  the investigation had already crossed a spend ceiling before recall got to the reranker, so the
+  call was declined rather than paid for. The run then falls through to the full loop, whose first
+  budget check stops it with the same ceiling. If you see this alongside
+  `runlore_investigation_budget_trips_total`, raise the ceiling; recall is behaving correctly.
 - **Check which gate is live before tuning anything.** The LLM reranker is **on by default** once
   instant recall is enabled, and it *replaces* the BM25-magnitude gate — so on a default install
   `min_score`, `margin_gap` and `solo_floor` play no part in the fire decision and tuning them

--- a/website/content/docs/reference/benchmarking.md
+++ b/website/content/docs/reference/benchmarking.md
@@ -126,8 +126,8 @@ describes a loop no deployment ever runs. A `--compare` run with no `runlore.yam
 still gets the shipped default per case.
 
 `--max-total-tokens` is the run-level ceiling those cannot express: a 30-case corpus
-at `-n 10` under a 100k per-case ceiling authorises 30 million tokens, and nothing
-about "per case" says otherwise. It is denominated in **tokens, not dollars**,
+at `-n 10` under the **default 400000** per-case ceiling authorises 120 million tokens,
+and nothing about "per case" says otherwise. It is denominated in **tokens, not dollars**,
 because a campaign routinely drives several different models at once (the entries
 under test plus the judge) and a single USD ceiling would have to price all of them
 from one rate card — misreporting exactly the multi-model run it most needs to bound.

--- a/website/content/docs/security/security-model.md
+++ b/website/content/docs/security/security-model.md
@@ -141,13 +141,24 @@ The chart's RBAC is scoped tightly (`deploy/helm/runlore/templates/rbac.yaml`):
 - **Scope the App to the KB repo** (Contents/PRs/Issues read-write), plus optional read-only on your
   GitOps source repos for the what-changed diff. Disable the App's webhook. See
   [Getting started → GitHub App]({{< relref "getting-started.md" >}}).
-- **The clone credential is confined to one host.** RunLore attaches the forge token only to clones of
-  `forge.git_host` (derived from `github_api_url` / `gitlab.base_url` unless you set it); any other
-  host clones anonymously. This matters because a GitOps `spec.source.repoURL` is *cluster state* — a
-  namespace admin who can create an Argo CD `Application` or a Flux `GitRepository` would otherwise
-  choose where the token is sent. A GitHub Enterprise install with subdomain isolation must name
-  `forge.git_host`, and **fails config load** until it does, so the credential is never quietly
-  withheld from your own GitOps repo either.
+- **The clone credential is confined to one host — on the paths that read a repo URL from the
+  cluster.** RunLore attaches the forge token only to clones of `forge.git_host` (derived from
+  `github_api_url` / `gitlab.base_url` unless you set it); any other host clones anonymously. This
+  matters because a GitOps `spec.source.repoURL` is *cluster state* — a namespace admin who can
+  create an Argo CD `Application` or a Flux `GitRepository` would otherwise choose where the token is
+  sent. A GitHub Enterprise install with subdomain isolation must name `forge.git_host`, and **fails
+  config load** until it does, so the credential is never quietly withheld from your own GitOps repo
+  either. The confinement is implemented as the `TokenHost` field on the differ that `what_changed`
+  and `source_diff` share.
+- **The catalog git-sync is outside that confinement, and rests on a different argument.** The
+  catalog syncer has no host field, so it sends its credential — `catalog.git.token_env`, or the
+  shared forge GitHub App identity when that is unset — to whatever `catalog.git.url` names, on any
+  host. `forge.git_host` does not gate this path and setting it changes nothing here. The reason
+  this is not the same exposure as the GitOps case is that `catalog.git.url` is **operator config,
+  not cluster state**: changing it means changing `runlore.yaml`, which no namespace admin can do.
+  Treat it accordingly — point it at a host you would hand the forge credential to, and give it a
+  dedicated read-scoped `catalog.git.token_env` when the catalog lives somewhere the forge App
+  identity should not reach.
 - **Secrets by indirection.** Every credential is referenced by the *name* of an env var / Secret key,
   never inlined in config — so config can't leak a secret (see [Configuration]({{< relref "/docs/configuration/configuration.md" >}})).
 - **Webhook auth.** The incident webhook accepts a bearer token (`server.webhook_token_env`). It is


### PR DESCRIPTION
Thirteen items from the release review. **Every one was confirmed wrong against the code — none turned out to be already correct.**

| # | Claim | Evidence it was false |
|---|---|---|
| 1 | Score histograms "keep the SDK defaults" | `internal/telemetry/setup.go:52` `scoreBuckets`, applied via views at `:79-80` |
| 2 | "Nothing compares a cost to a threshold and stops" | `internal/investigate/budget.go:38-39`; `:69` names `max_cost_per_investigation` |
| 3 | `pricing`/`thinking` "inherit from `model`" | `internal/config/config.go:807`, `:819` — the code says outright that *nothing reads* `model.chat.pricing` |
| 4 | Confinement covers the catalog git-sync | `catalog.Syncer` has no host field; `auth()` attaches to any URL. `TokenHost` lives only in `whatchanged/differ.go` |
| 5 | `lore validate --semantic` | `cmd/lore/main.go:99` — the case is `validate-kb` |
| 6 | Localpart matches "anywhere" in the body | `matrix_feedback.go:591-624` `containsWord`/`isWordRune` |
| 7 | 100k per-case ceiling in the worked example | `load.go:154` — the default is `400000`, so the worked total was 4× low |
| 8 | "four endings" then lists six | `providers.go:395-400` defines six |
| 9 | Recall-rejection table omits `rerank_over_budget` | `internal/investigate/recall.go:566` |
| 10 | Four undocumented metrics | **Six** — the two `history_*` counters were older gaps |
| 11 | Dashboard untouched this release | Confirmed |
| 12 | No alert rule for any new signal | Confirmed |
| 13 | 24 dead `runbook_url`s | Confirmed — and the widened grep found **2 more** |

### Beyond the brief

- **`SECURITY.md:10-11`** carried the same dead-`docs/*.md` links. The `docs-check` grep could not see them.
- The dead anchors (`#runloreagentdown`) are exactly what Hugo generates from `### RunloreAgentDown`, so rather than collapsing 24 links onto one section anchor, the page was given the **15 runbook sections the URLs were always written for**. All 15 verified against rendered HTML.
- **`observability.md` claimed the dashboard "panels every `runlore_` series"** — false; 13 had no panel. Corrected by adding the 13 panels rather than by softening the sentence.

### Observability added

Budget trips by `stage` and `reason`, plus a thread row (writes, throttles, chat calls, chat tokens) on the Grafana dashboard. Three alert rules in **both** `prometheusrule.yaml` and `vmrule.yaml`: budget trips at `stage="nudge"` (the recipe `observability.md:87` already explained and nothing implemented), dropped mentions, and failed curation writes via `runlore_curations_total{result="error"}`.

### Guards

**The bidirectional metric guard was built, not deferred.** `TestEveryInstrumentIsDocumented` reuses the existing scrape, so a new undocumented instrument can no longer pass forever. One correction mid-flight: the first version scanned the whole page while its comment claimed it required a table row — the code was changed to match the claim, since a series named only in a PromQL recipe is *used*, not documented. Mutation-tested three ways (new instrument, deleted row, row demoted to a PromQL mention).

`runbook_urls_test.go` adds three checks — the anchor resolves, every rule has a section, both manifest flavours stay identical — mutation-tested four ways. The `docs-check.yml` grep is widened to all published surfaces and both link patterns, with `paths:` now including `deploy/observability/**`; mutation-tested two ways.

### Exit codes

`hugo` 0 (`/usr/bin/hugo`, captured directly) · `check-anchors.sh` 0 — **439 in-page and 69 cross-page anchors across 67 pages** · `go test ./internal/docsguard/...` 0 · `build` 0 · `vet` 0 · `go test ./... -race` 0 · `gofmt -l .` empty · `golangci-lint` **0 issues** · CI grep step 0.

Verified independently before merge: `hugo` exit 0 and `check-anchors.sh` exit 0 at 439/69.

No overlap with #521, which owns the `resource_spec` RBAC-allowlist paragraphs in `security-model.md` and `kubernetes.md`; the hunks here are the clone-credential bullet and the "four endings" bullet respectively.
