### PR TITLE
fix(thread): close seven gaps between what a thread reports and what happened

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -906,6 +906,10 @@ type ThreadNotify struct {
 	// thread.DefaultMaxNoteBytes. See that constant's doc comment for why
 	// this bound exists.
 	//
+	// A positive value must be at least thread.MinMaxNoteBytes: below that the
+	// truncation marker fills the whole budget and NOTHING of the note is
+	// written, while the reply still reports it saved. Validate refuses it.
+	//
 	// It is also the ONLY term of the chat layer's assembled prompt an operator
 	// can move, and it moves it exactly one-for-one: the prompt ceiling is a
 	// fixed 7,192 bytes plus this value (thread.MaxChatContextBytes is that sum
@@ -1816,9 +1820,16 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("notify.thread.registry_max must be >= 0 (0 = use the default %d), got %d",
 			thread.DefaultRegistryMax, c.Notify.Thread.RegistryMax)
 	}
-	if c.Notify.Thread.MaxNoteBytes < 0 {
-		return fmt.Errorf("notify.thread.max_note_bytes must be >= 0 (0 = use the default %d), got %d",
-			thread.DefaultMaxNoteBytes, c.Notify.Thread.MaxNoteBytes)
+	// Not merely >= 0. A positive value below thread.MinMaxNoteBytes leaves no
+	// room for both the human's words and the mark saying they were cut, so
+	// capNoteText keeps the mark and drops the note — and every surface goes on
+	// reporting the write as a success. There is no honest degradation available
+	// once the note is gone, so it is refused here instead; see MinMaxNoteBytes
+	// for the derivation of the floor.
+	if c.Notify.Thread.MaxNoteBytes < 0 || (c.Notify.Thread.MaxNoteBytes > 0 && c.Notify.Thread.MaxNoteBytes < thread.MinMaxNoteBytes) {
+		return fmt.Errorf("notify.thread.max_note_bytes must be 0 (= use the default %d) or at least %d, got %d — "+
+			"below %d the truncation marker fills the whole budget and nothing of the note is written",
+			thread.DefaultMaxNoteBytes, thread.MinMaxNoteBytes, c.Notify.Thread.MaxNoteBytes, thread.MinMaxNoteBytes)
 	}
 	if c.Notify.Thread.ChatCallsPerHour < 0 {
 		return fmt.Errorf("notify.thread.chat_calls_per_hour must be >= 0 (0 = use the default %d), got %d",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1778,3 +1778,50 @@ func TestNotifyThreadDoesNotShadowARegisteredNotifier(t *testing.T) {
 		t.Fatal("notify.thread must not also land in Notify.Extra — it would shadow a notifier registered as \"thread\"")
 	}
 }
+
+// TestMaxNoteBytesTooSmallToKeepAnyNoteIsRejected closes a misconfiguration that
+// degraded silently in the one direction this whole feature exists to prevent:
+// the human being told their words were saved when nothing of them was.
+//
+// capNoteText reserves the truncation marker INSIDE the budget, because a cap
+// that the act of marking the cut then breaks is not a cap. Below the marker's
+// own width there is no room for both, and the cap wins: the entry body, the
+// generated title and the quote in the reply all become fragments of
+// "…_(truncated —" and nothing else. The reply still said "📝 Opened
+// knowledge-base PR #7 with your note" (reproduced at max_note_bytes: 20).
+//
+// Refused at LOAD rather than degraded more honestly at write time, because
+// there is no honest degradation available: every byte of the note is gone
+// either way, and the only question left is whether an operator finds out at
+// startup or a stranger in a chat thread finds out after losing their words.
+func TestMaxNoteBytesTooSmallToKeepAnyNoteIsRejected(t *testing.T) {
+	base := func() *Config { return &Config{Model: Model{Provider: "anthropic"}} }
+
+	for _, tt := range []struct {
+		name  string
+		value int
+		want  bool // want an error
+	}{
+		{"zero still means the default", 0, false},
+		{"negative, as before", -1, true},
+		{"the width of the marker alone", 45, true},
+		{"one below the floor", thread.MinMaxNoteBytes - 1, true},
+		{"the floor itself is accepted", thread.MinMaxNoteBytes, false},
+		{"a realistic operator value", 4096, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c := base()
+			c.Notify.Thread.MaxNoteBytes = tt.value
+			err := c.Validate()
+			if tt.want && err == nil {
+				t.Fatalf("max_note_bytes: %d was accepted; nothing of a note survives it", tt.value)
+			}
+			if !tt.want && err != nil {
+				t.Fatalf("max_note_bytes: %d was rejected: %v", tt.value, err)
+			}
+			if tt.want && !strings.Contains(err.Error(), "notify.thread.max_note_bytes") {
+				t.Fatalf("Validate() = %v, want it to name notify.thread.max_note_bytes", err)
+			}
+		})
+	}
+}

--- a/internal/docsguard/thread_defaults_test.go
+++ b/internal/docsguard/thread_defaults_test.go
@@ -633,3 +633,51 @@ func sortedStrings[V any](m map[string]V) []string {
 	sort.Strings(out)
 	return out
 }
+
+// TestMaxNoteBytesFloorMatchesTheDocs pins the one notify.thread number the
+// defaults guard above cannot see.
+//
+// That guard reads DEFAULTS — a number counts as a claim only when the text
+// between the key and the number says "default" — and this is a FLOOR: the
+// smallest positive max_note_bytes config.Validate accepts. It is a number an
+// operator acts on (a config below it fails to load) and one nothing else
+// checks, which is exactly the shape that rots: thread.MinMaxNoteBytes is
+// derived from the truncation marker's own width, so it moves when that wording
+// moves, and nobody editing a marker string thinks of a configuration page.
+//
+// The oracle is the constant, and the search is for the number as the page
+// actually writes it. It refuses to pass on finding nothing, for the reason the
+// guard above states about inertness: a page that stopped mentioning the floor
+// leaves an operator with no warning that their config will be rejected, and a
+// test that silently passes on an absent claim is how that happens quietly.
+func TestMaxNoteBytesFloorMatchesTheDocs(t *testing.T) {
+	page := filepath.Join(repoRoot(t), "website", "content", "docs", "configuration", "configuration.md")
+	src, err := os.ReadFile(page) //nolint:gosec // G304: a fixed path under the repo root
+	if err != nil {
+		t.Fatalf("read %s: %v", page, err)
+	}
+	text := string(src)
+
+	// The sentence that states the floor, located by its subject rather than by
+	// its number, so a WRONG number is found and reported rather than missed.
+	const marker = "a positive `max_note_bytes` under "
+	i := strings.Index(text, marker)
+	if i < 0 {
+		t.Fatalf("%s no longer states the max_note_bytes floor. An operator whose value is refused at "+
+			"load has nothing to read; restore the sentence or delete this guard deliberately.", page)
+	}
+	rest := text[i+len(marker):]
+	end := strings.IndexFunc(rest, func(r rune) bool { return r < '0' || r > '9' })
+	if end <= 0 {
+		t.Fatalf("the floor sentence in %s names no number: %.80q", page, rest)
+	}
+	got, err := strconv.Atoi(rest[:end])
+	if err != nil {
+		t.Fatalf("parse the floor from %s: %v", page, err)
+	}
+	if got != thread.MinMaxNoteBytes {
+		t.Errorf("%s says a positive max_note_bytes under %d is refused; config.Validate refuses under %d. "+
+			"An operator sizing to the documented figure gets a config that will not load.",
+			page, got, thread.MinMaxNoteBytes)
+	}
+}

--- a/internal/notify/format.go
+++ b/internal/notify/format.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/Smana/runlore/internal/providers"
-	"github.com/Smana/runlore/internal/redact"
 	"github.com/Smana/runlore/internal/thread"
 )
 
@@ -36,20 +35,20 @@ const curateErrorRunes = 300
 // that made the first version of this fix miss the Slack card entirely, which is the
 // exact surface #506 reports.
 //
-// redact → strip backticks → flatten → cap, the same order and for the same reasons as
-// thread.chatSafe. A forge error carries a server-provided JSON body, so:
+// redact → strip backticks → flatten → cap. The first three are thread.SafeErrorText,
+// which is where that pipeline now lives; see its doc comment for what each one answers
+// and why the order is not free. The cap stays HERE because the two surfaces that
+// publish a forge error bound it in different units for different reasons: this counts
+// runes against a Slack section limit, and internal/thread counts bytes against a chat
+// message budget it shares with a note quote.
 //
-//   - redact.Secrets FIRST, because it may echo the credential it rejected, and running
-//     it before the cap means a cut can never hand it a half-token it no longer matches;
-//   - backticks become apostrophes, because every render site wraps the result in an
-//     inline code span and a backtick inside would close it early (notify's own codeRe
-//     is `([^`\n]+)`, so one backtick is all it takes). Apostrophe, not deletion, so the
-//     rune count and the reading of a quoted identifier both survive;
-//   - thread.SingleLine, not a local flattener, because a line break inside the body
-//     would put that text at the left margin where RunLore's own status lines sit — and
-//     a second copy of the mandatory-break class list is exactly the drift
-//     notify.kbUpdateAnnouncement documents having been bitten by;
-//   - cap LAST so it holds unconditionally.
+// It calls that helper rather than keeping this pipeline local, and the reason is the
+// drift this comment used to document from the wrong side. The paragraph below argued
+// that publishing a forge error was already precedented because "internal/thread already
+// posts err.Error() from the same forge client into the same room, uncapped and
+// unredacted" — which was true, and was a defect there rather than a licence here. Both
+// surfaces now go through one function, so the next measure added to either reaches
+// both.
 //
 // The inline code span the callers add is the fourth measure, and it is what flattening
 // alone does not buy: a reason this long soft-wraps in every client, and a continuation
@@ -63,21 +62,17 @@ const curateErrorRunes = 300
 // The forge's own words are kept rather than classified into "auth / rate limit /
 // validation" deliberately. Classifying would need a parser over forge error strings —
 // a second, narrower copy of a vocabulary this package does not own, the same drift the
-// bullets above exist to avoid — and it would drop "Resource not accessible by
+// paragraph above exists to avoid — and it would drop "Resource not accessible by
 // integration", the half that told the operator the fix was a GitHub App permission and
-// not a broken token. This is also not new egress: internal/thread already posts
-// err.Error() from the same forge client into the same room, uncapped and unredacted
-// (responder.go, "I could not save that to the knowledge base"), and #506 quotes that
-// message as the thing that worked. If server-supplied topology (internal DNS, RFC1918,
-// a GHE proxy banner) is judged too much for a chat room, that is a property of every
-// forge error RunLore already publishes and belongs in redact as a topology filter at
-// the single egress chokepoint — not as a special case on this one line.
+// not a broken token. If server-supplied topology (internal DNS, RFC1918, a GHE proxy
+// banner) is judged too much for a chat room, that is a property of every forge error
+// RunLore publishes anywhere and belongs in redact as a topology filter at the single
+// egress chokepoint — not as a special case on this one line.
 func curateFailureReason(inv providers.Investigation) string {
 	if inv.CurateError == "" {
 		return ""
 	}
-	safe := strings.ReplaceAll(redact.Secrets(inv.CurateError), "`", "'")
-	return truncate(thread.SingleLine(safe), curateErrorRunes)
+	return truncate(thread.SafeErrorText(inv.CurateError), curateErrorRunes)
 }
 
 // verdictBadge maps a model verdict to its emoji + human label. Empty/unknown

--- a/internal/notify/kbupdate.go
+++ b/internal/notify/kbupdate.go
@@ -191,12 +191,44 @@ func kbHeadline(up providers.KBUpdate) string {
 	return head
 }
 
