### PR TITLE
fix(investigate): warn when a metrics query double-counts the cadvisor pod rollup

### DIFF
--- a/internal/investigate/cadvisor_rollup.go
+++ b/internal/investigate/cadvisor_rollup.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"regexp"
+	"strings"
+)
+
+// cadvisor exports every cgroup-accounted metric TWICE per pod: once per container,
+// and again as a pod-level rollup series carrying container="". Any aggregation that
+// SUMS across series therefore counts each pod twice. Measured live on one workspace
+// pod: container="dev" 17_100_390_400 + pause 229_376 + pod rollup 15_384_018_944 =
+// 32_484_638_720 — exactly the "32.48 GB" a verdict card reported for a pod whose
+// real peak was 17.1 GB. The same unguarded shape over a whole node returned 50.2 GB
+// of pods on a 33 GB node, and it shipped as "verified · high confidence".
+//
+// The detector below is ADVISORY ONLY: it never rewrites the query. RunLore hands the
+// model guidance and lets it choose (see metricsQLGuidance in query_tools.go); the
+// note is prepended to the rendered result so the model can re-run a corrected query
+// mid-loop, with the original rows still in front of it.
+
+var (
+	// cadvisorRollupMetric matches the cadvisor metric families that carry a
+	// pod-level rollup series. container_network_* is deliberately ABSENT: those
+	// counters are reported per pod sandbox only, with no per-container series to add
+	// to, so summing them is correct and an advisory there would be a false positive.
+	cadvisorRollupMetric = regexp.MustCompile(`\bcontainer_(?:memory|cpu|fs|blkio)_[a-z0-9_]+`)
+
+	// summingAggregation matches sum/count used as PromQL AGGREGATION operators:
+	// `sum(`, `sum by (…)`, `count without (…)`. The trailing \b on the keyword keeps
+	// sum_over_time / count_over_time / count_values out — they aggregate within a
+	// single series, so they cannot fold the rollup into a total. max/min/avg/topk are
+	// excluded by construction: `max by (namespace,pod) (…)` is the shape to prefer.
+	summingAggregation = regexp.MustCompile(`\b(?:sum|count)\b\s*(?:\(|by\b|without\b)`)
+
+	// aggregationByContainer matches a `by (…container…)` grouping, which keeps the
+	// rollup in an output series of its own instead of folding it into the pod's
+	// total — so such a query does not double-count. `without (container)` is the
+	// opposite (it merges the rollup in) and is deliberately not matched.
+	aggregationByContainer = regexp.MustCompile(`\bby\b\s*\([^)]*\bcontainer\b[^)]*\)`)
+
+	// containerMatcher matches any label matcher that constrains `container`
+	// (container!="", container="dev", container=~"…"), which is what makes a
+	// selector unambiguous about the rollup.
+	containerMatcher = regexp.MustCompile(`\bcontainer\b\s*(?:=~|!~|!=|=)`)
+)
+
+// cadvisorRollupNote is the advisory prepended to a metrics tool result whose query
+// would double-count. It names the concrete fix and a falsification step, because
+// the failure mode is a confidently wrong number rather than an error: an inflated
+// total looks plausible until it is compared with the node's real capacity.
+const cadvisorRollupNote = `warning: possible DOUBLE-COUNT in this query. cadvisor exports every cgroup metric twice per pod — once per container, and again as a pod-level rollup series carrying container="" — so sum()/count() over container_memory_*/container_cpu_*/container_fs_*/container_blkio_* counts each pod twice (a real 17.1 GB pod reads as 32.5 GB, and a node's pods can appear to exceed its physical memory).
+fix: add container!="" to the selector, or aggregate with max by (namespace,pod) (…) instead of sum. Before reporting any total, cross-check it against real capacity — node_memory_MemTotal_bytes, or kube_node_status_capacity{resource="memory"} — a pod total above capacity means the rollup is still in the sum.
+The rows below are the UNCHANGED result of the query as written, so they may be inflated.`
+
+// cadvisorRollupAdvisory returns cadvisorRollupNote when query sums cadvisor series
+// across a pod's containers without excluding the pod-level rollup, and "" when it
+// does not. It is a deliberately conservative regex check, not a PromQL parser: an
+// advisory on every metrics call would train the model to ignore it, so ambiguous
+// shapes stay silent (false negatives are preferred over false positives).
+//
+// The name deliberately does NOT end in "Warning": that suffix is reserved for the
+// operator-facing STARTUP guards whose message must reach log.Warn from exactly one
+// call site, a property internal/app/warnings_wired_test.go enforces by scanning for
+// the suffix. This is a per-tool-call advisory to the MODEL, raised from both metrics
+// tools and never logged, so it is a different shape — do not rename it back.
+func cadvisorRollupAdvisory(query string) string {
+	if query == "" {
+		return ""
+	}
+	// Mask string-literal contents first so only real syntax is matched:
+	// {agg="sum"} is not an aggregation, and {__name__="container_memory_…"} is not a
+	// selector this detector can reason about.
+	q := maskStringLiterals(query)
+	if !summingAggregation.MatchString(q) || aggregationByContainer.MatchString(q) {
+		return ""
+	}
+	for _, m := range cadvisorRollupMetric.FindAllStringIndex(q, -1) {
+		if !selectorConstrainsContainer(q, m[1]) {
+			return cadvisorRollupNote
+		}
+	}
+	return ""
+}
+
+// selectorConstrainsContainer reports whether the label matcher block starting at
+// from (the end of a metric name) constrains the container label. A metric with no
+// braces at all — `sum(container_memory_working_set_bytes)` — constrains nothing and
+// so returns false.
+func selectorConstrainsContainer(q string, from int) bool {
+	rest := strings.TrimLeft(q[from:], " \t\n")
+	if !strings.HasPrefix(rest, "{") {
+		return false
+	}
+	end := strings.IndexByte(rest, '}')
+	if end < 0 {
+		return false
+	}
+	return containerMatcher.MatchString(rest[1:end])
+}
+
+// maskStringLiterals blanks the CONTENTS of every PromQL string literal (double,
+// single or back quoted) while preserving the query's byte length, so offsets taken
+// from the masked copy still line up with the original query.
+func maskStringLiterals(q string) string {
+	out := []byte(q)
+	i := 0
+	for i < len(out) {
+		quote := out[i]
+		if quote != '"' && quote != '\'' && quote != '`' {
+			i++
+			continue
+		}
+		i++ // step past the opening quote
+		for i < len(out) && out[i] != quote {
+			// PromQL escapes with a backslash inside "" and '' (but not inside ``), so an
+			// escaped quote must not be mistaken for the terminator.
+			if out[i] == '\\' && quote != '`' && i+1 < len(out) {
+				out[i] = ' '
+				i++
+			}
+			out[i] = ' '
+			i++
+		}
+		i++ // step past the closing quote (or past the end of an unterminated literal)
+	}
+	return string(out)
+}