-// kbProvenanceLine names who the note came from and which chat system it was
-// typed in. Transport is RunLore's own value (it is the notifier's Transport(),
-// not anything a message carried), so it is never marked; Author is whatever
-// the chat transport reported and always is.
+// kbProvenanceLine names who the note came from, whether they WROTE it, and
+// which chat system it was typed in. Transport is RunLore's own value (it is the
+// notifier's Transport(), not anything a message carried), so it is never
+// marked; Author is whatever the chat transport reported and always is.
+//
+// "By <author>" is a claim about authorship, and on the freeform route it was
+// false: RunLore's chat model wrote that text from the human's message. Every
+// other surface already said so — the thread reply through openedWith, the entry
+// body through its "@alice did not write it" heading, the entry description
+// through a provenance clause deliberately placed first so a clipped listing
+// cannot lose it — and this line said the opposite of all three, to sinks that
+// never saw the thread. See providers.KBUpdate.ModelDrafted.
+//
+// The drafted wording still NAMES the human. They are whose message produced the
+// note, which is what a reader needs to follow it up, and dropping the name
+// would tell a channel less than the false line did; what changes is that they
+// are named as the prompt rather than as the author.
+//
+// On the drafted route the line is emitted even when nothing else is known. An
+// empty provenance line is fine when there is merely nothing to add, and never
+// fine when what there is to add is that a human did not write this — the
+// reduced in-thread form is the headline and this line, so an omission here is
+// the whole distinction gone.
 func kbProvenanceLine(up providers.KBUpdate) string {
 	author := kbField(up.Author, kbAuthorBytes)
+	if up.ModelDrafted {
+		switch {
+		case author != "" && up.Transport != "":
+			return "Drafted by RunLore from " + thread.Untrusted(author) + "'s " + up.Transport +
+				" thread message — not their own words, pending review"
+		case author != "":
+			return "Drafted by RunLore from " + thread.Untrusted(author) +
+				"'s thread message — not their own words, pending review"
+		case up.Transport != "":
+			return "Drafted by RunLore from a " + up.Transport + " thread message, pending review"
+		}
+		return "Drafted by RunLore from a thread message, pending review"
+	}
 	switch {
 	case author != "" && up.Transport != "":
 		return "By " + thread.Untrusted(author) + " in a " + up.Transport + " thread"

--- a/internal/notify/kbupdate.go
+++ b/internal/notify/kbupdate.go
@@ -146,18 +146,42 @@ func kbThreadAnnouncement(up providers.KBUpdate) string {
 // route in the words a human uses rather than the enum value a metric label
 // uses, and drops the "#n" when the forge returned a URL carrying no parseable
 // number — which is not an error, and must not suppress the announcement.
+//
+// The routes are partitioned by WHETHER THE CATALOG GAINS ANYTHING, and only the
+// side that does may say the knowledge base was updated. That is the same line
+// KBRouteAppend's own doc draws — it is a route separate from KBRouteComment
+// precisely because "what this route writes is inside the entry the catalog
+// gains when the PR merges, and what a comment writes is not".
+//
+// This used to prefix all three identically and differentiate only the verb, so
+// the comment route announced "📚 Knowledge base updated — noted on PR #7" for a
+// write that changed no entry at all: that note went onto the CURATOR's draft,
+// where it is review feedback a human reconciles at merge time, and the file the
+// catalog gains is the curator's, not the note. The verb carried the whole
+// distinction and the prefix contradicted it — and the prefix is the half a
+// reader skims, the half a transport keeps when it truncates, and on the
+// in-thread form one of only two lines in the message.
+//
+// The COMMENT wording is the default rather than a case, so an unknown route
+// inherits it. kbRoute deliberately passes an unrecognised value straight
+// through rather than guessing at a known one (mislabelling a landed write is
+// worse than reporting an unknown label honestly), which is only safe if the
+// fallback here is the weaker claim. A route this renderer has not learned about
+// must not assert that the catalog gained something.
 func kbHeadline(up providers.KBUpdate) string {
-	what := "noted on"
+	// "for review", and no "updated" claim: the note is beside the entry, not in
+	// it, until a human folds it in. The 📝 lead keeps it inside thread's status-
+	// glyph strip, the same protection the 📚 form has.
+	head := "📝 Note left for review on knowledge-base PR"
 	switch up.Route {
 	case providers.KBRouteOpenPR:
-		what = "opened"
+		head = "📚 Knowledge base updated — opened PR"
 	case providers.KBRouteAppend:
-		// "added to the entry on", not "noted on": this route wrote INTO the entry
-		// the catalog gains on merge, and a comment does not. A reader deciding
-		// whether the knowledge is safely captured is deciding exactly that.
-		what = "added to the entry on"
+		// "added to the entry on": this route wrote INTO the entry the catalog
+		// gains on merge, and a comment does not. A reader deciding whether the
+		// knowledge is safely captured is deciding exactly that.
+		head = "📚 Knowledge base updated — added to the entry on PR"
 	}
-	head := "📚 Knowledge base updated — " + what + " PR"
 	if up.PR > 0 {
 		head = fmt.Sprintf("%s #%d", head, up.PR)
 	}

--- a/internal/notify/kbupdate_test.go
+++ b/internal/notify/kbupdate_test.go
@@ -1024,7 +1024,8 @@ func TestKBUpdateFieldsAreAllRenderedOrDeliberatelyNot(t *testing.T) {
 		Transport: "matrix", Root: "$evt-root", Channel: "!room-of-origin:example.org",
 		Delivery: providers.KBDeliverBoth, Route: providers.KBRouteOpenPR, PR: 4242,
 		URL: "https://github.com/o/r/pull/4242", Title: "Operator note: OOM",
-		Author: "sre-jane", Note: "a spot reclaim", At: time.Date(2026, 8, 16, 9, 0, 0, 0, time.UTC),
+		Author: "sre-jane", ModelDrafted: true, Note: "a spot reclaim",
+		At: time.Date(2026, 8, 16, 9, 0, 0, 0, time.UTC),
 	}
 	// Values a list may search for, one per field, so an entry cannot be written
 	// against a value the fixture does not carry.
@@ -1035,11 +1036,16 @@ func TestKBUpdateFieldsAreAllRenderedOrDeliberatelyNot(t *testing.T) {
 		"URL":       "https://github.com/o/r/pull/4242",
 		"Title":     "Operator note: OOM",
 		"Author":    "sre-jane",
-		"Note":      "a spot reclaim",
-		"Root":      "$evt-root",
-		"Channel":   "!room-of-origin:example.org",
-		"Delivery":  "both",
-		"At":        "2026-08-16T09:00:00Z",
+		// Set true on the fixture so there is a string to search for. A boolean
+		// field renders as WORDING rather than as its own value, which is exactly
+		// why it needs to be in this guard: a renderer can drop it without dropping
+		// anything a reader would notice was missing.
+		"ModelDrafted": "Drafted by RunLore",
+		"Note":         "a spot reclaim",
+		"Root":         "$evt-root",
+		"Channel":      "!room-of-origin:example.org",
+		"Delivery":     "both",
+		"At":           "2026-08-16T09:00:00Z",
 	}
 
 	for _, form := range []struct {
@@ -1051,14 +1057,18 @@ func TestKBUpdateFieldsAreAllRenderedOrDeliberatelyNot(t *testing.T) {
 			// The CHANNEL form is the only thing anyone in that channel sees about
 			// the write, so it carries the entry name and quotes the note.
 			name: "channel", render: kbUpdateAnnouncement,
-			shows: []string{"Transport", "Route", "PR", "URL", "Title", "Author", "Note"},
+			shows: []string{"Transport", "Route", "PR", "URL", "Title", "Author", "ModelDrafted", "Note"},
 		},
 		{
 			// The IN-THREAD form drops Title and Note: the reply above it already
 			// carries the same entry name and the same quote of the same note.
 			// What is left is exactly the delta the reply lacks.
+			// ModelDrafted is shown HERE too, unlike Title and Note: the reply above
+			// does say the note was drafted, but this message can arrive first (the
+			// announcement is scheduled before the reply is posted) and can be the
+			// only one in the thread if the best-effort reply fails.
 			name: "thread", render: kbThreadAnnouncement,
-			shows: []string{"Transport", "Route", "PR", "URL", "Author"},
+			shows: []string{"Transport", "Route", "PR", "URL", "Author", "ModelDrafted"},
 		},
 	} {
 		t.Run(form.name, func(t *testing.T) {
@@ -1193,5 +1203,92 @@ func TestKBHeadlineLeadsWithARunLoreStatusGlyph(t *testing.T) {
 			t.Errorf("kbHeadline(%q) = %q leads with a glyph thread.QuoteUntrusted does not strip, so a "+
 				"note quoting this line back would forge a RunLore claim", route, head)
 		}
+	}
+}
+
+// TestKBProvenanceLineNeverFilesModelProseUnderAHumansName is the announcement's
+// half of a distinction every other surface already made.
+//
+// "By sre-jane in a slack thread" is a claim about who wrote the note, and on
+// the freeform route it was false: RunLore's chat model wrote that text from
+// sre-jane's message, which is precisely why the thread reply has openedWith,
+// the entry body says "@sre-jane did not write it", and the entry description
+// leads with the provenance clause so a clipped listing cannot lose it. This
+// line said the opposite of all three.
+//
+// It matters most in the reduced in-thread form, where the message is the
+// headline and this line and nothing else — and where, if the best-effort reply
+// fails, this is the only thing in the thread.
+func TestKBProvenanceLineNeverFilesModelProseUnderAHumansName(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		up   providers.KBUpdate
+		deny []string
+		want []string
+	}{
+		{
+			name: "the human typed it",
+			up:   providers.KBUpdate{Transport: "slack", Author: "sre-jane"},
+			want: []string{"By ", "sre-jane", "slack"},
+			deny: []string{"RunLore"},
+		},
+		{
+			name: "RunLore's model drafted it",
+			up:   providers.KBUpdate{Transport: "slack", Author: "sre-jane", ModelDrafted: true},
+			// Still names the human — they are whose message produced it, and a
+			// reader needs that to follow it up — but never as the author.
+			want: []string{"sre-jane", "slack", "RunLore", "not their own words"},
+			deny: []string{"By "},
+		},
+		{
+			name: "drafted, with no author reported",
+			up:   providers.KBUpdate{Transport: "slack", ModelDrafted: true},
+			want: []string{"RunLore", "slack"},
+		},
+		{
+			name: "drafted, with nothing else known",
+			up:   providers.KBUpdate{ModelDrafted: true},
+			// The provenance line is optional when there is nothing to say; it is
+			// NOT optional when what there is to say is that a human did not write
+			// this. An empty line here would drop the one fact that must travel.
+			want: []string{"RunLore"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := kbProvenanceLine(tt.up)
+			for _, w := range tt.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("kbProvenanceLine = %q, want it to contain %q", got, w)
+				}
+			}
+			for _, d := range tt.deny {
+				if strings.Contains(got, d) {
+					t.Errorf("kbProvenanceLine = %q, must not contain %q", got, d)
+				}
+			}
+		})
+	}
+}
+
+// TestAnnouncementFormsBothCarryTheDraftedProvenance pins it on the assembled
+// messages, in both destinations, because the field being set is worth nothing
+// if a renderer drops it — and the two forms are separate functions, so the one
+// that gets fixed alone is the one that stops being tested.
+func TestAnnouncementFormsBothCarryTheDraftedProvenance(t *testing.T) {
+	up := providers.KBUpdate{
+		Transport: "slack", Root: "111.222", Channel: "C1", Route: providers.KBRouteOpenPR, PR: 7,
+		URL: "https://github.com/o/r/pull/7", Title: "Operator note: OOM",
+		Author: "sre-jane", Note: "It was a spot reclaim.", ModelDrafted: true,
+	}
+	for name, render := range map[string]func(providers.KBUpdate) string{
+		"channel": kbUpdateAnnouncement,
+		"thread":  kbThreadAnnouncement,
+	} {
+		t.Run(name, func(t *testing.T) {
+			text := thread.RenderReply(render(up), escapeMrkdwn)
+			if !strings.Contains(text, "RunLore") || !strings.Contains(text, "not their own words") {
+				t.Errorf("the %s announcement presents model-drafted prose as sre-jane's own words:\n%s", name, text)
+			}
+		})
 	}
 }

--- a/internal/notify/kbupdate_test.go
+++ b/internal/notify/kbupdate_test.go
@@ -450,6 +450,12 @@ func longestRun(s string, c byte) int {
 // opened when the note was in fact appended as a comment to one someone else
 // owns. Denying the opposite wording is what stops a fix from over-correcting
 // into the mirror-image defect.
+//
+// The comment case additionally denies the "Knowledge base updated" claim, which
+// it used to make: that note went onto the curator's draft, so the file the
+// catalog gains is theirs and nothing of the note is in it until a human folds it
+// in. See TestKBHeadlineClaimsTheCatalogGainedOnlyWhenItDid for the property; this
+// pins it on the assembled channel message, which is what a reader actually sees.
 func TestKBUpdateAnnouncementNamesWhatLanded(t *testing.T) {
 	sinks, sent := kbUpdateSinkOnFakeTransport(t)
 	for _, tc := range []struct {
@@ -465,9 +471,9 @@ func TestKBUpdateAnnouncementNamesWhatLanded(t *testing.T) {
 				URL: "https://github.com/o/r/pull/99", Title: "Operator note: OOM in payments",
 				Author: "sre-jane", Note: "the real cause was a spot reclaim",
 			},
-			want: []string{"opened PR #99", "https://github.com/o/r/pull/99", "Operator note: OOM in payments",
-				"sre-jane", "> the real cause was a spot reclaim", "slack"},
-			deny: []string{"noted on"},
+			want: []string{"Knowledge base updated", "opened PR #99", "https://github.com/o/r/pull/99",
+				"Operator note: OOM in payments", "sre-jane", "> the real cause was a spot reclaim", "slack"},
+			deny: []string{"for review"},
 		},
 		{
 			name: "comment names the pull request it joined",
@@ -475,9 +481,9 @@ func TestKBUpdateAnnouncementNamesWhatLanded(t *testing.T) {
 				Transport: "matrix", Root: "$evt", Route: providers.KBRouteComment, PR: 42,
 				URL: "https://github.com/o/r/pull/42", Author: "sre-jane", Note: "it recurs after node rotation",
 			},
-			want: []string{"noted on PR #42", "https://github.com/o/r/pull/42", "sre-jane",
+			want: []string{"for review on knowledge-base PR #42", "https://github.com/o/r/pull/42", "sre-jane",
 				"> it recurs after node rotation", "matrix"},
-			deny: []string{"opened"},
+			deny: []string{"opened", "Knowledge base updated"},
 		},
 		{
 			name: "an unnumbered forge URL still announces the write",
@@ -485,8 +491,8 @@ func TestKBUpdateAnnouncementNamesWhatLanded(t *testing.T) {
 				Transport: "slack", Route: providers.KBRouteOpenPR,
 				URL: "https://github.com/o/r/kb", Note: "capture this",
 			},
-			want: []string{"opened PR", "https://github.com/o/r/kb", "> capture this"},
-			deny: []string{"noted on", "#0"},
+			want: []string{"Knowledge base updated", "opened PR", "https://github.com/o/r/kb", "> capture this"},
+			deny: []string{"for review", "#0"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1113,7 +1119,7 @@ func TestKBUpdateFieldsAreAllRenderedOrDeliberatelyNot(t *testing.T) {
 // three would answer that question wrongly for two of them.
 func TestKBHeadlineNamesEachRouteDistinctly(t *testing.T) {
 	want := map[providers.KBRoute]string{
-		providers.KBRouteComment: "📚 Knowledge base updated — noted on PR #7",
+		providers.KBRouteComment: "📝 Note left for review on knowledge-base PR #7",
 		providers.KBRouteOpenPR:  "📚 Knowledge base updated — opened PR #7",
 		providers.KBRouteAppend:  "📚 Knowledge base updated — added to the entry on PR #7",
 	}
@@ -1127,5 +1133,65 @@ func TestKBHeadlineNamesEachRouteDistinctly(t *testing.T) {
 			t.Errorf("routes %q and %q announce identically (%q) — a reader cannot tell them apart", route, other, got)
 		}
 		seen[got] = route
+	}
+}
+
+// TestKBHeadlineClaimsTheCatalogGainedOnlyWhenItDid is the honesty half, and it
+// is a property rather than a fixture: the routes are partitioned by whether
+// what they wrote is INSIDE the entry the catalog gains on merge, and only that
+// side may assert the knowledge base was updated.
+//
+// KBRouteAppend's own doc draws exactly that line — it exists as a route
+// separate from KBRouteComment because "what this route writes is inside the
+// entry the catalog gains when the PR merges, and what a comment writes is not".
+// kbHeadline nonetheless prefixed all three identically and differentiated only
+// the verb, so the comment route announced "📚 Knowledge base updated — noted on
+// PR #7" for a write that changed no entry at all: the merged file is the
+// curator's draft, and the note is feedback a human still has to fold in. It
+// matters most on the in-thread form, which is the headline and one other line.
+func TestKBHeadlineClaimsTheCatalogGainedOnlyWhenItDid(t *testing.T) {
+	const claim = "Knowledge base updated"
+	for _, tt := range []struct {
+		route     providers.KBRoute
+		inTheFile bool
+	}{
+		{providers.KBRouteOpenPR, true},
+		{providers.KBRouteAppend, true},
+		{providers.KBRouteComment, false},
+		// An unknown route is a route this renderer has not learned about, so it
+		// must not assert anything about the catalog. kbRoute passes an unrecognised
+		// value straight through rather than guessing, which is only safe if the
+		// default here fails toward the weaker claim.
+		{providers.KBRoute("some-future-route"), false},
+	} {
+		t.Run(string(tt.route), func(t *testing.T) {
+			got := kbHeadline(providers.KBUpdate{Route: tt.route, PR: 7})
+			if asserts := strings.Contains(got, claim); asserts != tt.inTheFile {
+				t.Errorf("kbHeadline(%q) = %q; claims %q = %v, want %v — "+
+					"only a route that writes inside the entry the catalog gains may say so",
+					tt.route, got, claim, asserts, tt.inTheFile)
+			}
+			if !strings.Contains(got, "#7") {
+				t.Errorf("kbHeadline(%q) = %q, want it to name the pull request", tt.route, got)
+			}
+		})
+	}
+}
+
+// TestKBHeadlineLeadsWithARunLoreStatusGlyph keeps the comment route's new
+// wording inside the protection the old one had for free. Every headline is
+// RunLore's own claim and sits at the left margin, and the defence against
+// untrusted text posing as one of those lines is thread.QuoteUntrusted stripping
+// these glyphs out of quoted note text — which only works for glyphs the strip
+// list knows.
+func TestKBHeadlineLeadsWithARunLoreStatusGlyph(t *testing.T) {
+	for _, route := range []providers.KBRoute{
+		providers.KBRouteOpenPR, providers.KBRouteAppend, providers.KBRouteComment, providers.KBRoute("unknown"),
+	} {
+		head := kbHeadline(providers.KBUpdate{Route: route, PR: 7})
+		if stripped := thread.QuoteUntrusted(head); strings.Contains(stripped, strings.TrimSpace(head[:4])) {
+			t.Errorf("kbHeadline(%q) = %q leads with a glyph thread.QuoteUntrusted does not strip, so a "+
+				"note quoting this line back would forge a RunLore claim", route, head)
+		}
 	}
 }

--- a/internal/notify/payload.go
+++ b/internal/notify/payload.go
@@ -124,8 +124,18 @@ type KBUpdatePayload struct {
 	URL     string `json:"url,omitempty"`
 	Title   string `json:"title,omitempty"`
 	Author  string `json:"author,omitempty"`
-	Note    string `json:"note,omitempty"`
-	At      string `json:"at,omitempty"` // RFC3339; "" when unknown
+	// ModelDrafted says RunLore's chat model wrote "note" from "author"'s
+	// message, rather than "author" having typed it.
+	//
+	// Sent WITHOUT omitempty, unlike every other optional field here, and that is
+	// the point: a receiver storing this as a record has to be able to tell "a
+	// human wrote it" from "this producer does not report provenance". With
+	// omitempty the two are the same absent key, and the safe reading of an absent
+	// key — assume a human wrote it — is exactly the wrong one. The record is
+	// three bytes larger and unambiguous.
+	ModelDrafted bool   `json:"model_drafted"`
+	Note         string `json:"note,omitempty"`
+	At           string `json:"at,omitempty"` // RFC3339; "" when unknown
 }
 
 // NewKBUpdatePayload maps a KBUpdate to the delivery payload.
@@ -137,6 +147,6 @@ func NewKBUpdatePayload(up providers.KBUpdate) KBUpdatePayload {
 	return KBUpdatePayload{
 		Event: kbUpdateEvent, Transport: up.Transport, Root: up.Root, Channel: up.Channel,
 		Route: string(up.Route), PR: up.PR, URL: up.URL,
-		Title: up.Title, Author: up.Author, Note: up.Note, At: at,
+		Title: up.Title, Author: up.Author, ModelDrafted: up.ModelDrafted, Note: up.Note, At: at,
 	}
 }

--- a/internal/notify/payload_test.go
+++ b/internal/notify/payload_test.go
@@ -3,7 +3,9 @@
 package notify
 
 import (
+	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -110,7 +112,7 @@ func TestNewKBUpdatePayloadPopulatesEveryFieldItDeclares(t *testing.T) {
 	got := NewKBUpdatePayload(providers.KBUpdate{
 		Transport: "slack", Root: "111.222", Channel: "C-ORIGIN",
 		Route: providers.KBRouteOpenPR, PR: 99, URL: "https://github.com/o/r/pull/99",
-		Title: "Operator note: OOM", Author: "sre-jane", Note: "a spot reclaim",
+		Title: "Operator note: OOM", Author: "sre-jane", ModelDrafted: true, Note: "a spot reclaim",
 		At: time.Date(2026, 8, 16, 9, 0, 0, 0, time.UTC),
 	})
 
@@ -124,5 +126,15 @@ func TestNewKBUpdatePayloadPopulatesEveryFieldItDeclares(t *testing.T) {
 	if got.Channel != "C-ORIGIN" {
 		t.Errorf("channel = %q, want the originating channel — root alone does not identify a "+
 			"conversation, so a receiver cannot build a permalink without it", got.Channel)
+	}
+	// A record that says who wrote the note has to say it explicitly. With
+	// omitempty, "a human wrote it" and "this producer does not report provenance"
+	// are the same absent key, and the safe reading of an absent key is the wrong
+	// one — so the field ships even when false.
+	if b, err := json.Marshal(NewKBUpdatePayload(providers.KBUpdate{Author: "sre-jane"})); err != nil {
+		t.Fatalf("marshal: %v", err)
+	} else if !strings.Contains(string(b), `"model_drafted":false`) {
+		t.Errorf("a human-authored note's payload omits model_drafted, so a receiver cannot tell it "+
+			"from a producer that never reports provenance: %s", b)
 	}
 }

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -847,6 +847,11 @@ func (d KBDelivery) IntoThread() bool { return d == KBDeliverThread || d == KBDe
 // can avoid announcing the same write to the same people twice, or deliver into
 // that thread rather than beside it (see Delivery).
 //
+// It also names WHO WROTE the note as distinct from whose message produced it:
+// on the freeform route RunLore's own chat model drafted the text and the human
+// only prompted it. See ModelDrafted — a consumer that renders Author without
+// consulting it will attribute model prose to a named engineer.
+//
 // # Untrusted fields
 //
 // Note, Title and Author are UNTRUSTED. They are secret-redacted upstream
@@ -890,7 +895,32 @@ type KBUpdate struct {
 	Title string
 	// Author is the human whose thread message produced the note, as the chat
 	// transport reported it. Provenance, not proof of identity. UNTRUSTED.
+	//
+	// It names whose message PRODUCED the note, which is not the same as who
+	// wrote its words — see ModelDrafted, which every renderer must consult
+	// before presenting Note as this person's own.
 	Author string
+	// ModelDrafted reports that RunLore's own chat model wrote Note from Author's
+	// message, rather than Author having typed it after an explicit "note:".
+	//
+	// It is the announcement's half of a distinction every other surface already
+	// makes, and the reason it has to exist HERE rather than be inferred: a sink
+	// receives this struct and nothing else. Without it the event carried
+	// {author: "alice", note: "<the model's text>"} with no way to tell the two
+	// routes apart, so a chat sink rendered "By alice in a slack thread" over
+	// prose alice never wrote and a webhook receiver stored it as her statement.
+	// The knowledge base's merge gate reads exactly that signal — a human
+	// attestation is what a reviewer weighs a note by — so filing model prose
+	// under a named engineer is the specific failure the thread reply's
+	// openedWith, NoteBody's "@alice did not write it" heading and
+	// conceptDescription's leading provenance clause were each written to close.
+	//
+	// TRUSTED: RunLore sets it from the note's own provenance (thread.Note.
+	// DraftedFrom), it is never reported by a chat system, and it is a boolean
+	// rather than text, so no renderer escapes it. It is nonetheless the field
+	// most likely to be forgotten by a renderer, which is why the announcement
+	// surfaces have tests asserting the two routes cannot render identically.
+	ModelDrafted bool
 	// Note is the note text AS WRITTEN to the forge — post-redaction and
 	// post-cap, never the caller's raw input, so an announcement cannot leak
 	// what the entry itself masked. UNTRUSTED.

--- a/internal/providers/providers_test.go
+++ b/internal/providers/providers_test.go
@@ -245,9 +245,16 @@ func TestKBUpdateNotifierIsOptional(t *testing.T) {
 //
 // Delivery is trusted because RunLore sets it from its own configuration; it is
 // never reported by a chat system and never rendered at all.
+//
+// ModelDrafted is trusted for the same reason and one more: it is a boolean, so
+// there is nothing in it to escape. Being unescapable is NOT the same as being
+// safe to ignore — a renderer that drops it attributes model prose to a named
+// human — which is why the announcement surfaces carry their own tests that the
+// two provenance routes cannot render identically. This classification answers
+// only "must a notifier escape it", and the honest answer is no.
 var (
 	kbUpdateUntrusted = map[string]bool{"Title": true, "Author": true, "Note": true, "URL": true, "Root": true, "Channel": true}
-	kbUpdateTrusted   = map[string]bool{"Transport": true, "Route": true, "PR": true, "At": true, "Delivery": true}
+	kbUpdateTrusted   = map[string]bool{"Transport": true, "Route": true, "PR": true, "At": true, "Delivery": true, "ModelDrafted": true}
 )
 
 // TestKBUpdateClassifiesEveryFieldForEscaping makes the two maps above bite: a

--- a/internal/ratelimit/window.go
+++ b/internal/ratelimit/window.go
@@ -50,6 +50,47 @@ func (w *Window) Allow() bool {
 	return true
 }
 
+// Refund hands one recorded event back to the budget, for a caller that took a
+// token before an operation and then learned the operation never happened.
+//
+// It exists because Allow() is necessarily optimistic: a caller has to reserve
+// before it acts, or two callers race past the same last token. Without a way to
+// undo that reservation, every failure downstream is charged as though it had
+// succeeded — which is how a forge outage spent an hour's whole write budget on
+// writes that landed nothing (see thread.Responder.write).
+//
+// It removes the MOST RECENT timestamp, which is not necessarily the one this
+// caller recorded. That is deliberate rather than sloppy: tokens here are
+// fungible — the window only ever asks HOW MANY events fall inside it, never
+// which — so returning one restores exactly the headroom that was taken. The
+// only observable difference is which instant the returned token would have
+// expired at, and dropping the newest is the conservative end of that: the
+// remaining timestamps expire no later than the one removed, so a refund can
+// never extend how long the window stays full.
+//
+// A refund with nothing recorded is a no-op, so it can neither push the count
+// negative nor mint budget the window never granted. That also covers a refund
+// arriving after the window has already rolled past the event being refunded —
+// the case a plain counter would turn into headroom for the NEXT window: the
+// entries are append-ordered, so an expired one can only ever PRECEDE a live
+// one, and dropping the tail therefore gives back a live token or nothing.
+//
+// It does not slide first, unlike Allow and Count, and that is not an omission:
+// by the ordering above, sliding could not change which entry the tail is or
+// what the window answers afterwards, and a line no test can falsify is worse
+// than the sentence explaining why it is absent.
+func (w *Window) Refund() {
+	if w.max <= 0 {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if len(w.recent) == 0 {
+		return
+	}
+	w.recent = w.recent[:len(w.recent)-1]
+}
+
 // Count returns the number of events currently in the window (peek; no record).
 func (w *Window) Count() int {
 	w.mu.Lock()

--- a/internal/ratelimit/window_test.go
+++ b/internal/ratelimit/window_test.go
@@ -42,3 +42,72 @@ func TestWindowZeroMaxUnlimited(t *testing.T) {
 		}
 	}
 }
+
+// TestWindowRefundReturnsATokenAndOnlyWhenThereIsOne pins Refund's two halves:
+// an allowed event can be handed back, and a Refund with nothing recorded is a
+// no-op rather than a way to mint budget.
+func TestWindowRefundReturnsATokenAndOnlyWhenThereIsOne(t *testing.T) {
+	now := time.Unix(0, 0)
+	w := New(2, time.Minute)
+	w.now = func() time.Time { return now }
+
+	// Nothing recorded yet: a refund must not push the count negative or create
+	// headroom the window never had.
+	w.Refund()
+	if got := w.Count(); got != 0 {
+		t.Fatalf("Refund on an empty window: Count = %d, want 0", got)
+	}
+	for range 2 {
+		if !w.Allow() {
+			t.Fatal("within budget")
+		}
+	}
+	if w.Allow() {
+		t.Fatal("budget 2 must be spent")
+	}
+	w.Refund()
+	if got := w.Count(); got != 1 {
+		t.Fatalf("after Refund: Count = %d, want 1", got)
+	}
+	if !w.Allow() {
+		t.Fatal("the refunded token must be spendable again")
+	}
+	if w.Allow() {
+		t.Fatal("Refund must return exactly one token, not reset the window")
+	}
+}
+
+// TestWindowRefundDoesNotOutliveTheWindow keeps a refund from resurrecting a
+// token the slide already expired: refunding after the window rolled forward
+// leaves the count at zero rather than at -1, which would be an extra event's
+// worth of headroom for the NEXT window.
+func TestWindowRefundDoesNotOutliveTheWindow(t *testing.T) {
+	now := time.Unix(0, 0)
+	w := New(1, time.Minute)
+	w.now = func() time.Time { return now }
+	if !w.Allow() {
+		t.Fatal("within budget")
+	}
+	now = now.Add(2 * time.Minute)
+	w.Refund()
+	if got := w.Count(); got != 0 {
+		t.Fatalf("Count = %d, want 0", got)
+	}
+	if !w.Allow() {
+		t.Fatal("a fresh window allows one")
+	}
+	if w.Allow() {
+		t.Fatal("and only one — the stale refund must not have added headroom")
+	}
+}
+
+// TestWindowRefundIsANoOpWhenUnlimited mirrors Allow's own max <= 0 guard: an
+// unlimited window records nothing, so there is nothing to hand back.
+func TestWindowRefundIsANoOpWhenUnlimited(t *testing.T) {
+	w := New(0, time.Minute)
+	w.Allow()
+	w.Refund()
+	if got := w.Count(); got != 0 {
+		t.Fatalf("Count = %d, want 0", got)
+	}
+}

--- a/internal/thread/note.go
+++ b/internal/thread/note.go
@@ -75,6 +75,33 @@ const (
 // constant is a close, not exact, bound on the rendered body.
 const DefaultMaxNoteBytes = 8 << 10
 
+// MinMaxNoteBytes is the smallest per-note cap an operator may configure.
+// config.Validate refuses anything between 1 and this, so no deployment can
+// reach the pathological branch in capNoteText below.
+//
+// It exists because a cap smaller than the truncation MARKER destroys the note
+// outright while every surface goes on reporting success. capNoteText reserves
+// the marker inside the budget — a cap that the act of marking the cut then
+// breaks is not a cap — so below the marker's own width there is no room for
+// both, the cap wins, and the entry body, the generated title and the quote in
+// the reply all become fragments of "…_(truncated —". Measured at
+// max_note_bytes: 20, the human still got "📝 Opened knowledge-base PR #7 with
+// your note".
+//
+// 128 is derived, not round. The marker's own width GROWS with the decimal
+// digits of the dropped byte count: 44 bytes when nothing was dropped, 47 at the
+// 8 KiB default, 50 at a 1 MiB Slack request body, 53 at a gigabyte. The floor
+// has to clear the WIDEST of those, not the narrowest — pinned by
+// TestMinMaxNoteBytesClearsTheWidestTruncationMarker — and still leave enough
+// behind to be worth accepting: at 128 a truncated note keeps ~75 bytes of what
+// the human actually typed, a short sentence rather than a fragment.
+//
+// Refused at load rather than degraded more honestly at write time, because
+// there is no honest degradation left to offer: every byte of the note is gone
+// either way, and the only question is whether an operator finds out at startup
+// or a stranger in a chat thread finds out after losing their words.
+const MinMaxNoteBytes = 128
+
 // Note is one knowledge-base-bound note: the text to file, the human it came
 // from, and — when RunLore's own model wrote that text rather than the human
 // typing it — the message it was drafted from.
@@ -285,14 +312,20 @@ func noteTruncationMarker(dropped int) string {
 // would be circular — the count depends on where the cut lands, which depends
 // on the reservation.
 //
-// PATHOLOGICAL CASE: a maxBytes smaller than the marker itself (roughly 45
-// bytes) leaves no room for both the human's words and the mark saying they
-// were cut. The cap wins: the result is the marker alone, itself cut to
-// maxBytes on a rune boundary, so the bound holds unconditionally and nothing
-// underflows or panics. Every shipped path passes DefaultMaxNoteBytes or an
-// operator's notify.thread.max_note_bytes, and config.Validate already rejects
-// a negative one, so a cap that small is a misconfiguration this degrades
-// predictably under rather than a case any real deployment reaches.
+// PATHOLOGICAL CASE: a maxBytes smaller than the marker itself (44 to 53 bytes,
+// depending on the digits of the dropped count) leaves no room for both the
+// human's words and the mark saying they were cut. The cap wins: the result is
+// the marker alone, itself cut to maxBytes on a rune boundary, so the bound
+// holds unconditionally and nothing underflows or panics.
+//
+// It is NO LONGER REACHABLE from configuration. That branch used to be defended
+// only by "config.Validate already rejects a negative one", which was true and
+// insufficient — max_note_bytes: 20 loaded fine and destroyed every note in the
+// deployment while the reply went on saying "Opened knowledge-base PR #7 with
+// your note". Validate now refuses anything between 1 and MinMaxNoteBytes; see
+// that constant for why refusing beats degrading. The branch stays as the
+// terminus for a direct in-process caller passing an arbitrary bound, which is
+// the only way left to get here.
 func capNoteText(text string, maxBytes int) string {
 	if maxBytes <= 0 {
 		maxBytes = DefaultMaxNoteBytes

--- a/internal/thread/note.go
+++ b/internal/thread/note.go
@@ -799,13 +799,14 @@ func atxHeadingText(line string) string {
 	return strings.TrimSpace(line[i:])
 }
 
-// SingleLine collapses every rune that can break or reorder a line — any
-// Unicode whitespace other than the plain space, every control character (Cc)
-// and every format character (Cf) — to a space, so text pulled from untrusted
-// sources (an alert title, in particular) can never break a single-line YAML
-// title. kbvalidate rejects any title containing \r or \n outright.
+// SingleLine collapses every rune that can break or reorder a line, or change
+// how a reply is escaped — any Unicode whitespace other than the plain space,
+// every control character (Cc), every format character (Cf) and every
+// private-use character (Co) — to a space, so text pulled from untrusted sources
+// (an alert title, in particular) can never break a single-line YAML title.
+// kbvalidate rejects any title containing \r or \n outright.
 //
-// The three categories, and why each is here rather than just \r and \n:
+// The four categories, and why each is here rather than just \r and \n:
 //
 //   - unicode.IsSpace covers U+2028 LINE SEPARATOR and U+2029 PARAGRAPH
 //     SEPARATOR, which YAML 1.1 counts as line breaks and which many
@@ -820,6 +821,17 @@ func atxHeadingText(line string) string {
 //     the bidi controls U+202E / U+061C, which reorder how a line RENDERS
 //     without changing a byte of what it says — a title that reads one way to
 //     a reviewer and another to the parser.
+//   - unicode.Co is the private-use category, and it is here for exactly ONE of
+//     its code points: U+E000 is untrustedMark, the delimiter RenderReply splits
+//     a reply on. That split is a PARITY — one stray mark flips it and hands a
+//     genuinely untrusted span to the transport unescaped, NARROWING what gets
+//     escaped rather than widening it. Untrusted() strips the mark from the
+//     content it wraps, which covers every marked span; this covers the
+//     single-line fields that reach a reply OUTSIDE one — an author, an entry
+//     title, a forge error (see SafeErrorText). The whole category goes rather
+//     than that one rune, because a private-use code point has no agreed meaning
+//     outside one font's private arrangement: there is nothing to preserve, and
+//     a one-rune exception is a list that drifts the moment the mark moves.
 //
 // The plain space is excluded so ordinary text is left exactly as written;
 // everything else in those categories becomes one, which keeps the result the
@@ -841,7 +853,7 @@ func SingleLine(s string) string {
 		if r == ' ' {
 			return r
 		}
-		if unicode.IsSpace(r) || unicode.IsControl(r) || unicode.Is(unicode.Cf, r) {
+		if unicode.IsSpace(r) || unicode.IsControl(r) || unicode.Is(unicode.Cf, r) || unicode.Is(unicode.Co, r) {
 			return ' '
 		}
 		return r

--- a/internal/thread/note_test.go
+++ b/internal/thread/note_test.go
@@ -1218,3 +1218,50 @@ func TestSingleLineFlattensThePrivateUseArea(t *testing.T) {
 		t.Errorf("SingleLine left the span mark in place: %q", got)
 	}
 }
+
+// TestCapNoteTextAtTheFloorStillKeepsTheHumansWords is what makes
+// MinMaxNoteBytes a derived number rather than a round one: at the smallest cap
+// an operator may configure, a truncated note must still carry a readable piece
+// of what the human actually wrote, not just the mark saying it was cut.
+//
+// The inputs run past what any chat transport can deliver (a Slack request body
+// is ~1 MiB), because the marker's own width GROWS with the decimal digits of
+// the dropped count — 44 bytes at nothing dropped, 53 at a gigabyte — and the
+// floor has to hold at the widest marker, not the narrowest.
+func TestCapNoteTextAtTheFloorStillKeepsTheHumansWords(t *testing.T) {
+	const sentence = "the real cause was a spot-node reclaim during the Karpenter consolidation window"
+	for _, size := range []int{1 << 10, 1 << 20, 1 << 30} {
+		text := sentence + strings.Repeat("x", size)
+		got := capNoteText(text, MinMaxNoteBytes)
+		if len(got) > MinMaxNoteBytes {
+			t.Errorf("size %d: capNoteText returned %d bytes, past the %d-byte cap", size, len(got), MinMaxNoteBytes)
+		}
+		kept, marker, found := strings.Cut(got, "…\n\n")
+		if !found || !strings.Contains(marker, "_(truncated —") {
+			t.Errorf("size %d: the cut is unmarked, so a reviewer reads a shortened note as complete: %q", size, got)
+			continue
+		}
+		if len(kept) < MinMaxNoteBytes/2 {
+			t.Errorf("size %d: only %d bytes of the human's own words survived a %d-byte cap (%q) — "+
+				"the floor is too low to be worth accepting", size, len(kept), MinMaxNoteBytes, got)
+		}
+		if !strings.HasPrefix(text, kept) {
+			t.Errorf("size %d: what survived is not a prefix of what was written: %q", size, kept)
+		}
+		// And enough of it to be a sentence rather than a fragment: the floor is
+		// only worth accepting if a reader can tell what the note was about.
+		if !strings.HasPrefix(got, "the real cause was a spot-node reclaim") {
+			t.Errorf("size %d: the surviving words do not carry the note's claim: %q", size, got)
+		}
+	}
+}
+
+// TestMinMaxNoteBytesClearsTheWidestTruncationMarker pins the derivation itself,
+// so the floor cannot silently stop being a floor if the marker's wording grows.
+func TestMinMaxNoteBytesClearsTheWidestTruncationMarker(t *testing.T) {
+	widest := len(noteTruncationMarker(1 << 30))
+	if MinMaxNoteBytes <= widest {
+		t.Fatalf("MinMaxNoteBytes = %d, but the truncation marker alone is %d bytes — "+
+			"at that cap nothing of the note survives, which is what the floor exists to refuse", MinMaxNoteBytes, widest)
+	}
+}

--- a/internal/thread/note_test.go
+++ b/internal/thread/note_test.go
@@ -1184,3 +1184,37 @@ func TestTruncateWordsHoldsItsBoundAtAZeroBudget(t *testing.T) {
 		}
 	}
 }
+
+// TestSingleLineFlattensThePrivateUseArea extends the rune set above to Co, the
+// private-use category, for one concrete reason rather than for completeness:
+// untrustedMark is U+E000, and it is the ONE rune whose survival changes how a
+// reply is ESCAPED rather than merely how it looks.
+//
+// RenderReply splits a reply on that mark and escapes alternate segments, so a
+// single extra one anywhere flips the parity of everything after it and hands a
+// genuinely untrusted span to the transport unescaped (see
+// TestForgeFailureCannotNarrowWhatTheReplyEscapes). Untrusted() strips the mark
+// from the content it wraps, which is what holds the property for every span
+// that goes through it; this is what holds it for the single-line fields that do
+// not — an author, an entry title, a forge error — all of which reach a reply
+// through SingleLine.
+//
+// A private-use code point has no agreed meaning outside one font's private
+// arrangement, so nothing legitimate is lost by mapping the whole category to a
+// space. Written as escapes, never as literal glyphs: they are invisible in a
+// diff, and ST1018 rejects them in source anyway.
+func TestSingleLineFlattensThePrivateUseArea(t *testing.T) {
+	for _, r := range []rune{
+		'\ue000',     // untrustedMark itself — the parity hazard this arm exists for
+		'\uf8ff',     // the far end of the Basic Multilingual Plane's private-use area
+		'\U000f0000', // Plane 15, Supplementary Private Use Area-A
+		'\U00100000', // Plane 16, Supplementary Private Use Area-B
+	} {
+		if got, want := SingleLine("before"+string(r)+"after"), "before after"; got != want {
+			t.Errorf("SingleLine(U+%04X) = %q, want %q", r, got, want)
+		}
+	}
+	if got := SingleLine(untrustedMark); strings.Contains(got, untrustedMark) {
+		t.Errorf("SingleLine left the span mark in place: %q", got)
+	}
+}

--- a/internal/thread/responder.go
+++ b/internal/thread/responder.go
@@ -1172,7 +1172,51 @@ func stripStatusGlyphs(s string) string {
 // What the two routes do NOT share is provenance: n carries which one it came
 // from (see Note), so the shared path can render each honestly instead of
 // filing model prose under the human's name.
+//
+// # The per-thread cap is decided inside this thread's own guard
+//
+// Reading the cap, writing to the forge and incrementing the counter are ONE
+// critical section, and they have to be: they are three steps of a single
+// read-modify-write over one number that concurrent deliveries share.
+//
+// They used to be three. The cap was read from the caller's own snapshot of the
+// context — captured before any guard was held — write() then took lockRoot for
+// its own reasons, and the increment ran after that guard had been released. So
+// eight concurrent notes on a thread two writes into a cap of three all observed
+// Notes == 2, all decided they were within budget, and produced TEN forge writes
+// with nothing refused, under -race. The guard this needs already existed for
+// the sibling duplicate-PR race one layer down; the cap was simply being decided
+// outside it.
+//
+// The guard is acquired HERE rather than in write() because this is the widest
+// span that has to be atomic — a lock taken inside write() cannot cover a
+// decision its caller already took. write() therefore documents this as its
+// precondition rather than acquiring anything itself; it has exactly one
+// production caller, which is this one.
+//
+// Everything under the guard is either local or a registry call. r.announce
+// schedules onto a bounded dispatcher and returns immediately (Dispatcher.Go
+// never blocks), so the one thing here that talks to the network does not hold
+// the thread's writers behind it.
 func (r *Responder) record(ctx context.Context, tc Context, n Note) (string, error) {
+	// Deferred immediately after acquiring, so every return below — a refusal, a
+	// forge error, a panic — releases it; a write that never released this would
+	// wedge every later note in the thread behind it forever. An untracked root
+	// ("" or a registry that has lost it) gets a no-op guard, exactly as before:
+	// there is nowhere durable to count, which is the separate degradation
+	// ErrThreadNotTracked reports.
+	release := r.Registry.lockRoot(tc.Root)
+	defer release()
+
+	// Re-read under the guard. The caller's tc is a snapshot taken before the
+	// wait — the mention handler reads the registry and then hands it here — so
+	// the count it carries may be several writes stale by the time this call owns
+	// the thread. A miss (disabled registry, or the entry aged out mid-request)
+	// leaves tc exactly as the caller passed it, same as before this existed.
+	if fresh, ok := r.Registry.Get(tc.Root); ok {
+		tc = fresh
+	}
+
 	if tc.Notes >= r.maxNotes() {
 		return fmt.Sprintf("This thread has hit its note limit (%d). Add anything further directly on the pull request.", r.maxNotes()), nil
 	}
@@ -1363,6 +1407,15 @@ func recordedOn(route string, num int, prURL string) string {
 // (see freeform). IntentReinvestigate never reaches it at all. Both callers
 // supply note CONTENT only — the route below is derived from the thread
 // context, never from the text and never from the model.
+//
+// PRECONDITION: the caller holds this root's write guard (Registry.lockRoot) and
+// has re-read tc under it. This method used to acquire that guard itself, which
+// serialised the forge round-trip correctly and still left the per-thread cap
+// being decided outside it by the caller — see record(), which now owns both.
+// The guard is what makes the routing below correct as well as the cap: it is
+// how "two callers both observe NoteURL == ” and both open a PR" (the residual
+// race GetOrCreate's doc comment describes) becomes "the second caller sees the
+// first caller's PR and appends to it instead".
 func (r *Responder) write(ctx context.Context, tc Context, n Note, at time.Time) (string, *KBWrite, error) {
 	// Checked once, upstream of BOTH write routes below: a CommentOnPR spends
 	// this budget exactly like an OpenPR does. Gating only the OpenPR branch —
@@ -1417,29 +1470,6 @@ func (r *Responder) write(ctx context.Context, tc Context, n Note, at time.Time)
 				r.ForgeWrites.Refund()
 			}
 		}()
-	}
-
-	// Serialize concurrent writes for THIS root — not the registry's own
-	// mutex, which is never held across the forge round-trip below, so this
-	// only blocks another write for the SAME thread, never Get/Put/Update or
-	// a write for a different thread. Deferred immediately after acquiring,
-	// so any return path below — success, a forge error, or a panic — always
-	// releases it; a write that never released this would wedge every later
-	// note in the thread behind it forever.
-	release := r.Registry.lockRoot(tc.Root)
-	defer release()
-
-	// Re-read the registry now that the guard is held: another write for
-	// this same root may have landed and updated NoteURL while this call was
-	// waiting for the lock, and the routing decision below must see THAT,
-	// not the possibly-stale tc captured before the wait. This is what turns
-	// "two callers can both observe NoteURL == '' and both open a PR" (the
-	// residual race GetOrCreate's doc comment describes) into "the second
-	// caller sees the first caller's PR and comments on it instead." A miss
-	// here (disabled registry, or the entry aged out mid-request) leaves tc
-	// exactly as the caller passed it, same as before this guard existed.
-	if fresh, ok := r.Registry.Get(tc.Root); ok {
-		tc = fresh
 	}
 
 	// Evaluated once here, ahead of the route branch, so whichever route runs

--- a/internal/thread/responder.go
+++ b/internal/thread/responder.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
+	"github.com/Smana/runlore/internal/okf"
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/ratelimit"
 	"github.com/Smana/runlore/internal/redact"
@@ -1370,6 +1371,24 @@ func (r *Responder) addToPR(ctx context.Context, tc Context, n Note, at time.Tim
 // the entry ends up saying what they said, once, and the alternative — a false
 // negative — is the permanent duplicate this is here to prevent.
 //
+// It keys BOTH sides of the entry's life: the marker stamped into the entry when
+// the open_pr route creates it (see write) and the one an append then looks for.
+// Only the second half existed at first, which left note 1 — and only note 1 —
+// duplicable by a redelivery.
+//
+// WHERE IT DOES NOT REACH: the freeform route. There n.Text is the MODEL's draft,
+// and a replayed delivery re-invokes the model, so the redelivery arrives with
+// different bytes and hashes to a different key. Nothing here can close that. The
+// only identity a replay genuinely shares is the human's original message, and
+// keying on that would collapse two deliberate follow-ups drafted from similar
+// messages into one — silently dropping a note somebody meant to file, which is
+// the worse of the two failures. What bounds it instead is upstream and already
+// present: internal/server's delivery dedup catches the common replay before a
+// model is called at all, and the per-thread cap and the ForgeWrites window bound
+// what gets through. The residue is visible duplicate prose in an entry a human
+// still has to merge, not silent catalog corruption. See
+// TestModelDraftedReplayIsNotDeduplicated.
+//
 // SHA-256 truncated to 16 hex characters. It is an identity, not a
 // authentication tag: the entry it is compared against is one RunLore wrote, and
 // note text reaching an entry has "<!" escaped out of it (see noteText), so a
@@ -1537,6 +1556,32 @@ func (r *Responder) write(ctx context.Context, tc Context, n Note, at time.Time)
 	}
 
 	entry := ConceptEntry(tc, n, at, r.maxNoteBytes())
+	// Mark note 1 with the SAME identity a later append would look for, so the
+	// entry this opens is already idempotent against its own redelivery.
+	//
+	// Without it the idempotency this package built covered every note in a
+	// thread except the first. A replayed delivery re-enters here with NoteURL
+	// already set by the write it is replaying, takes the append route, finds no
+	// marker in the entry — because nothing had ever put one there — and writes
+	// note 1 into the catalog a second time. Unlike a duplicated comment, which
+	// is visible conversation that dies at merge, that is permanent entry
+	// content: kb_search indexes it twice and recall serves it twice, with
+	// nothing saying either copy is a duplicate.
+	//
+	// Derived here rather than inside ConceptEntry because the key is a property
+	// of the DELIVERY, not of the entry: it is the same noteKey(tc, n) addToPR
+	// passes, over the same n — reassigned above by noteAsWritten, so both see the
+	// note as written rather than as typed. Two derivations that could disagree is
+	// the only way this fix fails while looking correct, so there is one, and
+	// TestOpenPRNoteMarkerIsTheKeyTheAppendPathDerives pins it.
+	//
+	// The marker survives the write: both forge clients render an entry body
+	// through neutralizeImages alone, which rewrites "![" and nothing else, and an
+	// HTML comment is not markdown a renderer shows. It cannot be forged from note
+	// text either — noteText escapes "<!" out of everything untrusted (see
+	// neutralizeHTML), which is what keeps a stranger from planting a marker that
+	// suppresses somebody else's later note.
+	entry.Body = okf.WithNoteMarker(entry.Body, noteKey(tc, n))
 	ref, err := r.Forge.OpenPR(ctx, entry)
 	if err != nil {
 		return forgeErrorReply(err), nil,

--- a/internal/thread/responder.go
+++ b/internal/thread/responder.go
@@ -150,6 +150,12 @@ type Responder struct {
 	// forge incident regardless of which route its notes happen to take. The
 	// token spend a model now makes ahead of this check is bounded separately,
 	// by Chat.Budget — see Chat below. nil means unlimited.
+	//
+	// It bounds writes that LANDED. The check reserves a token before the forge
+	// call, because it has to, and every path that then returns without a write
+	// refunds it — so this ceiling and the per-thread cap agree that a failure
+	// costs nothing, which is the whole reason a failed write must not be able to
+	// throttle the next healthy one.
 	ForgeWrites *ratelimit.Window
 	// MaxNoteBytes caps one human message, in bytes, before it is written to
 	// the knowledge base — see NoteBody / DefaultMaxNoteBytes for why. <= 0
@@ -1386,6 +1392,33 @@ func (r *Responder) write(ctx context.Context, tc Context, n Note, at time.Time)
 		return "⚠️ I have made too many knowledge-base writes recently and paused. Try again shortly.", nil, nil
 	}
 
+	// The token above is a RESERVATION, and every path below that returns without
+	// a landed write hands it back.
+	//
+	// Allow() has to be optimistic — a caller that checked the budget only after
+	// succeeding would let two callers race past the same last token — so the
+	// charge necessarily precedes the outcome. Leaving it charged on failure made
+	// this feature's two budgets disagree about what a failure costs: record()
+	// deliberately does NOT charge the per-thread count for a write that did not
+	// land, while a forge outage spent this hour's whole allowance on nothing and
+	// then told the next human "I have made too many knowledge-base writes
+	// recently" with zero writes behind it (see
+	// TestForgeOutageDoesNotBurnTheGlobalWriteBudget).
+	//
+	// Keyed on `landed` rather than on the returned error, because the two are not
+	// the same question: the ErrPRNotOpen paths below return no error and no
+	// result — they fall THROUGH to open a standalone entry, and the token they
+	// are still holding is the one that write pays with. So the flag is set at the
+	// two returns that carry a *KBWrite, and nowhere else.
+	landed := false
+	if r.ForgeWrites != nil {
+		defer func() {
+			if !landed {
+				r.ForgeWrites.Refund()
+			}
+		}()
+	}
+
 	// Serialize concurrent writes for THIS root — not the registry's own
 	// mutex, which is never held across the forge round-trip below, so this
 	// only blocks another write for the SAME thread, never Get/Put/Update or
@@ -1468,6 +1501,7 @@ func (r *Responder) write(ctx context.Context, tc Context, n Note, at time.Time)
 		}
 		r.log().Info("thread: note recorded on KB PR", "pr", num, "root", tc.Root, "route", route, "author", n.Author)
 		r.recordWrite(ctx, route)
+		landed = true
 		return recordedOn(route, num, candidate.url),
 			&KBWrite{Route: route, PR: num, URL: candidate.url, Note: asWritten}, nil
 	}
@@ -1484,6 +1518,7 @@ func (r *Responder) write(ctx context.Context, tc Context, n Note, at time.Time)
 	}
 	r.log().Info("thread: note opened a standalone KB PR", "url", ref.URL, "root", tc.Root, "author", n.Author)
 	r.recordWrite(ctx, RouteOpenPR)
+	landed = true
 	// PRNumber, not prNumberOn: this URL is one RunLore's own forge client just
 	// returned, which is exactly the case PRNumber documents itself as safe for.
 	// A URL it cannot parse is not a failure — the write landed, and the result

--- a/internal/thread/responder.go
+++ b/internal/thread/responder.go
@@ -805,6 +805,74 @@ func Untrusted(s string) string {
 	return untrustedMark + strings.ReplaceAll(s, untrustedMark, "") + untrustedMark
 }
 
+// SafeErrorText prepares a SERVER-SUPPLIED error string for a chat message:
+// redacted, backticks neutralised, flattened to one line. It is what a forge
+// error must go through before any surface publishes it.
+//
+// It is EXPORTED and shared rather than reimplemented per surface, because the
+// two surfaces that publish this class of text have already been shown to drift:
+// internal/notify's curateFailureReason arrived at exactly this pipeline for the
+// curate-failure line on an investigation card, while this package went on
+// posting `Untrusted(err.Error())` into a thread — which its own doc comment
+// cited as precedent for publishing forge errors at all. One implementation is
+// what makes "the same treatment" a fact rather than an intention, the same
+// argument QuoteUntrusted's own doc makes one function down.
+//
+// Three measures, in this order, each answering something the others do not:
+//
+//   - redact.Secrets FIRST, because a forge error may echo the credential it
+//     rejected — a GitHub 403 body carrying the bearer token was the live case —
+//     and running it before any cut means a truncation can never hand it a
+//     half-token it no longer matches;
+//   - backticks become apostrophes, because every caller wraps the result in an
+//     inline code span and ONE backtick inside would close it early. Apostrophe
+//     rather than deletion, so a quoted identifier still reads;
+//   - SingleLine LAST of the three, because no escaper in this repo touches a
+//     line break: a multi-line JSON body renders its continuation lines at the
+//     same left margin as RunLore's own status claims, which is the forged-
+//     headline class internal/notify was already bitten by. Flattening also maps
+//     the private-use area, which is what stops a mark in a server's body from
+//     flipping RenderReply's parity (see RenderReply).
+//
+// The CAP is deliberately left to the caller. Both surfaces bound this, in
+// different units for different reasons — notify counts runes against a Slack
+// section limit, this package counts bytes against a message budget it shares —
+// and folding one of those numbers in here would make the other a lie.
+func SafeErrorText(s string) string {
+	return SingleLine(strings.ReplaceAll(redact.Secrets(s), "`", "'"))
+}
+
+// forgeErrorBytes bounds the forge error one thread reply publishes.
+//
+// It is the byte counterpart of internal/notify's curateErrorRunes, and it is
+// that size for that comment's reason rather than a coincidentally similar one:
+// truncate cuts the HEAD, and a wrapped Go error puts the diagnosis LAST
+// ("open PR: github POST /repos/o/r/pulls: status 403: Resource not accessible
+// by integration"), so a tighter cap reliably keeps the call site and drops the
+// status and the message — the only two things an operator can act on.
+//
+// Bytes, not runes, because every other bound in this package counts bytes
+// (notePreviewBytes, MaxNoteBytes) and a second unit here would be one more
+// thing to get wrong. A forge error is overwhelmingly ASCII, so the two agree in
+// practice and the byte count is the conservative one where they do not.
+const forgeErrorBytes = 300
+
+// forgeErrorReply renders the one reply a failed knowledge-base write gets, from
+// both routes that can fail, so the two cannot drift into telling a human two
+// different things — which is exactly how the unredacted one survived: the fix
+// that would have covered it had two literals to find.
+//
+// The inline code span is the fourth measure, the one SafeErrorText cannot
+// provide: a reason this long soft-wraps in every client, and a continuation
+// line starts at the left margin with no quote bar of its own. Inside a span it
+// is monospaced-with-a-background on Slack and <code> on Matrix — visibly not
+// RunLore's own voice. The backticks are RunLore's OWN bytes, outside the marked
+// span, so no escaper rewrites them and nothing inside can close them early.
+func forgeErrorReply(err error) string {
+	return "⚠️ I could not save that to the knowledge base: `" +
+		Untrusted(truncate(SafeErrorText(err.Error()), forgeErrorBytes)) + "`"
+}
+
 // RenderReply resolves the untrusted spans a reply carries: escape is applied
 // to every span Untrusted marked, everything RunLore wrote itself is left
 // exactly as it is, and the marks themselves are removed either way. Every
@@ -818,8 +886,24 @@ func Untrusted(s string) string {
 // Splitting on a single mark rather than on an open/close pair is deliberate:
 // spans cannot nest (Untrusted strips the mark from its own content), so the
 // segments simply alternate — even indices are RunLore's, odd indices are not.
-// A stray unpaired mark could therefore only widen what gets escaped, never
-// narrow it, which is the safe direction to fail in.
+//
+// That alternation is the whole contract, and it is a PARITY: one stray mark
+// anywhere flips it for everything after that point, so a span downstream that
+// really is untrusted lands on an even index and is handed to the transport
+// UNESCAPED. This comment used to claim the opposite — that a stray mark "could
+// only widen what gets escaped, never narrow it" — and that was simply false;
+// measured, a raw U+E000 interpolated ahead of a marked span let "<!channel>"
+// through verbatim. The false rationale mattered more than the bug: it is what
+// would license a future caller to interpolate untrusted text without wrapping
+// it, on the grounds that the failure was safe.
+//
+// What actually holds the parity is that every untrusted span goes through
+// Untrusted(), which strips the mark from its own content, and that every
+// single-line field reaching a reply outside a span goes through SingleLine,
+// which maps the private-use area — U+E000 included — to a space (see
+// forgeErrorReply, and TestForgeFailureCannotNarrowWhatTheReplyEscapes). Neither
+// is optional, and neither is checked here: this function cannot tell a mark it
+// wrote from one it was handed.
 func RenderReply(reply string, escape func(string) string) string {
 	parts := strings.Split(reply, untrustedMark)
 	if len(parts) == 1 {
@@ -1379,7 +1463,7 @@ func (r *Responder) write(ctx context.Context, tc Context, n Note, at time.Time)
 			continue
 		}
 		if err != nil {
-			return fmt.Sprintf("⚠️ I could not save that to the knowledge base: %s", Untrusted(err.Error())), nil,
+			return forgeErrorReply(err), nil,
 				fmt.Errorf("comment on PR %d: %w", num, err)
 		}
 		r.log().Info("thread: note recorded on KB PR", "pr", num, "root", tc.Root, "route", route, "author", n.Author)
@@ -1391,7 +1475,7 @@ func (r *Responder) write(ctx context.Context, tc Context, n Note, at time.Time)
 	entry := ConceptEntry(tc, n, at, r.maxNoteBytes())
 	ref, err := r.Forge.OpenPR(ctx, entry)
 	if err != nil {
-		return fmt.Sprintf("⚠️ I could not save that to the knowledge base: %s", Untrusted(err.Error())), nil,
+		return forgeErrorReply(err), nil,
 			fmt.Errorf("open note PR: %w", err)
 	}
 	if uerr := r.Registry.Update(tc.Root, func(c *Context) { c.NoteURL = ref.URL }); uerr != nil {

--- a/internal/thread/responder.go
+++ b/internal/thread/responder.go
@@ -385,10 +385,18 @@ func kbRoute(route string) providers.KBRoute {
 // forge accepted the write (see KBWrite), so there is nothing to announce on a
 // throttle, a forge failure, or a note the model never proposed.
 //
-// n supplies the author, which is not on the KBWrite: the write is the same
-// write either way, and only the caller knows whose message produced it. It
-// goes through noteField — redacted and flattened, exactly as the entry itself
-// renders it — because this event is a NEW egress for transport-reported text.
+// n supplies the author AND the provenance, neither of which is on the KBWrite:
+// the write is the same write either way, and only the caller knows whose
+// message produced it and whether they wrote the words. The author goes through
+// noteField — redacted and flattened, exactly as the entry itself renders it —
+// because this event is a NEW egress for transport-reported text; the provenance
+// is RunLore's own boolean and needs neither.
+//
+// Carrying the provenance is not optional decoration. Without it the event said
+// {author: "alice", note: "<the model's text>"} and every sink rendered it as
+// alice's own words — the same claim openedWith exists to keep out of the thread
+// reply, and NoteBody's "@alice did not write it" out of the entry, arriving
+// through the one surface that had no such guard.
 //
 // tc supplies BOTH thread handles, Root and Channel. Root alone names a thread
 // only to the transport that already knows which channel it is in; a sink asked
@@ -400,7 +408,20 @@ func (r *Responder) announce(ctx context.Context, tc Context, n Note, w *KBWrite
 	if r.Announcer == nil || w == nil {
 		return
 	}
-	r.Announcer.deliver(ctx, providers.KBUpdate{
+	r.Announcer.deliver(ctx, r.kbUpdateFor(tc, n, w, at))
+}
+
+// kbUpdateFor composes the event announce delivers. Split out from announce so
+// the composition can be exercised without a sink and a dispatcher — the two
+// things that made the missing provenance field hard to see, since every
+// announcement test asserted on what a sink RECEIVED and none of them had a
+// reason to compare two notes that differed only in who wrote them.
+//
+// It is the ONE place a KBUpdate is built from a write, which is what lets
+// TestKBUpdateCarriesEveryNoteFact assert a property over the whole mapping
+// rather than over one fixture.
+func (r *Responder) kbUpdateFor(tc Context, n Note, w *KBWrite, at time.Time) providers.KBUpdate {
+	return providers.KBUpdate{
 		Transport: tc.Transport,
 		Root:      tc.Root,
 		Channel:   tc.Channel,
@@ -409,9 +430,15 @@ func (r *Responder) announce(ctx context.Context, tc Context, n Note, w *KBWrite
 		URL:       w.URL,
 		Title:     w.Title,
 		Author:    noteField(n.Author),
-		Note:      w.Note,
-		At:        at,
-	})
+		// Author names whose MESSAGE produced the note; this names whether they
+		// wrote its words. Read from the note's own provenance rather than from a
+		// parallel flag, for the reason Note.DraftedFrom is one field: two values
+		// that can disagree let model prose ship under a human's name through
+		// nothing worse than a forgotten assignment.
+		ModelDrafted: n.modelDrafted(),
+		Note:         w.Note,
+		At:           at,
+	}
 }
 
 // The routes a knowledge write can take, named once. They are both the

--- a/internal/thread/responder_test.go
+++ b/internal/thread/responder_test.go
@@ -4191,3 +4191,90 @@ func TestForgeFailureCannotNarrowWhatTheReplyEscapes(t *testing.T) {
 		t.Errorf("a mark smuggled through the forge error narrowed the escaping and let <!channel> reach the wire: %q", rendered)
 	}
 }
+
+// TestForgeOutageDoesNotBurnTheGlobalWriteBudget closes the disagreement between
+// this feature's two budgets about what a FAILURE costs.
+//
+// ForgeWrites is consumed at the top of write(), upstream of the route branch,
+// which is right: a comment must spend it exactly as an OpenPR does. But no
+// failure path handed the token back, so a forge outage spent the whole hour on
+// writes that never happened — 20 failed attempts, zero entries, and the 21st
+// caller told "I have made too many knowledge-base writes recently" (reproduced).
+// The per-thread count is deliberately NOT charged for a failure (see record),
+// so the two ceilings were answering the same question differently.
+//
+// The 21st write here is the assertion: the forge is healthy again, and the only
+// thing that could still refuse it is a budget spent on nothing.
+func TestForgeOutageDoesNotBurnTheGlobalWriteBudget(t *testing.T) {
+	f := &fakeForge{openErr: errors.New("503 service unavailable")}
+	r := newTestResponder(t, f)
+	r.ForgeWrites = ratelimit.New(20, time.Hour)
+	r.MaxNotesPerThread = 1000
+	tc := Context{Transport: "slack", Root: "root-1"}
+	if err := r.Registry.Put(tc); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	ctx := context.Background()
+	for i := range 20 {
+		if _, err := r.Handle(ctx, tc, "alice", "note: attempt during the outage"); err == nil {
+			t.Fatalf("attempt %d: expected the forge failure to be reported", i)
+		}
+	}
+	if got := r.ForgeWrites.Count(); got != 0 {
+		t.Errorf("%d tokens still spent after 20 writes that never landed", got)
+	}
+
+	f.openErr = nil
+	f.openURL = "https://github.com/o/r/pull/7"
+	fresh, _ := r.Registry.Get("root-1")
+	reply, err := r.Handle(ctx, fresh, "alice", "note: the forge is healthy again")
+	if err != nil {
+		t.Fatalf("handle: %v", err)
+	}
+	if strings.Contains(reply, "too many knowledge-base writes") {
+		t.Fatalf("throttled on a healthy forge, having landed nothing: %q", reply)
+	}
+	if len(f.opened) != 1 {
+		t.Errorf("opened %d PRs, want the one that succeeded", len(f.opened))
+	}
+}
+
+// TestGlobalWriteBudgetStillChargesEveryLandedWrite is the other direction, and
+// it is why the refund is placed on the failure paths rather than on the whole
+// call: a write that LANDED must still cost a token, on either route, or the
+// refund would quietly turn the one global ceiling this feature has into no
+// ceiling at all.
+func TestGlobalWriteBudgetStillChargesEveryLandedWrite(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		tc   Context
+	}{
+		{"open_pr", Context{Transport: "slack", Root: "root-1"}},
+		{"comment", Context{Transport: "slack", Root: "root-1", CuratedURL: "https://github.com/o/r/pull/7"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &fakeForge{openURL: "https://github.com/o/r/pull/9"}
+			r := newTestResponder(t, f)
+			r.ForgeWrites = ratelimit.New(2, time.Hour)
+			r.MaxNotesPerThread = 1000
+			if err := r.Registry.Put(tt.tc); err != nil {
+				t.Fatalf("put: %v", err)
+			}
+			ctx := context.Background()
+			for i := range 2 {
+				fresh, _ := r.Registry.Get("root-1")
+				if _, err := r.Handle(ctx, fresh, "alice", fmt.Sprintf("note: landed write %d", i)); err != nil {
+					t.Fatalf("write %d: %v", i, err)
+				}
+			}
+			fresh, _ := r.Registry.Get("root-1")
+			reply, err := r.Handle(ctx, fresh, "alice", "note: one past the budget")
+			if err != nil {
+				t.Fatalf("handle: %v", err)
+			}
+			if !strings.Contains(reply, "too many knowledge-base writes") {
+				t.Errorf("the third write was not throttled: %q", reply)
+			}
+		})
+	}
+}

--- a/internal/thread/responder_test.go
+++ b/internal/thread/responder_test.go
@@ -4066,3 +4066,128 @@ func TestKBRouteVocabulariesAgree(t *testing.T) {
 		t.Errorf("kbRoute(%q) = %q, want %q", RouteAppend, got, providers.KBRouteAppend)
 	}
 }
+
+// forgeErrorText returns what the FORGE contributed to a "could not save" reply:
+// RunLore's own lead-in and the inline code span it wraps the reason in are
+// stripped, and the span marks are left in place so a test can count them.
+//
+// Requiring the code span here rather than asserting it separately is
+// deliberate: it is the fourth measure — the one that keeps a soft-wrapped
+// continuation line visibly out of RunLore's own voice — so a reply that lost it
+// must fail every test built on this helper, not only one named for it.
+func forgeErrorText(t *testing.T, reply string) string {
+	t.Helper()
+	const lead = "⚠️ I could not save that to the knowledge base: "
+	if !strings.HasPrefix(reply, lead) {
+		t.Fatalf("reply is not a forge-failure reply: %q", reply)
+	}
+	rest := strings.TrimPrefix(reply, lead)
+	if len(rest) < 2 || !strings.HasPrefix(rest, "`") || !strings.HasSuffix(rest, "`") {
+		t.Fatalf("the forge reason is not inside an inline code span: %q", rest)
+	}
+	return rest[1 : len(rest)-1]
+}
+
+// TestForgeFailureReplyIsRedactedFlattenedAndBounded pins the treatment a forge
+// error gets before it is posted into a chat thread — on BOTH failure routes,
+// because the two are separate literals and the one that gets fixed alone is the
+// one that stops being tested.
+//
+// It used to get none. Untrusted(err.Error()) marks a span for the transport's
+// markup escaper and does nothing else, and a forge error is a SERVER-SUPPLIED
+// body: a GitHub 403 echoes the credential it rejected, and every escaper in
+// this repo leaves a line break alone, so a multi-line JSON body rendered its
+// continuation lines at the same left margin as RunLore's own status claims.
+//
+// The four measures are the ones internal/notify's curateFailureReason already
+// applied to the identical class of text, and they are asserted here rather than
+// assumed: redaction, backtick neutralisation (the reply wraps the reason in an
+// inline code span, which one backtick would close early), flattening, and a
+// bound.
+func TestForgeFailureReplyIsRedactedFlattenedAndBounded(t *testing.T) {
+	const token = "ghp_0123456789abcdefghijklmnopqrstuvwxyzAB"
+	// The backtick is the forge quoting an identifier back at RunLore, which real
+	// forge errors do ("branch `main` is protected") — one is all it takes to close
+	// the inline code span the reply wraps this in.
+	body := "github POST /repos/o/r/pulls: status 403: branch `main`: {\n \"message\": \"Bad credentials\",\n \"token\": \"" + token + "\"\n}"
+
+	routes := map[string]func(*fakeForge){
+		// The standalone-entry route: OpenPR itself failed.
+		"open_pr": func(f *fakeForge) { f.openErr = errors.New(body) },
+		// The existing-PR route: the comment (and, before it, the append) failed.
+		"comment": func(f *fakeForge) { f.commErr, f.appendErr = errors.New(body), errors.New(body) },
+	}
+	for name, setup := range routes {
+		t.Run(name, func(t *testing.T) {
+			f := &fakeForge{}
+			setup(f)
+			r := newTestResponder(t, f)
+			tc := Context{Transport: "slack", Root: "root-1"}
+			if name == "comment" {
+				tc.CuratedURL = "https://github.com/o/r/pull/7"
+			}
+			reply, err := r.Handle(context.Background(), tc, "alice", "note: the cause was a spot reclaim")
+			if err == nil {
+				t.Fatalf("expected the forge failure to be reported, got reply %q", reply)
+			}
+			got := forgeErrorText(t, reply)
+			if strings.Contains(got, token) {
+				t.Errorf("the credential the forge echoed reached the thread verbatim: %q", got)
+			}
+			if strings.ContainsAny(got, "\n\r\v\f") {
+				t.Errorf("a break rune survived, so a forged status line can sit at RunLore's own left margin: %q", got)
+			}
+			if strings.Contains(got, "`") {
+				t.Errorf("a backtick survived and would close the inline code span early: %q", got)
+			}
+			if !strings.Contains(got, "status 403") {
+				t.Errorf("the diagnosis an operator acts on was dropped: %q", got)
+			}
+		})
+	}
+}
+
+// TestForgeFailureReplyIsCapped keeps the bound a property of the reply rather
+// than of whatever the forge happened to return. A forge body is server-supplied
+// and unbounded — a proxy banner, an HTML error page — and an unbounded one is
+// an unbounded chat post on a path any channel member can trigger.
+func TestForgeFailureReplyIsCapped(t *testing.T) {
+	f := &fakeForge{openErr: errors.New("open PR: " + strings.Repeat("x", 4000))}
+	r := newTestResponder(t, f)
+	reply, err := r.Handle(context.Background(), Context{Root: "root-1"}, "alice", "note: the cause was a spot reclaim")
+	if err == nil {
+		t.Fatalf("expected a forge failure, got %q", reply)
+	}
+	if got := len(forgeErrorText(t, reply)); got > forgeErrorBytes+2*len(untrustedMark)+8 {
+		t.Errorf("the published forge error is %d bytes, past the %d-byte bound", got, forgeErrorBytes)
+	}
+}
+
+// TestForgeFailureCannotNarrowWhatTheReplyEscapes is the composed guard behind
+// RenderReply's parity, and the reason that function's doc comment no longer
+// claims a stray mark is harmless.
+//
+// RenderReply splits on a single mark and escapes the odd-indexed segments, so
+// the segments simply alternate. One EXTRA mark anywhere flips that parity for
+// everything after it: a genuinely untrusted span downstream lands on an even
+// index and is handed to the transport unescaped. The forge error is the one
+// piece of transport-bound text this package interpolates straight from a
+// server, so it is where an injected mark would arrive — and on the freeform
+// route a reply carries model prose in the very same message.
+func TestForgeFailureCannotNarrowWhatTheReplyEscapes(t *testing.T) {
+	f := &fakeForge{openErr: errors.New("open PR: forbidden" + untrustedMark + " and then")}
+	r := newTestResponder(t, f)
+	reply, err := r.Handle(context.Background(), Context{Root: "root-1"}, "alice", "note: the cause was a spot reclaim")
+	if err == nil {
+		t.Fatalf("expected a forge failure, got %q", reply)
+	}
+	if n := strings.Count(reply, untrustedMark); n%2 != 0 {
+		t.Fatalf("the reply carries %d span marks — an odd count flips RenderReply's parity: %q", n, reply)
+	}
+	rendered := RenderReply(reply+"\n"+Untrusted("<!channel>"), func(s string) string {
+		return strings.ReplaceAll(s, "<", "&lt;")
+	})
+	if strings.Contains(rendered, "<!channel>") {
+		t.Errorf("a mark smuggled through the forge error narrowed the escaping and let <!channel> reach the wire: %q", rendered)
+	}
+}

--- a/internal/thread/responder_test.go
+++ b/internal/thread/responder_test.go
@@ -19,6 +19,7 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
+	"github.com/Smana/runlore/internal/okf"
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/ratelimit"
 	"github.com/Smana/runlore/internal/telemetry"
@@ -4349,5 +4350,118 @@ func TestConcurrentNotesCannotExceedThePerThreadCap(t *testing.T) {
 	}
 	if tc, ok := r.Registry.Get(root); !ok || tc.Notes != noteCap {
 		t.Errorf("Notes = %d (tracked %v), want %d — the counter must end at the cap, not past it or short of it", tc.Notes, ok, noteCap)
+	}
+}
+
+// TestOpenPRMarksTheFirstNoteSoAReplayCannotDuplicateIt closes the one gap in
+// the idempotency this package already built.
+//
+// noteKey and okf.NoteMarker exist because the layers above replay: internal/
+// server dedups Slack deliveries through a bounded, PER-PROCESS set that is
+// wiped wholesale at capacity, so a busy channel, a restart or a leader failover
+// all deliver the same message twice. Both APPEND paths honoured that — an entry
+// already carrying the key is left alone. The OPEN_PR path did not: it wrote
+// note 1 into a brand-new entry with no marker at all, so a redelivery found
+// nothing to match, took the append route (NoteURL is set by then) and wrote the
+// same note into the entry a second time. Permanent catalog content, indexed and
+// recalled twice, with no signal that either is a duplicate.
+//
+// The oracle is the CONTRACT between the two layers rather than a simulated
+// forge: the marker the entry carries must be the one the replay's append then
+// looks for. github.Client and gitlab.Client both implement HasNoteMarker as a
+// substring search for exactly that literal, and both have their own tests for
+// the skip; faking that here would prove only that the fake agrees with itself.
+func TestOpenPRMarksTheFirstNoteSoAReplayCannotDuplicateIt(t *testing.T) {
+	f := &fakeForge{openURL: "https://github.com/o/r/pull/7"}
+	r := newTestResponder(t, f)
+	tc := Context{Transport: "slack", Root: "root-1", Channel: "C1"}
+	if err := r.Registry.Put(tc); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	ctx := context.Background()
+	const text = "the real cause was a spot-node reclaim"
+
+	if _, err := r.record(ctx, tc, HumanNote("alice", text)); err != nil {
+		t.Fatalf("first delivery: %v", err)
+	}
+	if len(f.opened) != 1 {
+		t.Fatalf("opened = %d, want 1", len(f.opened))
+	}
+
+	// The replay: same thread, same author, same text — everything that does not
+	// move between a delivery and its redelivery.
+	fresh, _ := r.Registry.Get("root-1")
+	if _, err := r.record(ctx, fresh, HumanNote("alice", text)); err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	if len(f.appends) != 1 {
+		t.Fatalf("appends = %d, want the replay to have taken the append route", len(f.appends))
+	}
+
+	key := f.appends[0].key
+	if key == "" {
+		t.Fatal("the replay's append carries no key, so the forge has nothing to match")
+	}
+	if marker := okf.NoteMarker(key); !strings.Contains(f.opened[0].Body, marker) {
+		t.Errorf("the entry opened for note 1 does not carry %s, so the replay's HasNoteMarker finds "+
+			"nothing and writes the same note into the catalog twice.\nentry body:\n%s", marker, f.opened[0].Body)
+	}
+}
+
+// TestOpenPRNoteMarkerIsTheKeyTheAppendPathDerives keeps the two halves of that
+// contract from drifting apart in the harmless-looking direction: an entry that
+// carries SOME marker, derived differently from the one an append looks for,
+// reads as correct and dedups nothing.
+func TestOpenPRNoteMarkerIsTheKeyTheAppendPathDerives(t *testing.T) {
+	f := &fakeForge{openURL: "https://github.com/o/r/pull/7"}
+	r := newTestResponder(t, f)
+	tc := Context{Transport: "slack", Root: "root-1"}
+	if err := r.Registry.Put(tc); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	n := HumanNote("alice", "the real cause was a spot-node reclaim")
+	if _, err := r.record(context.Background(), tc, n); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	// noteKey is derived from the note AS WRITTEN — redacted and capped — which is
+	// what write() files, so the expectation has to go through the same step.
+	written, _ := r.noteAsWritten(n)
+	want := okf.NoteMarker(noteKey(tc, written))
+	if !strings.Contains(f.opened[0].Body, want) {
+		t.Errorf("entry carries no %s\nbody:\n%s", want, f.opened[0].Body)
+	}
+}
+
+// TestModelDraftedReplayIsNotDeduplicated states the limit of all this, because
+// a guarantee that quietly does not hold on one route is worse than one that
+// says where it stops.
+//
+// noteKey hashes the note's own TEXT, and on the freeform route that text is the
+// model's draft rather than the human's message. A replayed delivery re-invokes
+// the model, which is not deterministic, so the redelivery arrives with
+// different bytes, hashes to a different key, and appends as a genuinely new
+// note. Nothing at this layer can fix that: the only stable identity a replay
+// shares is the human's original message, and keying on THAT would collapse two
+// deliberate follow-ups drafted from similar messages into one — silently
+// dropping a note somebody meant to file, which is the worse failure of the two.
+//
+// What bounds it instead is upstream and already there: the per-thread cap (now
+// enforced under the thread's own guard), the global ForgeWrites window, and
+// internal/server's delivery dedup, which catches the common replay before a
+// model is ever called. A duplicated model draft is visible prose in an entry a
+// human still has to merge, not silent catalog corruption.
+func TestModelDraftedReplayIsNotDeduplicated(t *testing.T) {
+	tc := Context{Transport: "slack", Root: "root-1"}
+	const message = "was it the CNI?"
+	first := ProposedNote("alice", message, "It was a spot-node reclaim.")
+	replay := ProposedNote("alice", message, "The cause was a spot node being reclaimed.")
+
+	if noteKey(tc, first) == noteKey(tc, replay) {
+		t.Fatal("two different drafts hashed to one key — noteKey no longer keys on the note text")
+	}
+	// The human's own message is identical across the two, which is exactly the
+	// identity that is NOT used, and the comment above says why.
+	if first.DraftedFrom != replay.DraftedFrom {
+		t.Fatal("fixture error: the replayed delivery must carry the same human message")
 	}
 }

--- a/internal/thread/responder_test.go
+++ b/internal/thread/responder_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -4463,5 +4464,124 @@ func TestModelDraftedReplayIsNotDeduplicated(t *testing.T) {
 	// identity that is NOT used, and the comment above says why.
 	if first.DraftedFrom != replay.DraftedFrom {
 		t.Fatal("fixture error: the replayed delivery must carry the same human message")
+	}
+}
+
+// TestAnnouncementCarriesWhoActuallyWroteTheNote closes the last surface on
+// which model-authored prose was filed under a named human.
+//
+// Every other surface already made the distinction. NoteBody heads a drafted
+// entry "🤖 Proposed operator note — drafted by RunLore" and states "@alice did
+// not write it"; conceptDescription leads with the provenance clause so a
+// listing that clips the line cannot clip it; openedWith exists ONLY to stop the
+// thread reply saying "with your note" for text the human did not type. The
+// announcement had no provenance field at all, so it published
+// {author: "alice", note: "<the model's text>"} to every configured sink and
+// rendered "By alice in a slack thread" — the exact claim openedWith exists to
+// prevent, arriving through the one door nobody had checked.
+//
+// It is worst under announce_kb_updates: thread, where the reduced form is two
+// lines and one of them IS the attribution — and where, if the best-effort reply
+// fails, it is the only thing in the thread.
+func TestAnnouncementCarriesWhoActuallyWroteTheNote(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		note Note
+		want bool
+	}{
+		{"an explicit note: is the human's own words", HumanNote("alice", "the real cause was a spot reclaim"), false},
+		{"a freeform answer's note is the model's", ProposedNote("alice", "was it the CNI?", "It was a spot reclaim."), true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &fakeForge{openURL: "https://github.com/o/r/pull/7"}
+			r, sink := newAnnouncingResponder(t, f)
+			tc := Context{Transport: "slack", Root: "root-1", Channel: "C1"}
+			if err := r.Registry.Put(tc); err != nil {
+				t.Fatalf("Put: %v", err)
+			}
+			if _, err := r.record(context.Background(), tc, tt.note); err != nil {
+				t.Fatalf("record: %v", err)
+			}
+			drainAnnouncements(t, r)
+
+			ups := sink.updates()
+			if len(ups) != 1 {
+				t.Fatalf("announced %d writes, want 1", len(ups))
+			}
+			if got := ups[0].ModelDrafted; got != tt.want {
+				t.Errorf("KBUpdate.ModelDrafted = %v, want %v — the announcement reports %q as the note's "+
+					"provenance and carries %q as its text", got, tt.want, ups[0].Author, ups[0].Note)
+			}
+			// Author stays the human either way: they are still whose message
+			// produced the note, which is what a reader needs to follow it up. What
+			// changes is whether the announcement may present the TEXT as theirs.
+			if ups[0].Author != "alice" {
+				t.Errorf("Author = %q, want the human whose message produced the note", ups[0].Author)
+			}
+		})
+	}
+}
+
+// noteFactsOnTheAnnouncement names, for every field of Note, the KBUpdate field
+// that carries it to a sink. Stated here rather than derived, so a fact added to
+// Note has to be deliberately routed or deliberately withheld.
+//
+// It exists because the two field-classification guards that already cover
+// KBUpdate — the untrusted/trusted split in internal/providers and the webhook
+// payload's coverage check — both WALK KBUPDATE. A fact that was never put on
+// the struct is invisible to both: they can only ask whether an existing field
+// is handled, never whether a field is missing. Note.DraftedFrom was exactly
+// that for as long as the announcement existed, and every one of those guards
+// passed the whole time.
+//
+// This walks the SOURCE type instead, which is the direction that bites.
+var noteFactsOnTheAnnouncement = map[string]string{
+	"Author": "Author",
+	"Text":   "Note",
+	// The FACT, not the text. The human's original message is already in the
+	// entry, where a reviewer weighs the draft against it (see NoteBody); an
+	// announcement is a short chat post to sinks the thread never reached, and
+	// republishing someone's raw message into all of them widens egress for no
+	// reader who needs it. What must travel is that the note is not their words.
+	"DraftedFrom": "ModelDrafted",
+}
+
+// TestKBUpdateCarriesEveryNoteFact makes the map above bite in both directions,
+// and adds the behavioural half a name-matching test cannot give: two notes that
+// differ ONLY in provenance must not produce indistinguishable announcements.
+func TestKBUpdateCarriesEveryNoteFact(t *testing.T) {
+	note := reflect.TypeOf(Note{})
+	update := reflect.TypeOf(providers.KBUpdate{})
+
+	for i := range note.NumField() {
+		name := note.Field(i).Name
+		carrier, ok := noteFactsOnTheAnnouncement[name]
+		if !ok {
+			t.Errorf("thread.Note.%s reaches no announcement and is not classified. Route it to a "+
+				"providers.KBUpdate field, or record why a sink does not need it — a fact never put on "+
+				"the struct is one neither KBUpdate guard can see is missing.", name)
+			continue
+		}
+		if _, found := update.FieldByName(carrier); !found {
+			t.Errorf("thread.Note.%s is classified as reaching providers.KBUpdate.%s, which does not exist — "+
+				"stale entry, so nothing is checking whatever replaced it", name, carrier)
+		}
+	}
+	for name := range noteFactsOnTheAnnouncement {
+		if _, ok := note.FieldByName(name); !ok {
+			t.Errorf("noteFactsOnTheAnnouncement names %q, which thread.Note no longer has — stale entry", name)
+		}
+	}
+
+	// The behavioural half. Same author, same filed text, same thread: the only
+	// difference is who wrote it, and the two events must not be equal.
+	r := &Responder{Now: func() time.Time { return noteAt }}
+	human := r.kbUpdateFor(Context{Transport: "slack", Root: "r"}, HumanNote("alice", "a spot reclaim"),
+		&KBWrite{Route: RouteOpenPR, PR: 7, Note: "a spot reclaim"}, noteAt)
+	drafted := r.kbUpdateFor(Context{Transport: "slack", Root: "r"}, ProposedNote("alice", "was it the CNI?", "a spot reclaim"),
+		&KBWrite{Route: RouteOpenPR, PR: 7, Note: "a spot reclaim"}, noteAt)
+	if human == drafted {
+		t.Error("a note the human typed and a note RunLore's model drafted announce identically — " +
+			"the classification above is satisfied by a field nothing actually sets")
 	}
 }

--- a/internal/thread/responder_test.go
+++ b/internal/thread/responder_test.go
@@ -4278,3 +4278,76 @@ func TestGlobalWriteBudgetStillChargesEveryLandedWrite(t *testing.T) {
 		})
 	}
 }
+
+// TestConcurrentNotesCannotExceedThePerThreadCap closes the gap between the cap
+// and the lock that was already there for the sibling race.
+//
+// The cap used to be read in record() from the caller's OWN snapshot of the
+// thread context — taken before write() acquired lockRoot — and the counter was
+// incremented after that guard had already been released. So the check, the
+// write and the increment sat in three different critical sections, none of
+// which was the one protecting the thread: eight concurrent notes on a thread
+// two writes into a cap of three produced TEN forge writes and refused none,
+// under -race.
+//
+// The guard needed for this is the same guard write() already takes for the
+// duplicate-PR race — one thread's writes were already serialised, the cap was
+// simply being decided outside that. So the assertion is exact rather than
+// "fewer than before": with one write of headroom, exactly one caller may write
+// and every other must be refused, whatever order they arrive in.
+func TestConcurrentNotesCannotExceedThePerThreadCap(t *testing.T) {
+	const (
+		noteCap  = 3 // not `cap`: revive rejects an identifier that shadows a builtin
+		already  = 2
+		writers  = 8
+		headroom = noteCap - already
+	)
+	f := &fakeForge{openURL: "https://github.com/o/r/pull/7"}
+	r := newTestResponder(t, f)
+	r.MaxNotesPerThread = noteCap
+	r.ForgeWrites = ratelimit.New(0, time.Hour) // unlimited; the global budget is not what this pins
+	root := "root-1"
+	if err := r.Registry.Put(Context{Transport: "slack", Root: root, Notes: already}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	refused := 0
+	for i := range writers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// A stale snapshot, exactly as the mention handler takes one: every
+			// writer reads the registry before any of them has written, so all eight
+			// observe Notes == already. Nothing but the guard can separate them.
+			tc, ok := r.Registry.Get(root)
+			if !ok {
+				t.Errorf("Get[%d]: registry lost the root mid-test", i)
+				return
+			}
+			reply, err := r.Handle(context.Background(), tc, "alice", fmt.Sprintf("note: concurrent %d", i))
+			if err != nil {
+				t.Errorf("Handle[%d]: %v", i, err)
+				return
+			}
+			if strings.Contains(reply, "note limit") {
+				mu.Lock()
+				refused++
+				mu.Unlock()
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	comments, opened := f.counts()
+	if got := comments + opened; got != headroom {
+		t.Errorf("%d forge writes with %d of headroom left — the cap was decided outside the guard that serialises this thread", got, headroom)
+	}
+	if refused != writers-headroom {
+		t.Errorf("refused = %d, want %d — every writer past the cap must be told so, not silently written", refused, writers-headroom)
+	}
+	if tc, ok := r.Registry.Get(root); !ok || tc.Notes != noteCap {
+		t.Errorf("Notes = %d (tracked %v), want %d — the counter must end at the cap, not past it or short of it", tc.Notes, ok, noteCap)
+	}
+}

--- a/website/content/docs/configuration/configuration.md
+++ b/website/content/docs/configuration/configuration.md
@@ -654,10 +654,17 @@ transports), `max_note_bytes` (default **8192**, one human message's input), `re
 **168h**), `registry_max` (default **2000**), plus `chat_calls_per_hour` and `chat_tokens_per_hour`
 — which apply only with `model.chat` set, and are covered in full below.
 
+One of those has a floor as well as a default: a positive `max_note_bytes` under 128 bytes is
+refused at load. Below that the truncation marker — the visible mark saying a note was cut —
+fills the whole budget on its own, so nothing of what the human typed is written while every
+surface still reports the write as saved. Leave it at 0 to use the default.
+
 The same block holds the one key that is a switch rather than a ceiling:
 `announce_kb_updates` (default **false**). With it on, every knowledge write that lands is
-also announced to your notifiers — naming the pull request, the entry, who wrote the note and
-which chat system they typed it in, and quoting the note itself. The announcement carries note
+also announced to your notifiers — naming the pull request, the entry, whose message produced the
+note and which chat system they typed it in, and quoting the note itself. Where the note was
+drafted by RunLore's chat model rather than typed after an explicit `note:`, the announcement
+says so instead of attributing the words to the person who prompted it. The announcement carries note
 content, so a note written in one thread reaches every sink you have configured; that is why it
 is opt-in.
 


### PR DESCRIPTION
Seven findings from the v0.15.0 release review that share one shape: **the human is told one thing while another is true.** All seven confirmed by reproduction before any fix, every test watched failing, every fix mutation-tested.

| # | Finding | Fix |
|---|---|---|
| 1 | The announcement cannot say who wrote the note | `providers.KBUpdate.ModelDrafted`, set from the note's own provenance |
| 2 | A raw forge error is published into a chat thread | `thread.SafeErrorText` + `forgeErrorReply`, shared with `notify` |
| 3 | A replayed delivery duplicates the first note | Note marker stamped on the `OpenPR` entry body |
| 4 | The per-thread cap is decided outside the guard | Cap, write and increment moved into one `lockRoot` section |
| 5 | `max_note_bytes` accepts a value too small to keep any note | `thread.MinMaxNoteBytes = 128`, refused at load |
| 6 | A forge outage spends the write budget on nothing | `ratelimit.Window.Refund`, deferred on every non-landing path |
| 7 | The comment route claims the catalog gained something | It no longer does |
| + | `SingleLine`'s doc understates what it narrows | Doc corrected; it now maps `Co` |

### The ones worth reading

**Finding 2 — reproduced a GitHub 403 body carrying `ghp_…` posted verbatim into a chat room.** `notify`'s `curateFailureReason` had already solved exactly this, and its doc cited `internal/thread`'s unredacted `err.Error()` as *precedent* for leaving it raw. The pipeline moved into `thread.SafeErrorText` and both surfaces now call it. Caps stay per-surface — `notify` counts runes against a Slack section limit, `thread` counts bytes against a message budget — and both `write()` failure returns go through one helper, since two literals is how the original fix missed one.

**Finding 4 — reproduced exactly as briefed:** 8 concurrent writes, `refused=0`, counter left at 10. `record()` now takes the guard, and `write()` documents that as a precondition — a lock taken *inside* it could never cover a decision its caller already made.

**Finding 5 — refusal at load, not clamping.** Once the note is destroyed there is no honest degradation left. The floor is derived from the marker's own width (44 bytes at nothing dropped, 53 at a gigabyte) and pinned by a test.

**Finding 6 — `Refund()` drops the newest timestamp.** Tokens are fungible, and since entries are append-ordered an expired one can only precede a live one. A `slideLocked()` call was removed from it after no mutation could falsify its absence.

**Finding 3's freeform limit, stated rather than papered over.** The freeform note cannot be keyed: a replay re-invokes the model and the text differs. Keying on the human's message instead would collapse deliberate follow-ups, silently dropping a note somebody meant to file. `noteKey`'s doc now says so, with a test.

### Finding 1's guard gap — the structural one

Both existing guards **walk `KBUpdate`**, so they can only ask whether an existing field is handled — never whether a fact is *missing*. Both passed the entire time the announcement could not name its author. The new guard walks `thread.Note`, the **source** type, and requires each field to name its carrier, plus a behavioural check that two notes differing only in provenance cannot announce identically. Verified failing on a newly added, unrouted `Note` field.

### Eighth commit, beyond the brief

Operators had no warning their config would stop loading under the new `max_note_bytes` floor, so it is documented — and the announcement paragraph's "who wrote the note" corrected — pinned against `thread.MinMaxNoteBytes` by a guard that fails in all three drift directions.

Gate: `build` · `vet` · `go test ./... -race` · `gofmt -l .` silent · `golangci-lint run ./...` **0 issues** · `hugo` exit 0 · `check-anchors.sh` exit 0.