--- a/internal/investigate/cadvisor_rollup.go
+++ b/internal/investigate/cadvisor_rollup.go
@@ -2,10 +2,7 @@
 
 package investigate
 
-import (
-	"regexp"
-	"strings"
-)
+import "regexp"
 
 // cadvisor exports every cgroup-accounted metric TWICE per pod: once per container,
 // and again as a pod-level rollup series carrying container="". Any aggregation that
@@ -21,11 +18,23 @@ import (
 // mid-loop, with the original rows still in front of it.
 
 var (
-	// cadvisorRollupMetric matches the cadvisor metric families that carry a
-	// pod-level rollup series. container_network_* is deliberately ABSENT: those
-	// counters are reported per pod sandbox only, with no per-container series to add
-	// to, so summing them is correct and an advisory there would be a false positive.
-	cadvisorRollupMetric = regexp.MustCompile(`\bcontainer_(?:memory|cpu|fs|blkio)_[a-z0-9_]+`)
+	// cadvisorRollupMetric matches a cadvisor metric family that carries a pod-level
+	// rollup series, together with the label matcher block that follows it (capture
+	// group 2, empty when the metric is written bare).
+	//
+	// container_network_* is deliberately ABSENT: those counters are reported per pod
+	// sandbox only, with no per-container series to add to, so summing them is correct
+	// and an advisory there would be a false positive.
+	//
+	// The leading (?:^|[^\w:]) rejects RECORDING RULE names, and the (:?) capture
+	// rejects them from the other side. A plain \b would match inside
+	// node_namespace_pod_container:container_memory_working_set_bytes:sum_irate,
+	// because ':' is a word boundary — and since a recording rule can never carry a
+	// {container!=""} matcher on the raw family, that would be a permanent false
+	// positive on a metric name most stock dashboards use. Recording rules are
+	// pre-aggregated by whoever defined them, so this detector cannot judge them.
+	cadvisorRollupMetric = regexp.MustCompile(
+		`(?:^|[^\w:])container_(?:memory|cpu|fs|blkio|spec)_[a-z0-9_]+(:?)\s*(\{[^}]*\})?`)
 
 	// summingAggregation matches sum/count used as PromQL AGGREGATION operators:
 	// `sum(`, `sum by (…)`, `count without (…)`. The trailing \b on the keyword keeps
@@ -38,19 +47,43 @@ var (
 	// rollup in an output series of its own instead of folding it into the pod's
 	// total — so such a query does not double-count. `without (container)` is the
 	// opposite (it merges the rollup in) and is deliberately not matched.
+	//
+	// This check is query-WIDE, not per-aggregation: one `by (container)` anywhere
+	// silences the whole query, even for a second term that genuinely double-counts.
+	// Scoping it to the aggregation that encloses each metric needs a real parser, and
+	// erring toward silence is the direction this detector deliberately errs in.
 	aggregationByContainer = regexp.MustCompile(`\bby\b\s*\([^)]*\bcontainer\b[^)]*\)`)
 
-	// containerMatcher matches any label matcher that constrains `container`
-	// (container!="", container="dev", container=~"…"), which is what makes a
-	// selector unambiguous about the rollup.
-	containerMatcher = regexp.MustCompile(`\bcontainer\b\s*(?:=~|!~|!=|=)`)
+	// collapsingByPod matches a max/min/avg aggregation grouped per pod. Such an
+	// aggregation collapses {container, pause, rollup} to ONE value per pod BEFORE any
+	// outer sum sees them, so `sum(max by (namespace,pod) (…))` — the very shape
+	// cadvisorRollupNote tells the model to switch to — does not double-count.
+	// Warning on the recommended fix is the fastest way to teach the model to ignore
+	// the advisory, so it is suppressed. The trailing \b on each keyword keeps
+	// max_over_time/avg_over_time out: those collapse over TIME within one series and
+	// leave the rollup series intact, so an outer sum still double-counts.
+	//
+	// Like aggregationByContainer this is query-WIDE; see the note there.
+	collapsingByPod = regexp.MustCompile(`\b(?:max|min|avg)\b\s*by\b\s*\([^)]*\bpod\b[^)]*\)`)
+
+	// rollupLabelMatcher matches one label matcher that can make a selector
+	// unambiguous about the rollup, capturing its operator (1) and quoted value (2).
+	// Three labels qualify, and all three are in real-world use:
+	//   container — container!="", container="dev", container=~"…"
+	//   image     — image!="" is what kube-prometheus's kubelet recording rules use
+	//   name      — name=~".+" is the cadvisor-dashboard equivalent
+	// The rollup series carries all three empty, so constraining any one of them is a
+	// deliberate statement about it. Matching only `container` reported the other two
+	// canonical idioms as unguarded.
+	rollupLabelMatcher = regexp.MustCompile(
+		`\b(?:container|image|name)\b\s*(=~|!~|!=|=)\s*("[^"]*"|'[^']*'|` + "`[^`]*`" + `)`)
 )
 
 // cadvisorRollupNote is the advisory prepended to a metrics tool result whose query
 // would double-count. It names the concrete fix and a falsification step, because
 // the failure mode is a confidently wrong number rather than an error: an inflated
 // total looks plausible until it is compared with the node's real capacity.
-const cadvisorRollupNote = `warning: possible DOUBLE-COUNT in this query. cadvisor exports every cgroup metric twice per pod — once per container, and again as a pod-level rollup series carrying container="" — so sum()/count() over container_memory_*/container_cpu_*/container_fs_*/container_blkio_* counts each pod twice (a real 17.1 GB pod reads as 32.5 GB, and a node's pods can appear to exceed its physical memory).
+const cadvisorRollupNote = `warning: possible DOUBLE-COUNT in this query. cadvisor exports every cgroup metric twice per pod — once per container, and again as a pod-level rollup series carrying container="" — so sum()/count() over container_memory_*/container_cpu_*/container_fs_*/container_blkio_*/container_spec_* counts each pod twice (a real 17.1 GB pod reads as 32.5 GB, and a node's pods can appear to exceed its physical memory).
 fix: add container!="" to the selector, or aggregate with max by (namespace,pod) (…) instead of sum. Before reporting any total, cross-check it against real capacity — node_memory_MemTotal_bytes, or kube_node_status_capacity{resource="memory"} — a pod total above capacity means the rollup is still in the sum.
 The rows below are the UNCHANGED result of the query as written, so they may be inflated.`
 
@@ -66,48 +99,65 @@ The rows below are the UNCHANGED result of the query as written, so they may be 
 // the suffix. This is a per-tool-call advisory to the MODEL, raised from both metrics
 // tools and never logged, so it is a different shape — do not rename it back.
 func cadvisorRollupAdvisory(query string) string {
-	if query == "" {
+	// Blank comments and string-literal contents first so only real syntax is matched:
+	// {agg="sum"} is not an aggregation, `# not a sum(x)` is not one either, and
+	// {__name__="container_memory_…"} is not a selector this detector can reason about.
+	q := maskLiteralsAndComments(query)
+	if !summingAggregation.MatchString(q) ||
+		aggregationByContainer.MatchString(q) ||
+		collapsingByPod.MatchString(q) {
 		return ""
 	}
-	// Mask string-literal contents first so only real syntax is matched:
-	// {agg="sum"} is not an aggregation, and {__name__="container_memory_…"} is not a
-	// selector this detector can reason about.
-	q := maskStringLiterals(query)
-	if !summingAggregation.MatchString(q) || aggregationByContainer.MatchString(q) {
-		return ""
-	}
-	for _, m := range cadvisorRollupMetric.FindAllStringIndex(q, -1) {
-		if !selectorConstrainsContainer(q, m[1]) {
+	for _, m := range cadvisorRollupMetric.FindAllStringSubmatch(q, -1) {
+		// m[1] is ":" when the family name is really the head of a recording rule
+		// name; m[2] is the selector, "" for a bare metric — which constrains nothing.
+		if m[1] == ":" {
+			continue
+		}
+		if !selectorExcludesRollup(m[2]) {
 			return cadvisorRollupNote
 		}
 	}
 	return ""
 }
 
-// selectorConstrainsContainer reports whether the label matcher block starting at
-// from (the end of a metric name) constrains the container label. A metric with no
-// braces at all — `sum(container_memory_working_set_bytes)` — constrains nothing and
-// so returns false.
-func selectorConstrainsContainer(q string, from int) bool {
-	rest := strings.TrimLeft(q[from:], " \t\n")
-	if !strings.HasPrefix(rest, "{") {
-		return false
+// selectorExcludesRollup reports whether a label matcher block is explicit about the
+// container="" pod rollup — either excluding it or selecting it alone. An empty
+// selector (a bare metric) constrains nothing and so returns false.
+func selectorExcludesRollup(selector string) bool {
+	for _, m := range rollupLabelMatcher.FindAllStringSubmatch(selector, -1) {
+		// container!="POD" — the legacy cAdvisor idiom for dropping the pause
+		// container — is NOT a guard: it keeps the container="" rollup, so it
+		// double-counts exactly like an unguarded selector. Only a NEGATIVE match
+		// against a non-empty value behaves this way; container!="" excludes the
+		// rollup and container="dev" selects one container. Literal contents are
+		// masked to spaces but their LENGTH is preserved, so `""` (2 bytes with its
+		// quotes) is still distinguishable here from `"POD"`.
+		if m[1] == "!=" && len(m[2]) > 2 {
+			continue
+		}
+		return true
 	}
-	end := strings.IndexByte(rest, '}')
-	if end < 0 {
-		return false
-	}
-	return containerMatcher.MatchString(rest[1:end])
+	return false
 }
 
-// maskStringLiterals blanks the CONTENTS of every PromQL string literal (double,
-// single or back quoted) while preserving the query's byte length, so offsets taken
-// from the masked copy still line up with the original query.
-func maskStringLiterals(q string) string {
+// maskLiteralsAndComments blanks the CONTENTS of every PromQL string literal (double,
+// single or back quoted) and every `#` comment, in one left-to-right pass so that each
+// construct is only recognised outside the other: a '#' inside {pod="a#b"} does not
+// start a comment, and an apostrophe inside `# it's the rollup` does not open a
+// literal that swallows the rest of the query.
+func maskLiteralsAndComments(q string) string {
 	out := []byte(q)
 	i := 0
 	for i < len(out) {
 		quote := out[i]
+		if quote == '#' {
+			for i < len(out) && out[i] != '\n' {
+				out[i] = ' '
+				i++
+			}
+			continue
+		}
 		if quote != '"' && quote != '\'' && quote != '`' {
 			i++
 			continue

--- a/internal/investigate/cadvisor_rollup_test.go
+++ b/internal/investigate/cadvisor_rollup_test.go
@@ -47,6 +47,51 @@ func TestCadvisorRollupWarning(t *testing.T) {
 		{"sum inside a label value is not an aggregation", `max by (pod) (container_memory_working_set_bytes{agg="sum"})`, false},
 		{"metric named only inside a string literal", `sum({__name__="container_memory_working_set_bytes"})`, false},
 		{"unrelated metric", `sum(kube_pod_status_phase)`, false},
+
+		// container_spec_* carries the same pod-level rollup, and "total limits on this
+		// node" is exactly the capacity cross-check the advisory itself recommends.
+		{"spec family rolls up as well", `sum(container_spec_memory_limit_bytes)`, true},
+		{"guarded spec family", `sum(container_spec_memory_limit_bytes{container!=""})`, false},
+
+		// image!="" is kube-prometheus's kubelet-rule idiom for dropping the rollup and
+		// name=~".+" the cadvisor-dashboard one; the rollup carries all three labels
+		// empty, so constraining any of them is a deliberate statement about it.
+		{"image!='' excludes the rollup too", `sum(container_memory_working_set_bytes{image!="",node="n1"})`, false},
+		{"name matcher excludes the rollup too", `sum(container_memory_working_set_bytes{name=~".+"})`, false},
+
+		// A recording rule is pre-aggregated by whoever defined it and can never carry a
+		// matcher on the raw family, so matching inside its name is a permanent false
+		// positive. ':' is a word boundary, so \b alone does not exclude either side.
+		{"family name inside a recording rule name", `sum(node_namespace_pod_container:container_memory_working_set_bytes:sum_irate)`, false},
+		{"family name heading a recording rule name", `sum(container_memory_working_set_bytes:sum_irate)`, false},
+
+		// Comments are masked in the same pass as literals, so neither construct can be
+		// recognised inside the other.
+		{"apostrophe in a comment must not blank the query", "# it's the rollup\nsum(container_memory_working_set_bytes{node=\"n1\"})", true},
+		{"by (container) in a comment is not a grouping", `sum(container_memory_working_set_bytes{node="n1"}) # by (container)`, true},
+		{"sum( in a comment is not an aggregation", `max by (pod) (container_memory_working_set_bytes) # not a sum(x)`, false},
+		{"# inside a label value is not a comment", `sum(container_memory_working_set_bytes{pod="a#b"})`, true},
+
+		// The selector is attached to its metric across whitespace, and an unterminated
+		// brace constrains nothing.
+		{"space between metric and selector", `sum(container_memory_working_set_bytes {container!=""})`, false},
+		{"unterminated selector constrains nothing", `sum(container_memory_working_set_bytes{node="n1"`, true},
+
+		// max/min/avg grouped per pod collapses {container, pause, rollup} to one value
+		// per pod BEFORE the outer sum, so this is the corrected shape the advisory
+		// itself recommends — warning on it would train the model to ignore the advisory.
+		{"sum over a per-pod max does not double-count", `sum(max by (namespace,pod) (container_memory_working_set_bytes{node="n1"}))`, false},
+		{"sum by node over a per-pod max", `sum by (node) (max by (namespace,pod,node) (container_memory_working_set_bytes))`, false},
+		{"cadvisor metric never summed at all", `sum(node_memory_MemTotal_bytes) - max by (pod) (container_memory_working_set_bytes)`, false},
+		// max_over_time collapses over TIME within one series and leaves the rollup
+		// series intact, so the outer sum still double-counts.
+		{"max_over_time is not a per-pod collapse", `sum(max_over_time(container_memory_working_set_bytes[1h]))`, true},
+
+		// container!="POD" is the legacy cAdvisor idiom for dropping the pause container.
+		// It KEEPS the container="" rollup, so it double-counts like an unguarded query.
+		{"container!='POD' still admits the rollup", `sum(container_memory_working_set_bytes{container!="POD"})`, true},
+		{"POD exclusion plus a real guard", `sum(container_memory_working_set_bytes{container!="POD",container!=""})`, false},
+		{"negative image match is not a guard", `sum(container_memory_working_set_bytes{image!="pause"})`, true},
 		{"empty query", ``, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/investigate/cadvisor_rollup_test.go
+++ b/internal/investigate/cadvisor_rollup_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// cadvisor exports every cgroup-accounted metric twice per pod: once per container
+// and once more as a pod-level rollup carrying container="". Summing without
+// excluding the rollup double-counts the pod. Observed live: a 17.1 GB workspace
+// pod reported as 32.48 GB (17100390400 + 229376 pause + 15384018944 rollup), and
+// the same query over a whole node returning 50.2 GB of pods on a 33 GB node.
+func TestCadvisorRollupWarning(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  bool
+	}{
+		{"sum of working set, no container matcher", `sum(container_memory_working_set_bytes{node="n1"})`, true},
+		{"sum by pod, no container matcher", `sum by (pod) (container_memory_working_set_bytes{node="n1"})`, true},
+		{"bare metric, no selector at all", `sum by(namespace,pod) (container_memory_working_set_bytes)`, true},
+		{"count double-counts too", `count(container_memory_usage_bytes)`, true},
+		{"sum of cpu rate", `sum(rate(container_cpu_usage_seconds_total[5m]))`, true},
+		{"sum of fs usage", `sum(container_fs_usage_bytes{namespace="ns"})`, true},
+		{"blkio family rolls up as well", `sum(container_blkio_device_usage_total)`, true},
+		{"without(container) drops the guard label, still double-counts", `sum without (container) (container_memory_rss)`, true},
+		{"only the second selector is guarded", `sum(container_memory_working_set_bytes{container!=""}) / sum(container_memory_usage_bytes)`, true},
+
+		{"guarded with container!=''", `sum(container_memory_working_set_bytes{container!=""})`, false},
+		{"pinned to one container", `sum(container_memory_working_set_bytes{container="dev"})`, false},
+		{"regex container matcher", `sum(container_memory_working_set_bytes{container=~"dev|cache"})`, false},
+		{"guarded cpu rate", `sum(rate(container_cpu_usage_seconds_total{container!=""}[5m]))`, false},
+		{"max is not a summing aggregation", `max by (pod) (container_memory_working_set_bytes)`, false},
+		{"avg is not a summing aggregation", `avg by (pod) (container_memory_working_set_bytes)`, false},
+		{"the recommended shape", `topk(5, max by (namespace,pod) (container_memory_working_set_bytes{node="n1",container!=""}))`, false},
+		{"grouping by container keeps the rollup in its own series", `sum by (namespace,pod,container) (container_memory_working_set_bytes)`, false},
+		{"sum_over_time aggregates over time, not over series", `sum_over_time(container_memory_working_set_bytes[5m])`, false},
+		{"network metrics are pod-level only", `sum(container_network_receive_bytes_total)`, false},
+		{"network rate is pod-level only", `sum by (pod) (rate(container_network_transmit_bytes_total[5m]))`, false},
+		{"no selector, no aggregation", `container_memory_working_set_bytes{pod="p"}`, false},
+		{"sum inside a label value is not an aggregation", `max by (pod) (container_memory_working_set_bytes{agg="sum"})`, false},
+		{"metric named only inside a string literal", `sum({__name__="container_memory_working_set_bytes"})`, false},
+		{"unrelated metric", `sum(kube_pod_status_phase)`, false},
+		{"empty query", ``, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cadvisorRollupAdvisory(tc.query) != ""
+			if got != tc.want {
+				t.Fatalf("cadvisorRollupAdvisory(%q) warned=%v, want %v", tc.query, got, tc.want)
+			}
+		})
+	}
+}
+
+// The warning is only useful if it names the concrete fix and a way to falsify the
+// number, so an inflated total can't be shipped as a verdict.
+func TestCadvisorRollupWarningNamesFixAndCrossCheck(t *testing.T) {
+	w := cadvisorRollupAdvisory(`sum by (pod) (container_memory_working_set_bytes{node="n1"})`)
+	for _, want := range []string{`container!=""`, "node_memory_MemTotal_bytes", "kube_node_status_capacity"} {
+		if !strings.Contains(w, want) {
+			t.Fatalf("warning must mention %q, got:\n%s", want, w)
+		}
+	}
+}
+
+// The warning has to reach the model, so it is prepended to the rendered result
+// rather than logged — an advisory the investigation can act on mid-loop.
+func TestQueryMetricsToolWarnsOnRollupDoubleCount(t *testing.T) {
+	tool := QueryMetricsTool{Metrics: fakeMetrics{samples: providers.Samples{
+		{Metric: map[string]string{"__name__": "container_memory_working_set_bytes", "pod": "p"}, Value: 32484638720},
+	}}}
+	out, err := tool.Call(context.Background(), `{"query":"sum by (pod) (container_memory_working_set_bytes{node=\"n1\"})"}`)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if !strings.Contains(out, `container!=""`) {
+		t.Fatalf("expected a double-count warning naming the fix, got:\n%s", out)
+	}
+	if !strings.Contains(out, "container_memory_working_set_bytes{pod=\"p\"}") {
+		t.Fatalf("warning must not replace the result rows, got:\n%s", out)
+	}
+}
+
+// A guarded query must stay clean: a spurious advisory on every metrics call would
+// train the model to ignore it.
+func TestQueryMetricsToolNoWarningWhenGuarded(t *testing.T) {
+	tool := QueryMetricsTool{Metrics: fakeMetrics{samples: providers.Samples{
+		{Metric: map[string]string{"__name__": "container_memory_working_set_bytes", "pod": "p"}, Value: 17100390400},
+	}}}
+	out, err := tool.Call(context.Background(), `{"query":"max by (pod) (container_memory_working_set_bytes{container!=\"\"})"}`)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if strings.Contains(out, "double-count") {
+		t.Fatalf("guarded query must not be warned about, got:\n%s", out)
+	}
+}
+
+// The range tool runs the same PromQL against the same backend, so it double-counts
+// identically — and it is the tool an investigation uses to establish a peak.
+func TestQueryMetricsRangeToolWarnsOnRollupDoubleCount(t *testing.T) {
+	fm := &fakeRangeMetrics{matrix: providers.Matrix{{
+		Metric: map[string]string{"__name__": "container_memory_working_set_bytes", "pod": "p"},
+		Points: []providers.Point{
+			{Time: time.Unix(1700000000, 0).UTC(), Value: 17100390400},
+			{Time: time.Unix(1700000060, 0).UTC(), Value: 32484638720},
+		},
+	}}}
+	tool := QueryMetricsRangeTool{Metrics: fm}
+	out, err := tool.Call(context.Background(), `{"query":"sum by (pod) (container_memory_working_set_bytes{node=\"n1\"})","since_minutes":30,"step_seconds":60}`)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if !strings.Contains(out, `container!=""`) {
+		t.Fatalf("expected a double-count warning naming the fix, got:\n%s", out)
+	}
+	if !strings.Contains(out, "first=1.71003904e+10") {
+		t.Fatalf("warning must not replace the trend rows, got:\n%s", out)
+	}
+}

--- a/internal/investigate/query_tools.go
+++ b/internal/investigate/query_tools.go
@@ -119,6 +119,12 @@ func (t QueryMetricsTool) Call(ctx context.Context, args string) (string, error)
 		return math.Abs(samples[i].Value) > math.Abs(samples[j].Value)
 	})
 	var b strings.Builder
+	// Advisory FIRST, so it survives the row cap and is read before the numbers it
+	// calls into question. Additive: the rows below are untouched and the query is
+	// never rewritten. See cadvisor_rollup.go.
+	if w := cadvisorRollupAdvisory(in.Query); w != "" {
+		b.WriteString(w + "\n")
+	}
 	renderRows(&b, len(samples), "more series", func(i int) {
 		fmt.Fprintf(&b, "%s = %g\n", formatMetric(samples[i].Metric), samples[i].Value)
 	})
@@ -185,6 +191,12 @@ func (t QueryMetricsRangeTool) Call(ctx context.Context, args string) (string, e
 		return noSeriesMatched, nil
 	}
 	var b strings.Builder
+	// Same advisory as the instant tool: a range query over an unguarded cadvisor
+	// selector double-counts identically, and this is the tool an investigation uses
+	// to establish a peak. See cadvisor_rollup.go.
+	if w := cadvisorRollupAdvisory(in.Query); w != "" {
+		b.WriteString(w + "\n")
+	}
 	if clampNote != "" {
 		b.WriteString(clampNote + "\n")
 	}

--- a/internal/investigate/query_tools.go
+++ b/internal/investigate/query_tools.go
@@ -56,6 +56,27 @@ func renderRows(b *strings.Builder, n int, noun string, row func(i int)) {
 	}
 }
 
+// exampleAggregation and exampleCadvisorAggregation are the two query shapes
+// seriesCapGuidance recommends. They are constants rather than prose so that
+// TestQueryMetricsDescriptionSteersAggregation can feed them straight back through
+// cadvisorRollupAdvisory: a description that steers the model into the very shape the
+// advisory then warns about would teach it to ignore advisories.
+const (
+	exampleAggregation         = `topk(10, sum by(pod)(rate(http_requests_total[5m])))`
+	exampleCadvisorAggregation = `topk(10, sum by(pod)(container_memory_working_set_bytes{container!=""}))`
+)
+
+// seriesCapGuidance is the closing sentence shared by both metrics tool Descriptions:
+// aggregate rather than send a raw selector, because the 50-series cap would otherwise
+// hide the signal — and, on the cadvisor container_* families, exclude the pod rollup
+// while aggregating. `sum by(pod)` is right for an ordinary counter and stays the
+// headline advice; the second clause is the cadvisor-only correction, so the guidance
+// is neither wrong for the common case nor self-contradictory for cadvisor.
+const seriesCapGuidance = "Results cap at 50 series (largest |value| kept); aggregate instead of sending a raw selector, " +
+	"so the cap can't hide the signal — e.g. " + exampleAggregation + ". " +
+	`On cadvisor container_* metrics also exclude the container="" pod rollup, or the sum counts each pod twice: ` +
+	exampleCadvisorAggregation + "."
+
 // metricsQLGuidance is the MetricsQL sentence appended to the query_metrics /
 // query_metrics_range Descriptions ONLY when the backend flavor is VictoriaMetrics.
 // MetricsQL is a PromQL superset, so these helpers would be invalid against real
@@ -84,7 +105,7 @@ func (t QueryMetricsTool) Name() string { return "query_metrics" }
 
 // Description returns the tool description.
 func (t QueryMetricsTool) Description() string {
-	d := "Run a PromQL instant query against the metrics backend (VictoriaMetrics/Prometheus) — check saturation, error rates, restarts, resource usage. This returns the value NOW only; to see when a metric started rising/spiking around the incident, use query_metrics_range instead. Results cap at 50 series (largest |value| kept); prefer topk(10, sum by(pod)(rate(...))) over a raw selector so the cap doesn't hide the signal."
+	d := "Run a PromQL instant query against the metrics backend (VictoriaMetrics/Prometheus) — check saturation, error rates, restarts, resource usage. This returns the value NOW only; to see when a metric started rising/spiking around the incident, use query_metrics_range instead. " + seriesCapGuidance
 	if t.MetricsQL {
 		d += metricsQLGuidance
 	}
@@ -159,7 +180,7 @@ func (t QueryMetricsRangeTool) Name() string { return "query_metrics_range" }
 
 // Description returns the tool description.
 func (t QueryMetricsRangeTool) Description() string {
-	d := "Run a PromQL RANGE query over a recent window (default 60m, 60s step) to see how a metric TRENDS — rising, spiking, or recovering around the incident — not just its value right now. Use rate()/error-rate/saturation expressions; returns per-series first→last with min/max, a compact downsampled trend, and the biggest adjacent jump so you can tell WHEN a problem started and whether it was a step-change or a ramp. since_minutes bounds the window; step_seconds the resolution (auto-derived/coarsened if it would exceed the backend point cap). Results cap at 50 series (largest |value| kept); prefer topk(10, sum by(pod)(rate(...))) over a raw selector so the cap doesn't hide the signal."
+	d := "Run a PromQL RANGE query over a recent window (default 60m, 60s step) to see how a metric TRENDS — rising, spiking, or recovering around the incident — not just its value right now. Use rate()/error-rate/saturation expressions; returns per-series first→last with min/max, a compact downsampled trend, and the biggest adjacent jump so you can tell WHEN a problem started and whether it was a step-change or a ramp. since_minutes bounds the window; step_seconds the resolution (auto-derived/coarsened if it would exceed the backend point cap). " + seriesCapGuidance
 	if t.MetricsQL {
 		d += metricsQLGuidance
 	}

--- a/internal/investigate/query_tools_test.go
+++ b/internal/investigate/query_tools_test.go
@@ -399,14 +399,45 @@ func TestQueryMetricsToolTruncateKeepsExtremes(t *testing.T) {
 	}
 }
 
+// TestQueryMetricsDescriptionSteersAggregation pins the PROPERTY, not the wording:
+// both metrics tools tell the model to aggregate rather than send a raw selector
+// (naming the 50-series cap that motivates it), and every query shape they recommend
+// is one cadvisorRollupAdvisory stays SILENT on. The two used to contradict each
+// other — the description recommended `sum by(pod)` on a bare selector, which is
+// exactly the double-counting shape the advisory then warned about — and an advisory
+// that fires on the shape the tool description recommends teaches the model to ignore
+// advisories. Deriving the shapes from the description's own constants is what makes
+// that contradiction impossible to reintroduce silently.
 func TestQueryMetricsDescriptionSteersAggregation(t *testing.T) {
 	for _, d := range []string{QueryMetricsTool{}.Description(), QueryMetricsRangeTool{}.Description()} {
-		if !strings.Contains(d, "topk") {
-			t.Fatalf("description must steer toward topk aggregation:\n%s", d)
+		if !strings.Contains(d, seriesCapGuidance) {
+			t.Fatalf("description must carry the shared series-cap guidance:\n%s", d)
 		}
 		if !strings.Contains(d, "50") {
 			t.Fatalf("description must mention the 50-series cap:\n%s", d)
 		}
+		if !strings.Contains(d, "topk") {
+			t.Fatalf("description must steer toward topk aggregation:\n%s", d)
+		}
+	}
+	for _, q := range []string{exampleAggregation, exampleCadvisorAggregation} {
+		if !strings.Contains(seriesCapGuidance, q) {
+			t.Fatalf("guidance must actually show the shape under test: %s", q)
+		}
+		if w := cadvisorRollupAdvisory(q); w != "" {
+			t.Fatalf("recommended shape %s trips the rollup advisory:\n%s", q, w)
+		}
+	}
+	// Guard the guard. The cadvisor example's silence must mean "this selector
+	// excludes the rollup", not "the advisory never looks at queries like this" —
+	// otherwise the check above would pass for a shape that still double-counts.
+	// Strip the rollup guard and the same query must trip it.
+	unguarded := strings.ReplaceAll(exampleCadvisorAggregation, `{container!=""}`, "")
+	if unguarded == exampleCadvisorAggregation {
+		t.Fatalf("cadvisor example no longer carries the container!=\"\" guard: %s", exampleCadvisorAggregation)
+	}
+	if cadvisorRollupAdvisory(unguarded) == "" {
+		t.Fatalf("vacuous check: the advisory is silent on the UNGUARDED cadvisor example too: %s", unguarded)
 	}
 }
 


### PR DESCRIPTION
cadvisor exports every cgroup-accounted metric twice per pod: once per container, and again as a pod-level rollup carrying `container=""`. A query that sums without excluding the rollup counts each pod twice.

Measured live on one workspace pod:

```
container="dev"  17,100,390,400
pause                   229,376
pod rollup       15,384,018,944
                 ──────────────
                 32,484,638,720
```

— exactly the "32.48 GB" a verdict card reported for a pod whose real peak was **17.1 GB**. The same unguarded shape over a whole node returned 50.2 GB of pods on a 33 GB node, and it shipped as *"verified, high confidence"*.

`query_metrics` and `query_metrics_range` now inspect the query and prepend an advisory when it would double-count, naming the fix (`container!=""`) and a falsification step (cross-check against `node_memory_MemTotal_bytes` or `kube_node_status_capacity`). **The query is never rewritten** — RunLore hands the model guidance and lets it choose, as `metricsQLGuidance` already does — and the result rows are unchanged, so the advisory is purely additive.

### The detector is deliberately conservative

A regex check, not a PromQL parser: an advisory on every metrics call would train the model to ignore it. It stays silent for `container_network_*` (pod-level only, summing is correct), for `max`/`min`/`avg`/`topk`, for `by (…container…)` groupings, for `sum_over_time`, and for any selector already constraining `container`.

Review of that detector found five shapes it judged wrongly, all now pinned in the case matrix:

| Shape | Was | Why it mattered |
|---|---|---|
| `sum(max by (namespace,pod) (…))` | warned | The per-pod `max` collapses `{container, pause, rollup}` **before** the outer sum — it is the exact shape the advisory recommends, so the advisory warned about its own fix |
| `image!=""`, `name=~".+"` | warned | The other two canonical rollup exclusions (kube-prometheus's kubelet rules, the cadvisor dashboards) — only `container` counted as a guard |
| recording-rule names | warned | `:` is a word boundary, so `\b` matched inside `node_namespace_pod_container:…:sum_irate`. A recording rule can never carry a matcher on the raw family — a permanent false positive |
| `#` comments | misparsed | A comment containing `sum(` read as an aggregation; an apostrophe in a comment opened a "literal" that blanked the rest of the query. Comments are now masked in the same pass as literals |
| `container!="POD"` | counted as a guard | The legacy cAdvisor idiom drops only the pause container and **keeps** the `container=""` rollup |

`container_spec_*` was a false negative too — it carries the same rollup, and "total limits on this node" is precisely the capacity cross-check the advisory recommends.

Left alone deliberately, and recorded in the comment: `aggregationByContainer` stays query-**wide**, so one `by (container)` anywhere silences an unrelated term that does double-count. Scoping it per-aggregation needs a real parser, and erring toward silence is the direction this detector is documented to err in.

### The tool descriptions were steering the model into the trap

Both tools told the model to *"prefer `topk(10, sum by(pod)(rate(...)))`"* — on a cadvisor `container_*` family that is exactly the shape this branch's own advisory warns about. The system steered the model into the trap and then warned it for arriving there, and an advisory that fires on the shape the tool description recommends teaches the model to ignore advisories.

The closing sentence is now a shared `seriesCapGuidance` constant keeping `sum by(pod)` as the headline advice (correct for an ordinary counter), with a second clause for the cadvisor-only correction. Both recommended shapes are constants, so `TestQueryMetricsDescriptionSteersAggregation` feeds them straight back through `cadvisorRollupAdvisory` and asserts silence — pinning the coherence property rather than literal wording. The test also strips the `container!=""` guard off the cadvisor example and requires the advisory to fire, so its silence cannot be vacuous.

Gate: `build` · `vet` · `go test ./... -race` · `gofmt -l .` silent · `golangci-lint run ./...` **0 issues**.
