### PR TITLE
fix(investigate): match a cloud resource by identity, not by spelling

### DIFF
--- a/internal/curator/draft.go
+++ b/internal/curator/draft.go
@@ -138,9 +138,12 @@ func alertResourceIfDistinct(inv providers.Investigation) string {
 }
 
 // normalizeResource renders the affected workload as its canonical namespace/name
-// ref with the volatile pod-hash suffix stripped from the NAME segment only (via
-// the curator-local normalizeWorkloadName → providers.NormalizeWorkloadName, the
-// single source of truth for CORE-681).
+// ref with the NAME segment only reduced to its resource identity (via the
+// curator-local normalizeResourceName → providers.NormalizeResourceName): the
+// volatile pod-hash suffix stripped, and an AWS ARN collapsed to the identifier its
+// CloudWatch dimension carries, so a model that echoes back the full ARN from the
+// seed prompt does not file an entry under a second spelling of a resource the
+// catalog already holds.
 //
 // WHY: a pod-scoped alert (KubePodNotReady carries only a `pod` label) resolves to
 // the FULL pod name INCLUDING the ReplicaSet/pod-hash suffix, e.g.
@@ -155,7 +158,7 @@ func alertResourceIfDistinct(inv providers.Investigation) string {
 //
 // It reuses Workload.Ref(), so the namespace is never touched and the empty /
 // bare-namespace cases pass through unchanged; w is a value copy, so mutating its
-// Name is local. Idempotent (NormalizeWorkloadName is).
+// Name is local. Idempotent (NormalizeResourceName is).
 //
 // The Ref() is then narrowed by kbvalidate.DraftResource → providers.EntryResourceRef, because
 // Workload.Name on a curated finding is MODEL-WRITTEN free text and a
@@ -165,7 +168,7 @@ func alertResourceIfDistinct(inv providers.Investigation) string {
 // exact source; only the value the model happened to produce differed, so fixing
 // one path and not the other would leave the same defect armed here.
 func normalizeResource(w providers.Workload) string {
-	w.Name = normalizeWorkloadName(w.Name)
+	w.Name = normalizeResourceName(w.Name)
 	ref, _ := kbvalidate.DraftResource(w.Ref())
 	return ref
 }

--- a/internal/curator/fingerprint.go
+++ b/internal/curator/fingerprint.go
@@ -38,13 +38,20 @@ func normalizeText(s string) string {
 	return strings.Join(strings.Fields(s), " ")
 }
 
-// normalizeWorkloadName strips a trailing pod-name hash so a per-pod name reduces to
-// its controller family. The implementation is shared with the instant-recall
-// structural gate — it lives in providers.NormalizeWorkloadName (the single source
-// of truth, see CORE-681) so the dedup and recall paths can never drift. This thin
-// alias keeps the curator's internal call sites (and their tests) unchanged.
+// normalizeWorkloadName reduces a resource name to the identity the curator's keys
+// group by: an AWS ARN collapses to the resource identifier its CloudWatch dimension
+// carries, and a trailing pod-name hash is stripped so a per-pod name reduces to its
+// controller family. The implementation is shared with the instant-recall structural
+// gate — it lives in providers (the single source of truth, see CORE-681) so the
+// dedup and recall paths can never drift. This thin alias keeps the curator's
+// internal call sites (and their tests) unchanged.
+//
+// The ARN collapse is what lets one recurring cloud resource key alike when the
+// alert spells it two ways; providers.NormalizeResourceName documents the accepted
+// consequence (the account and region are dropped) and why the fields the callers
+// wrap around this name make it safe here.
 func normalizeWorkloadName(name string) string {
-	return providers.NormalizeWorkloadName(name)
+	return providers.NormalizeResourceName(name)
 }
 
 // IncidentKey builds a host-invariant, per-class dedup key for an alert: the alert

--- a/internal/curator/fingerprint.go
+++ b/internal/curator/fingerprint.go
@@ -60,13 +60,41 @@ func normalizeResourceName(name string) string {
 // stripped. The same alert on a different pod/node yields the same key (so it
 // dedupes to one KB entry), while a different cluster stays distinct. Returned as
 // the alert TriggerKey and folded into DupFingerprint. "" when there is no signal.
-func IncidentKey(alertname, namespace, kind, name, cluster string) string {
+//
+// The AWS account is a segment of its own, appended only when the workload carries
+// one. It is what separates two accounts that agree on every other field — a
+// CloudWatch-derived rule authors `namespace` as the exporter's, one Prometheus
+// stamps one `cluster` label across every account it scrapes, and kind is empty for
+// a cloud resource, so "datagrok" in two accounts was ONE key. Via the recurrence
+// ledger that key decides suppression, so the collision could drop a genuine
+// incident in one account on another account's conclusion.
+//
+// APPENDED-WHEN-PRESENT, not always: a Kubernetes workload has no account, and
+// emitting an empty segment for it would change every K8s key's bytes for nothing.
+// Omitting it keeps them byte-identical, and no key is ambiguous — a key with the
+// account has six segments, one without has five.
+//
+// It reads the workload's Account FIELD and never an account embedded in an
+// ARN-spelled Name, because a map key is compared by equality and must therefore be
+// spelling-invariant: ingestion (providers.ResolveWorkloadIdentity) fills the field
+// on BOTH the ARN and the short-name path, so the two spellings of one resource
+// still key alike, which is the split this key already exists to close.
+//
+// ONE-OFF MIGRATION: a cloud resource's key gains a segment, so it no longer matches
+// the key the same resource was persisted under in outcome.Ledger's byTrigger index.
+// Its recurrence count restarts from zero once, on the first firing after the
+// upgrade; the old bucket is simply never looked up again. Kubernetes keys are
+// byte-identical (they have no account segment) and are unaffected.
+func IncidentKey(alertname string, w providers.Workload, cluster string) string {
 	parts := []string{
 		strings.TrimSpace(alertname),
-		strings.TrimSpace(namespace),
-		strings.TrimSpace(kind),
-		normalizeResourceName(strings.TrimSpace(name)),
+		strings.TrimSpace(w.Namespace),
+		strings.TrimSpace(w.Kind),
+		normalizeResourceName(strings.TrimSpace(w.Name)),
 		strings.TrimSpace(cluster),
+	}
+	if account := strings.TrimSpace(w.Account); account != "" {
+		parts = append(parts, account)
 	}
 	for _, p := range parts {
 		if p != "" {
@@ -145,6 +173,16 @@ func DupFingerprint(inv providers.Investigation) string {
 	res := inv.Resource
 	res.Name = normalizeResourceName(res.Name)
 	ref := strings.ToLower(res.Ref())
+	// The AWS account qualifies the ref, so one instance name in two accounts does not
+	// curate as one incident. Appended only when present, so a Kubernetes ref — and
+	// therefore its fingerprint — is byte-identical to what it was. Like IncidentKey
+	// this reads the Account FIELD and not an account embedded in an ARN-spelled name:
+	// inv.Resource is MODEL-WRITTEN free text (submit_findings), so a model that echoes
+	// the full ARN back from the seed prompt must still fingerprint as the same
+	// incident as one that writes the short name.
+	if account := strings.TrimSpace(res.Account); account != "" && ref != "" {
+		ref += "@" + strings.ToLower(account)
+	}
 	if tk := strings.ToLower(strings.TrimSpace(inv.TriggerKey)); tk != "" {
 		// "trigger:" namespaces the key so a trigger value can never collide with a
 		// prose causeKey from the fallback path below.

--- a/internal/curator/fingerprint.go
+++ b/internal/curator/fingerprint.go
@@ -38,19 +38,20 @@ func normalizeText(s string) string {
 	return strings.Join(strings.Fields(s), " ")
 }
 
-// normalizeWorkloadName reduces a resource name to the identity the curator's keys
-// group by: an AWS ARN collapses to the resource identifier its CloudWatch dimension
+// normalizeResourceName reduces a resource name to the identity the curator groups
+// by: an AWS ARN collapses to the resource identifier its CloudWatch dimension
 // carries, and a trailing pod-name hash is stripped so a per-pod name reduces to its
-// controller family. The implementation is shared with the instant-recall structural
-// gate — it lives in providers (the single source of truth, see CORE-681) so the
-// dedup and recall paths can never drift. This thin alias keeps the curator's
-// internal call sites (and their tests) unchanged.
+// controller family. It is a thin alias for providers.NormalizeResourceName, the
+// single source of truth shared with the instant-recall path (CORE-681) so the two
+// can never drift.
 //
-// The ARN collapse is what lets one recurring cloud resource key alike when the
-// alert spells it two ways; providers.NormalizeResourceName documents the accepted
-// consequence (the account and region are dropped) and why the fields the callers
-// wrap around this name make it safe here.
-func normalizeWorkloadName(name string) string {
+// It is deliberately NOT named normalizeWorkloadName any more: providers still
+// exports a NormalizeWorkloadName that does only the pod-hash half, and a local alias
+// wearing that exact name would read as a pass-through to it while meaning something
+// wider. Read providers.NormalizeResourceName for the accepted consequence of the ARN
+// collapse — the account and region are dropped, and the surrounding key fields do
+// not reliably put them back.
+func normalizeResourceName(name string) string {
 	return providers.NormalizeResourceName(name)
 }
 
@@ -64,7 +65,7 @@ func IncidentKey(alertname, namespace, kind, name, cluster string) string {
 		strings.TrimSpace(alertname),
 		strings.TrimSpace(namespace),
 		strings.TrimSpace(kind),
-		normalizeWorkloadName(strings.TrimSpace(name)),
+		normalizeResourceName(strings.TrimSpace(name)),
 		strings.TrimSpace(cluster),
 	}
 	for _, p := range parts {
@@ -91,7 +92,7 @@ func Fingerprint(inv providers.Investigation) string {
 	}
 	if len(inv.Changes) > 0 {
 		w := inv.Changes[0].Workload
-		b.WriteString(" " + w.Namespace + " " + normalizeWorkloadName(w.Name))
+		b.WriteString(" " + w.Namespace + " " + normalizeResourceName(w.Name))
 	}
 	return strings.TrimSpace(b.String())
 }
@@ -142,7 +143,7 @@ func DupFingerprint(inv providers.Investigation) string {
 	// incident on a different pod/node keys alike (CORE-681). The TriggerKey is
 	// already a host-invariant per-class key for alert sources (see IncidentKey).
 	res := inv.Resource
-	res.Name = normalizeWorkloadName(res.Name)
+	res.Name = normalizeResourceName(res.Name)
 	ref := strings.ToLower(res.Ref())
 	if tk := strings.ToLower(strings.TrimSpace(inv.TriggerKey)); tk != "" {
 		// "trigger:" namespaces the key so a trigger value can never collide with a

--- a/internal/curator/fingerprint_test.go
+++ b/internal/curator/fingerprint_test.go
@@ -218,19 +218,24 @@ func TestNormalizeTextMasksVolatile(t *testing.T) {
 	}
 }
 
+// pod builds the observability/Pod workload the per-class key cases share.
+func pod(name string) providers.Workload {
+	return providers.Workload{Kind: "Pod", Namespace: "observability", Name: name}
+}
+
 func TestIncidentKeyPerClassKeepsCluster(t *testing.T) {
-	k1 := IncidentKey("KubePodNotReady", "observability", "Pod", "node-exporter-prometheus-node-exporter-km6ld", "shared")
-	k2 := IncidentKey("KubePodNotReady", "observability", "Pod", "node-exporter-prometheus-node-exporter-n5zld", "shared")
+	k1 := IncidentKey("KubePodNotReady", pod("node-exporter-prometheus-node-exporter-km6ld"), "shared")
+	k2 := IncidentKey("KubePodNotReady", pod("node-exporter-prometheus-node-exporter-n5zld"), "shared")
 	if k1 == "" || k1 != k2 {
 		t.Fatalf("same alert on different pods must share a key: %q vs %q", k1, k2)
 	}
-	if IncidentKey("KubePodNotReady", "observability", "Pod", "node-exporter-prometheus-node-exporter-km6ld", "dev-0") == k1 {
+	if IncidentKey("KubePodNotReady", pod("node-exporter-prometheus-node-exporter-km6ld"), "dev-0") == k1 {
 		t.Fatal("different cluster must change the key")
 	}
-	if IncidentKey("KubeDaemonSetRolloutStuck", "observability", "Pod", "node-exporter-prometheus-node-exporter-km6ld", "shared") == k1 {
+	if IncidentKey("KubeDaemonSetRolloutStuck", pod("node-exporter-prometheus-node-exporter-km6ld"), "shared") == k1 {
 		t.Fatal("different alertname must change the key")
 	}
-	if IncidentKey("", "", "", "", "") != "" {
+	if IncidentKey("", providers.Workload{}, "") != "" {
 		t.Fatal("no signal must yield an empty key")
 	}
 }
@@ -241,11 +246,11 @@ func TestIncidentKeyPerClassKeepsCluster(t *testing.T) {
 func TestDupFingerprintStableAcrossPodSuffix(t *testing.T) {
 	a := providers.Investigation{
 		Resource:   providers.Workload{Kind: "Pod", Namespace: "observability", Name: "node-exporter-prometheus-node-exporter-km6ld"},
-		TriggerKey: IncidentKey("KubePodNotReady", "observability", "Pod", "node-exporter-prometheus-node-exporter-km6ld", "shared"),
+		TriggerKey: IncidentKey("KubePodNotReady", pod("node-exporter-prometheus-node-exporter-km6ld"), "shared"),
 	}
 	b := providers.Investigation{
 		Resource:   providers.Workload{Kind: "Pod", Namespace: "observability", Name: "node-exporter-prometheus-node-exporter-n5zld"},
-		TriggerKey: IncidentKey("KubePodNotReady", "observability", "Pod", "node-exporter-prometheus-node-exporter-n5zld", "shared"),
+		TriggerKey: IncidentKey("KubePodNotReady", pod("node-exporter-prometheus-node-exporter-n5zld"), "shared"),
 	}
 	fa, fb := DupFingerprint(a), DupFingerprint(b)
 	if fa == "" || fa != fb {

--- a/internal/curator/fingerprint_test.go
+++ b/internal/curator/fingerprint_test.go
@@ -187,7 +187,7 @@ func TestDupFingerprintDiffersByTriggerKey(t *testing.T) {
 	}
 }
 
-func TestNormalizeWorkloadName(t *testing.T) {
+func TestNormalizeResourceNameAlias(t *testing.T) {
 	cases := map[string]string{
 		"node-exporter-prometheus-node-exporter-km6ld": "node-exporter-prometheus-node-exporter", // DaemonSet pod hash
 		"node-exporter-prometheus-node-exporter-n5zld": "node-exporter-prometheus-node-exporter", // different pod, same family
@@ -198,8 +198,8 @@ func TestNormalizeWorkloadName(t *testing.T) {
 		"":                                             "",
 	}
 	for in, want := range cases {
-		if got := normalizeWorkloadName(in); got != want {
-			t.Errorf("normalizeWorkloadName(%q) = %q, want %q", in, got, want)
+		if got := normalizeResourceName(in); got != want {
+			t.Errorf("normalizeResourceName(%q) = %q, want %q", in, got, want)
 		}
 	}
 }

--- a/internal/curator/resource_identity_test.go
+++ b/internal/curator/resource_identity_test.go
@@ -13,6 +13,14 @@ const (
 	rdsARN       = "arn:aws:rds:us-east-1:142655614335:db:" + rdsShortName
 )
 
+// rds builds the observability-scoped cloud workload the key cases share: no kind
+// (a cloud resource is not a Kubernetes object), and the account as its own field —
+// which is where ingestion puts it, having read it from the alert labels and from an
+// ARN-spelled name alike (providers.ResolveWorkloadIdentity).
+func rds(name, account string) providers.Workload {
+	return providers.Workload{Namespace: "observability", Name: name, Account: account}
+}
+
 // TestIncidentKeyCollapsesTheTwoSpellingsOfOneResource is the recurrence half of the
 // 2026-08-17/18 split. One RDS instance fired at 21:18Z identified by its
 // DBInstanceIdentifier dimension and again at 03:53Z identified by its full ARN. The
@@ -20,8 +28,8 @@ const (
 // string equality, so the two firings landed in two buckets: one recurring fault
 // read as two unrelated first sightings, and the suppression gate never armed.
 func TestIncidentKeyCollapsesTheTwoSpellingsOfOneResource(t *testing.T) {
-	short := IncidentKey("RDSHighCPU", "observability", "", rdsShortName, "aqemia-shared")
-	arn := IncidentKey("RDSHighCPU", "observability", "", rdsARN, "aqemia-shared")
+	short := IncidentKey("RDSHighCPU", rds(rdsShortName, ""), "aqemia-shared")
+	arn := IncidentKey("RDSHighCPU", rds(rdsARN, ""), "aqemia-shared")
 	if short == "" {
 		t.Fatal("IncidentKey returned no key for a well-formed alert")
 	}
@@ -29,11 +37,11 @@ func TestIncidentKeyCollapsesTheTwoSpellingsOfOneResource(t *testing.T) {
 		t.Fatalf("the two spellings of one RDS instance produced two trigger keys:\n short: %q\n arn:   %q", short, arn)
 	}
 	// The key must still separate genuinely different resources.
-	if other := IncidentKey("RDSHighCPU", "observability", "", "compute-stages", "aqemia-shared"); other == short {
+	if other := IncidentKey("RDSHighCPU", rds("compute-stages", ""), "aqemia-shared"); other == short {
 		t.Fatal("two different DB instances collapsed to the same trigger key")
 	}
 	// …and everything else the key already qualified on stays qualifying.
-	if other := IncidentKey("RDSHighCPU", "observability", "", rdsARN, "aqemia-dev"); other == short {
+	if other := IncidentKey("RDSHighCPU", rds(rdsARN, ""), "aqemia-dev"); other == short {
 		t.Fatal("the cluster stopped qualifying the trigger key")
 	}
 }
@@ -55,5 +63,82 @@ func TestDupFingerprintCollapsesTheTwoSpellingsOfOneResource(t *testing.T) {
 	}
 	if short != arn {
 		t.Fatalf("the two spellings of one RDS instance produced two dup fingerprints:\n short: %q\n arn:   %q", short, arn)
+	}
+}
+
+// TestIncidentKeySplitsTwoAWSAccounts is the collision this change closes. Two AWS
+// accounts scraped by one exporter through one Prometheus agree on every other field
+// the key is built from — the alertname is the rule's, the namespace is the
+// EXPORTER's, the kind is empty for a cloud resource, and the `cluster` external
+// label is stamped once per Prometheus across every account it watches — so one
+// instance name in two accounts was ONE key. That key is the recurrence ledger's
+// grouping key, so inside a cooldown the second account's genuine incident was
+// suppressed on the first account's conclusion: no model call, no notification, no
+// ledger entry.
+func TestIncidentKeySplitsTwoAWSAccounts(t *testing.T) {
+	a := IncidentKey("RDSHighCPU", rds("datagrok", "111111111111"), "aqemia-shared")
+	b := IncidentKey("RDSHighCPU", rds("datagrok", "222222222222"), "aqemia-shared")
+	if a == "" {
+		t.Fatal("IncidentKey returned no key for a well-formed cloud alert")
+	}
+	if a == b {
+		t.Fatalf("two AWS accounts hosting an instance named \"datagrok\" share one trigger key %q", a)
+	}
+	// The account qualifies; it does not replace. One account still fuses with itself
+	// however the name was spelled, because the key reads the Account FIELD and not an
+	// account embedded in the name — ingestion has already reconciled the two.
+	arn := IncidentKey("RDSHighCPU", rds(rdsARN, "111111111111"), "aqemia-shared")
+	short := IncidentKey("RDSHighCPU", rds(rdsShortName, "111111111111"), "aqemia-shared")
+	if arn != short {
+		t.Fatalf("the two spellings of one instance in one account produced two keys:\n arn:   %q\n short: %q", arn, short)
+	}
+}
+
+// TestIncidentKeyForKubernetesIsByteIdentical is the regression this change is most
+// likely to cause, so the expected bytes are written out literally: a Kubernetes
+// object has no AWS account, must not grow a key segment, and must key exactly as it
+// did before the account existed. Persisted recurrence counts for every Kubernetes
+// alert depend on it.
+func TestIncidentKeyForKubernetesIsByteIdentical(t *testing.T) {
+	cases := []struct {
+		w    providers.Workload
+		want string
+	}{
+		{providers.Workload{Kind: "Pod", Namespace: "observability", Name: "node-exporter-prometheus-node-exporter-km6ld"},
+			"kubepodnotready|observability|pod|node-exporter-prometheus-node-exporter|shared"},
+		{providers.Workload{Kind: "Deployment", Namespace: "apps", Name: "payment-api"},
+			"kubepodnotready|apps|deployment|payment-api|shared"},
+		{providers.Workload{Namespace: "apps"},
+			"kubepodnotready|apps|||shared"},
+	}
+	for _, c := range cases {
+		if got := IncidentKey("KubePodNotReady", c.w, "shared"); got != c.want {
+			t.Errorf("IncidentKey(%+v):\n got  %q\n want %q", c.w, got, c.want)
+		}
+	}
+}
+
+// TestDupFingerprintSplitsTwoAWSAccounts pins the same split on the curation side:
+// without it, two accounts' incidents coalesce into ONE knowledge-base pull request
+// describing whichever account was investigated first.
+func TestDupFingerprintSplitsTwoAWSAccounts(t *testing.T) {
+	inv := func(account string) providers.Investigation {
+		return providers.Investigation{
+			Title:      "RDSHighCPU",
+			Resource:   rds("datagrok", account),
+			RootCauses: []providers.Hypothesis{{Summary: "connection pool exhausted by the nightly backfill"}},
+		}
+	}
+	a, b := DupFingerprint(inv("111111111111")), DupFingerprint(inv("222222222222"))
+	if a == "" {
+		t.Fatal("DupFingerprint returned no fingerprint for a well-formed finding")
+	}
+	if a == b {
+		t.Fatal("two AWS accounts hosting the same instance name share one dup fingerprint")
+	}
+	// A workload with no account is fingerprinted exactly as it was.
+	unqualified := DupFingerprint(inv(""))
+	if unqualified == a || unqualified == b {
+		t.Fatal("an unqualified finding collided with a qualified one")
 	}
 }

--- a/internal/curator/resource_identity_test.go
+++ b/internal/curator/resource_identity_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package curator
+
+import (
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+const (
+	rdsShortName = "datagrok-aqemia-shared"
+	rdsARN       = "arn:aws:rds:us-east-1:142655614335:db:" + rdsShortName
+)
+
+// TestIncidentKeyCollapsesTheTwoSpellingsOfOneResource is the recurrence half of the
+// 2026-08-17/18 split. One RDS instance fired at 21:18Z identified by its
+// DBInstanceIdentifier dimension and again at 03:53Z identified by its full ARN. The
+// TriggerKey this builds is the recurrence ledger's grouping key and is compared by
+// string equality, so the two firings landed in two buckets: one recurring fault
+// read as two unrelated first sightings, and the suppression gate never armed.
+func TestIncidentKeyCollapsesTheTwoSpellingsOfOneResource(t *testing.T) {
+	short := IncidentKey("RDSHighCPU", "observability", "", rdsShortName, "aqemia-shared")
+	arn := IncidentKey("RDSHighCPU", "observability", "", rdsARN, "aqemia-shared")
+	if short == "" {
+		t.Fatal("IncidentKey returned no key for a well-formed alert")
+	}
+	if short != arn {
+		t.Fatalf("the two spellings of one RDS instance produced two trigger keys:\n short: %q\n arn:   %q", short, arn)
+	}
+	// The key must still separate genuinely different resources.
+	if other := IncidentKey("RDSHighCPU", "observability", "", "compute-stages", "aqemia-shared"); other == short {
+		t.Fatal("two different DB instances collapsed to the same trigger key")
+	}
+	// …and everything else the key already qualified on stays qualifying.
+	if other := IncidentKey("RDSHighCPU", "observability", "", rdsARN, "aqemia-dev"); other == short {
+		t.Fatal("the cluster stopped qualifying the trigger key")
+	}
+}
+
+// TestDupFingerprintCollapsesTheTwoSpellingsOfOneResource pins the same collapse on
+// the curation side: without it the ARN firing opens a SECOND knowledge-base pull
+// request for a resource the catalog already has an entry for.
+func TestDupFingerprintCollapsesTheTwoSpellingsOfOneResource(t *testing.T) {
+	inv := func(name string) providers.Investigation {
+		return providers.Investigation{
+			Title:      "RDSHighCPU",
+			Resource:   providers.Workload{Namespace: "observability", Name: name},
+			RootCauses: []providers.Hypothesis{{Summary: "connection pool exhausted by the nightly backfill"}},
+		}
+	}
+	short, arn := DupFingerprint(inv(rdsShortName)), DupFingerprint(inv(rdsARN))
+	if short == "" {
+		t.Fatal("DupFingerprint returned no fingerprint for a well-formed finding")
+	}
+	if short != arn {
+		t.Fatalf("the two spellings of one RDS instance produced two dup fingerprints:\n short: %q\n arn:   %q", short, arn)
+	}
+}

--- a/internal/investigate/kbsearch_tool.go
+++ b/internal/investigate/kbsearch_tool.go
@@ -126,9 +126,12 @@ func (t KBSearchTool) withEnrichment(s string) KBSearchTool {
 // identifies the incident (namespace/name) lives only in the labels, so the model's
 // symptom-text kb_search re-suffers the vocabulary mismatch recall already measured
 // and solved (0.096 BM25 vs a perfect runbook → rank #1 once the ref is folded in;
-// see buildRecallQuery). The name is normalized (pod-hash stripped) so a per-pod
-// alert reaches the controller-family runbook; empty parts are dropped so the suffix
-// never carries stray whitespace. It is ADDITIVE — appended to the model's own
+// see buildRecallQuery). The name is normalized to its resource identity — pod-hash
+// stripped so a per-pod alert reaches the controller-family runbook, ARN collapsed so
+// the two spellings of one cloud resource query alike — by the same
+// providers.NormalizeResourceName buildRecallQuery uses, because this expansion and
+// that one must never disagree about what names a resource; empty parts are dropped
+// so the suffix never carries stray whitespace. It is ADDITIVE — appended to the model's own
 // query, never replacing it — so a query that already names the workload is at worst
 // neutral.
 func kbSearchEnrichment(req Request) string {
@@ -139,7 +142,7 @@ func kbSearchEnrichment(req Request) string {
 		}
 	}
 	add(req.Workload.Namespace)
-	add(providers.NormalizeWorkloadName(req.Workload.Name))
+	add(providers.NormalizeResourceName(req.Workload.Name))
 	add(req.Labels["alertname"])
 	return strings.Join(parts, " ")
 }

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -638,7 +638,7 @@ func resourceAgrees(reqW providers.Workload, entryResource string, requireWorklo
 	if entryResource == "" || reqW.Namespace == "" {
 		return matchNone
 	}
-	if refsAgree(reqW.Ref(), entryResource) {
+	if refsAgree(reqW, entryResource) {
 		return matchExact
 	}
 	if requireWorkload {
@@ -673,20 +673,27 @@ func resourceAgrees(reqW providers.Workload, entryResource string, requireWorklo
 //     ("observability/arn:aws:rds:…:db:compute-stages" beside short names).
 //     Canonicalising new alerts at ingestion cannot reach those already-written
 //     entries, so the gate itself compares names as cloud resource identities (see
-//     providers.ResourceID). Note what that does NOT buy: ingestion has already
-//     stripped the ARN off the request side, so the alert is unqualified and agrees
-//     with an entry's ARN in ANY account. The account/region check separates two
-//     QUALIFIED values only — it is what keeps two legacy ARN-form entries apart, not
-//     a guarantee that this gate is account-safe. See providers.NormalizeResourceName
-//     for the exposure that buys the collapse.
+//     providers.ResourceID).
+//
+// What is forgiven is the SPELLING, never the SCOPE. The request is compared as
+// providers.Workload.ResourceID — the name resolved as a cloud identifier, qualified
+// by the account and region ingestion stamped on the workload — so an alert from one
+// AWS account no longer agrees with a catalog entry still filed under a full ARN in
+// another. That comparison only became possible when the account stopped being
+// carried inside the name: ingestion reduces the name to its bare identifier, so
+// before it had a field of its own the request side was ALWAYS unqualified here and
+// the qualifier check was vacuous for alert traffic. An absent qualifier still means
+// unknown rather than different, so an alert that carries no account (every
+// Kubernetes workload, and any stack whose rules omit the label) matches exactly as
+// it did.
 //
 // Only the NAME half is normalized, never the namespace: the ref is cut on the FIRST
 // "/" and Kubernetes namespaces never contain one, so a slash-style ARN in the name
 // half survives whole. Both sides must be scoped the same way — a bare namespace and
 // a named workload inside it are not an exact match; the caller decides that pair on
 // its weaker namespace tier.
-func refsAgree(a, b string) bool {
-	ans, aname, aScoped := strings.Cut(a, "/")
+func refsAgree(reqW providers.Workload, b string) bool {
+	ans, _, aScoped := strings.Cut(reqW.Ref(), "/")
 	bns, bname, bScoped := strings.Cut(b, "/")
 	if ans != bns || aScoped != bScoped {
 		return false
@@ -698,7 +705,9 @@ func refsAgree(a, b string) bool {
 		// get wrong.
 		return true
 	}
-	return providers.ParseResourceID(aname).Agrees(providers.ParseResourceID(bname))
+	// The request's name half is not re-cut out of the ref: reqW.ResourceID already
+	// holds it, resolved and qualified, and a namespace never contains a "/".
+	return reqW.ResourceID().Agrees(providers.ParseResourceID(bname))
 }
 
 func clampF(v, lo, hi float64) float64 {

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -633,18 +633,7 @@ func resourceAgrees(reqW providers.Workload, entryResource string, requireWorklo
 	if entryResource == "" || reqW.Namespace == "" {
 		return matchNone
 	}
-	// Strip the volatile pod-hash suffix off the NAME segment on BOTH sides before
-	// the structural comparison. A pod-scoped alert (KubePodNotReady carries only a
-	// `pod` label — no deployment/workload label) arrives with the full pod name,
-	// e.g. tooling/harbor-registry-59598dbd57-ltkzw, while the KB entry stores the
-	// normalized controller family tooling/harbor-registry. Without normalization the
-	// two never agree → the recall is rejected (no_resource_match) and a full paid
-	// investigation runs despite a perfect KB entry (live-found). Normalizing BOTH
-	// sides also matches an entry written before the curator-side CORE-681 fix, which
-	// may itself still carry a pod hash. Only the name is normalized — never the
-	// namespace — and the normalization is the same idempotent one the dedup path
-	// uses, so two distinct workloads never collapse together.
-	if normalizeResourceRef(reqW.Ref()) == normalizeResourceRef(entryResource) {
+	if refsAgree(reqW.Ref(), entryResource) {
 		return matchExact
 	}
 	if requireWorkload {
@@ -661,18 +650,42 @@ func resourceAgrees(reqW providers.Workload, entryResource string, requireWorklo
 	return matchNone
 }
 
-// normalizeResourceRef strips the volatile pod-hash suffix from the NAME segment of
-// a "namespace/name" resource ref, leaving a bare "namespace" (or "") untouched. It
-// splits on the first "/" only — Kubernetes namespaces and names never contain a
-// slash — so the namespace is never normalized, only the name. It delegates to the
-// shared providers.NormalizeWorkloadName so the recall gate and the curator dedup
-// path strip identically (and idempotently).
-func normalizeResourceRef(ref string) string {
-	ns, name, ok := strings.Cut(ref, "/")
-	if !ok {
-		return ref // bare namespace (or empty): no name segment to normalize
+// refsAgree reports whether two rendered "namespace/name" resource refs name the
+// same resource. Every way one resource can be SPELLED two ways is forgiven here,
+// because each of them otherwise costs a full paid investigation beside a catalog
+// that already holds the answer:
+//
+//   - The volatile pod-hash suffix. A pod-scoped alert (KubePodNotReady carries only
+//     a `pod` label — no deployment/workload label) arrives with the full pod name,
+//     e.g. tooling/harbor-registry-59598dbd57-ltkzw, while the KB entry stores the
+//     controller family tooling/harbor-registry. Normalizing BOTH sides also matches
+//     an entry written before the curator-side CORE-681 fix, which may itself still
+//     carry a hash.
+//   - The two spellings of a cloud resource, which is what this replaced a plain
+//     string comparison for. A CloudWatch alert identifies one RDS instance by its
+//     DBInstanceIdentifier dimension on one firing and by its full ARN on the next,
+//     and the live catalog holds entries in both forms
+//     ("observability/arn:aws:rds:…:db:compute-stages" beside short names).
+//     Canonicalising new alerts at ingestion cannot reach those already-written
+//     entries, so the gate itself compares names as cloud resource identities — which
+//     also keeps two accounts or two regions hosting the same instance name apart
+//     (see providers.ResourceID).
+//
+// Only the NAME half is normalized, never the namespace: the ref is cut on the FIRST
+// "/" and Kubernetes namespaces never contain one, so a slash-style ARN in the name
+// half survives whole. Both sides must be scoped the same way — a bare namespace and
+// a named workload inside it are not an exact match; the caller decides that pair on
+// its weaker namespace tier.
+func refsAgree(a, b string) bool {
+	ans, aname, aScoped := strings.Cut(a, "/")
+	bns, bname, bScoped := strings.Cut(b, "/")
+	if ans != bns || aScoped != bScoped {
+		return false
 	}
-	return ns + "/" + providers.NormalizeWorkloadName(name)
+	if !aScoped {
+		return true // two bare namespaces (or two empties), already found equal
+	}
+	return providers.ParseResourceID(aname).Agrees(providers.ParseResourceID(bname))
 }
 
 func clampF(v, lo, hi float64) float64 {

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -119,8 +119,13 @@ const staleFactor = 0.75
 // actually shares ("tooling", "harbor-registry"), lifting those cases from zero-hit
 // to rank #1.
 //
-// Deliberate boundaries: the name is NORMALIZED (pod-hash stripped, same function
-// as the structural gate) so a per-pod alert matches the controller-family runbook;
+// Deliberate boundaries: the name is NORMALIZED to its resource IDENTITY — the pod
+// hash stripped so a per-pod alert matches the controller-family runbook, and an ARN
+// collapsed to the identifier its CloudWatch dimension carries so the retrieval that
+// FEEDS the structural gate can no longer disagree with it about which spellings name
+// one resource. Ingestion already does the ARN half for alert-derived requests; this
+// covers the ones that never went through it (the CLI path) and keeps this query
+// builder identical to curator.Fingerprint, which normalizes the same way;
 // the alertname is appended only when it is NOT already the title, so a label alert
 // (title == alertname) is not double-counted; and the ref is additive, so the
 // GitOps-failure source — whose title already carries "Kind/Name" — is not harmed
@@ -136,7 +141,7 @@ func buildRecallQuery(req Request) string {
 	add(req.Title)
 	add(req.Message)
 	add(req.Workload.Namespace)
-	add(providers.NormalizeWorkloadName(req.Workload.Name))
+	add(providers.NormalizeResourceName(req.Workload.Name))
 	if an := req.Labels["alertname"]; an != req.Title {
 		add(an)
 	}
@@ -667,9 +672,13 @@ func resourceAgrees(reqW providers.Workload, entryResource string, requireWorklo
 //     and the live catalog holds entries in both forms
 //     ("observability/arn:aws:rds:…:db:compute-stages" beside short names).
 //     Canonicalising new alerts at ingestion cannot reach those already-written
-//     entries, so the gate itself compares names as cloud resource identities — which
-//     also keeps two accounts or two regions hosting the same instance name apart
-//     (see providers.ResourceID).
+//     entries, so the gate itself compares names as cloud resource identities (see
+//     providers.ResourceID). Note what that does NOT buy: ingestion has already
+//     stripped the ARN off the request side, so the alert is unqualified and agrees
+//     with an entry's ARN in ANY account. The account/region check separates two
+//     QUALIFIED values only — it is what keeps two legacy ARN-form entries apart, not
+//     a guarantee that this gate is account-safe. See providers.NormalizeResourceName
+//     for the exposure that buys the collapse.
 //
 // Only the NAME half is normalized, never the namespace: the ref is cut on the FIRST
 // "/" and Kubernetes namespaces never contain one, so a slash-style ARN in the name
@@ -683,7 +692,11 @@ func refsAgree(a, b string) bool {
 		return false
 	}
 	if !aScoped {
-		return true // two bare namespaces (or two empties), already found equal
+		// Two bare namespaces (or two empties): ans == bns has already decided it.
+		// Falling through would reach the same answer via two empty names, so this is
+		// an intent marker and a short-circuit, not a case the comparison below would
+		// get wrong.
+		return true
 	}
 	return providers.ParseResourceID(aname).Agrees(providers.ParseResourceID(bname))
 }

--- a/internal/investigate/redact_egress_test.go
+++ b/internal/investigate/redact_egress_test.go
@@ -114,6 +114,24 @@ var egressVerbatim = map[string]bool{
 	"Investigation.Changes.BlastRadius.Kind":      true,
 	"Investigation.Changes.BlastRadius.Name":      true,
 	"Investigation.Changes.BlastRadius.Namespace": true,
+	// Account and Region are the cloud half of that same identifier, added when
+	// resource identity stopped being a bare name: a cloud resource is keyed by the
+	// account it lives in, so two accounts' "prod-db" are no longer one resource.
+	// Same provenance and same trust level as Kind/Name/Namespace above — an AWS
+	// account id and a region code, matched on rather than read as prose — and they
+	// are listed here per occurrence for the reason the block above gives: they
+	// inherit redactionSkipTypes' Workload exemption, so without an explicit claim
+	// they would have been waved through by a type rule nobody re-examined.
+	"Investigation.Resource.Account":            true,
+	"Investigation.Resource.Region":             true,
+	"Investigation.AlertResource.Account":       true,
+	"Investigation.AlertResource.Region":        true,
+	"Investigation.Actions.Target.Account":      true,
+	"Investigation.Actions.Target.Region":       true,
+	"Investigation.Changes.Workload.Account":    true,
+	"Investigation.Changes.Workload.Region":     true,
+	"Investigation.Changes.BlastRadius.Account": true,
+	"Investigation.Changes.BlastRadius.Region":  true,
 }
 
 // TestRedactInvestigationCoversEveryReachableString is the #197 guard, rebuilt so it

--- a/internal/investigate/resource_identity_test.go
+++ b/internal/investigate/resource_identity_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"testing"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// TestResourceAgreesAcrossARNAndShortName is the second half of the 2026-08-17/18
+// split. The same RDS instance reached RunLore as "observability/datagrok-aqemia-shared"
+// on one firing and as "observability/arn:aws:rds:us-east-1:142655614335:db:datagrok-aqemia-shared"
+// on the next, and the structural recall gate compares those by string equality — so
+// a catalog entry filed under either spelling is invisible to the other. That is not
+// hypothetical: a live entry is indexed as
+// "observability/arn:aws:rds:us-east-1:195275669196:db:compute-stages" while its
+// neighbours use short names.
+//
+// Canonicalising at ingestion cannot fix it on its own — entries already written in
+// the ARN form stay written that way — so the gate itself has to be identity-aware.
+func TestResourceAgreesAcrossARNAndShortName(t *testing.T) {
+	w := func(ns, name string) providers.Workload { return providers.Workload{Namespace: ns, Name: name} }
+	const (
+		rdsARN   = "arn:aws:rds:us-east-1:142655614335:db:datagrok-aqemia-shared"
+		otherAcc = "arn:aws:rds:us-east-1:999999999999:db:datagrok-aqemia-shared"
+	)
+	cases := []struct {
+		name      string
+		reqW      providers.Workload
+		entry     string
+		requireWL bool
+		want      matchStrength
+	}{
+		{"arn-spelled alert vs short-name entry",
+			w("observability", rdsARN), "observability/datagrok-aqemia-shared", false, matchExact},
+		{"short-name alert vs arn-spelled entry (the live catalog entry)",
+			w("observability", "datagrok-aqemia-shared"), "observability/" + rdsARN, false, matchExact},
+		{"both spelled as the same arn",
+			w("observability", rdsARN), "observability/" + rdsARN, false, matchExact},
+		{"strict mode still agrees — the two spellings ARE an exact match",
+			w("observability", rdsARN), "observability/datagrok-aqemia-shared", true, matchExact},
+		{"slash-style arn vs its identifier",
+			w("observability", "arn:aws:ec2:us-east-1:142655614335:instance/i-0abc123def4567890"),
+			"observability/i-0abc123def4567890", false, matchExact},
+		// Identity, not string-collapse: the account qualifies the resource.
+		{"the same instance name in two different accounts stays two resources",
+			w("observability", rdsARN), "observability/" + otherAcc, false, matchNone},
+		{"an arn in another namespace is still another resource",
+			w("observability", rdsARN), "other/datagrok-aqemia-shared", false, matchNone},
+		// Nothing about Kubernetes matching may move.
+		{"plain kubernetes namespace/name is untouched",
+			w("apps", "payment-api"), "apps/payment-api", false, matchExact},
+		{"two distinct kubernetes workloads stay distinct",
+			w("apps", "payment-api"), "apps/web", false, matchNone},
+		{"pod-template-hash forgiveness still holds",
+			w("tooling", "harbor-registry-59598dbd57-ltkzw"), "tooling/harbor-registry", false, matchExact},
+		{"a name merely containing arn is not an arn",
+			w("apps", "arnica-exporter"), "apps/exporter", false, matchNone},
+		{"bare-namespace tiers are unchanged",
+			w("observability", rdsARN), "observability", false, matchNamespace},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := resourceAgrees(c.reqW, c.entry, c.requireWL); got != c.want {
+				t.Errorf("resourceAgrees(%+v, %q, %v) = %v, want %v", c.reqW, c.entry, c.requireWL, got, c.want)
+			}
+		})
+	}
+}
+
+// TestEntryAgreesMatchesARNOnEitherStoredResource pins that identity-awareness
+// reaches BOTH resources an entry carries — the fault locus and the resource the
+// originating alert fired on — because entryAgrees is the function the recall
+// pre-filter actually calls, and an entry whose AlertResource is the ARN form is
+// exactly the shape the live catalog holds.
+func TestEntryAgreesMatchesARNOnEitherStoredResource(t *testing.T) {
+	reqW := providers.Workload{Namespace: "observability", Name: "datagrok-aqemia-shared"}
+	e := catalog.Entry{
+		Resource:      "observability/some-other-thing",
+		AlertResource: "observability/arn:aws:rds:us-east-1:142655614335:db:datagrok-aqemia-shared",
+	}
+	if got := entryAgrees(reqW, e, false); got != matchExact {
+		t.Fatalf("entryAgrees = %v, want matchExact — the entry's AlertResource is the same DB instance spelled as an ARN", got)
+	}
+}

--- a/internal/investigate/resource_identity_test.go
+++ b/internal/investigate/resource_identity_test.go
@@ -85,3 +85,50 @@ func TestEntryAgreesMatchesARNOnEitherStoredResource(t *testing.T) {
 		t.Fatalf("entryAgrees = %v, want matchExact — the entry's AlertResource is the same DB instance spelled as an ARN", got)
 	}
 }
+
+// TestResourceAgreesUsesTheAccountThatSurvivedIngestion closes the recall half of the
+// cross-account collision. The live catalog holds an entry indexed as
+// "observability/arn:aws:rds:us-east-1:195275669196:db:compute-stages", and ingestion
+// reduces an incoming alert to the bare identifier — so the request side used to be
+// unqualified and agreed with that ARN from ANY account. Instant recall then presents
+// one account's runbook as the answer for another account's database, short-circuiting
+// the loop with no investigation at all.
+//
+// Ingestion now carries the account as its own field (providers.ResolveWorkloadIdentity),
+// so the qualifier the ARN names has something real to be compared against.
+func TestResourceAgreesUsesTheAccountThatSurvivedIngestion(t *testing.T) {
+	const (
+		theirs = "observability/arn:aws:rds:us-east-1:195275669196:db:compute-stages"
+		ours   = "195275669196"
+	)
+	w := func(account string) providers.Workload {
+		return providers.Workload{Namespace: "observability", Name: "compute-stages", Account: account}
+	}
+	cases := []struct {
+		name  string
+		reqW  providers.Workload
+		entry string
+		want  matchStrength
+	}{
+		{"another account's alert must not reach this account's entry",
+			w("999999999999"), theirs, matchNone},
+		{"the owning account still reaches it",
+			w(ours), theirs, matchExact},
+		{"an unqualified alert still reaches it — an absent qualifier is unknown, not different",
+			w(""), theirs, matchExact},
+		{"a qualified alert still reaches an unqualified entry",
+			w("999999999999"), "observability/compute-stages", matchExact},
+		{"the region qualifies too, when both sides carry one",
+			providers.Workload{Namespace: "observability", Name: "compute-stages", Region: "eu-west-1"},
+			theirs, matchNone},
+		{"a Kubernetes workload is unqualified and matches exactly as before",
+			providers.Workload{Namespace: "apps", Name: "payment-api"}, "apps/payment-api", matchExact},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := resourceAgrees(c.reqW, c.entry, false); got != c.want {
+				t.Errorf("resourceAgrees(%+v, %q) = %v, want %v", c.reqW, c.entry, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -48,11 +48,29 @@ const (
 	ChangeCloudAPI  ChangeType = "cloud-api"  // a mutating cloud control-plane call (CloudTrail)
 )
 
-// Workload identifies a Kubernetes object.
+// Workload identifies a Kubernetes object, or — when it names a cloud resource —
+// that resource plus the cloud scope it lives in.
+//
+// Account and Region are that scope. They exist because Kind/Name/Namespace do not
+// separate two AWS accounts: a CloudWatch-derived alert rule authors `namespace` as
+// a literal (the exporter's), one Prometheus stamps a single `cluster` external
+// label across every account it scrapes, and Kind is empty for a cloud resource. So
+// an RDS instance named "datagrok" in two accounts was ONE identity everywhere a key
+// is built from these fields. They are stamped at ingestion (ResolveWorkloadIdentity)
+// from the alert's account/region labels AND from an ARN-spelled name, so they are
+// present regardless of which spelling the alert used — which is what lets an
+// identity key both fuse the two spellings and split the two accounts.
+//
+// Both are EMPTY for a Kubernetes object, whose identity is namespace/name and
+// nothing else. Nothing renders them: Ref() is unchanged, so a K8s workload's ref,
+// its entry frontmatter and its keys are byte-identical to what they were before
+// these fields existed.
 type Workload struct {
 	Kind      string
 	Name      string
 	Namespace string
+	Region    string // AWS region; "" for a Kubernetes object and for an unqualified resource
+	Account   string // AWS account id; "" for a Kubernetes object and for an unqualified resource
 }
 
 // Ref renders the workload as "namespace/name", or just "namespace" when the

--- a/internal/providers/resourceid.go
+++ b/internal/providers/resourceid.go
@@ -2,7 +2,10 @@
 
 package providers
 
-import "strings"
+import (
+	"cmp"
+	"strings"
+)
 
 // arnFields is the field count of a well-formed AWS ARN:
 // arn:partition:service:region:account-id:resource. The resource field is last and
@@ -55,19 +58,22 @@ func ParseResourceID(name string) ResourceID {
 //
 // The relation is symmetric and reflexive but NOT transitive — a short name agrees
 // with two ARNs that do not agree with each other. That is why callers needing a
-// map key use NormalizeResourceName instead (see its doc for the tradeoff), and why
-// this is a predicate rather than a comparable canonical value.
+// map key cannot use it: a key is compared by equality, so it reads the account off
+// Workload.Account instead (see curator.IncidentKey).
 //
-// REACHABILITY, stated because the qualifier check reads stronger than it acts:
-// ingestion rewrites an ARN to its bare identifier (ARNResourceName) before a
-// Workload is built, so a resource name derived from an ALERT carries no qualifiers
-// and both qualifierAgrees calls are vacuously true for it. The check therefore
-// bites only where a qualified value actually survives — a model-written entry
-// resource compared against another qualified value, or a caller that never went
-// through ingestion. It does NOT make the recall gate account-safe for alert
-// traffic: an unqualified short name still agrees with an ARN in ANY account. That
-// is the behaviour the fix requires (it is how the live ARN-spelled catalog entries
-// stay reachable) and the exposure it accepts, not a guarantee this provides.
+// REACHABILITY. The qualifier check used to be vacuous for alert traffic, and is no
+// longer. Ingestion rewrites an ARN to its bare identifier before a Workload is
+// built, so a name derived from an ALERT carries no qualifiers of its own; what
+// makes the check bite is that ingestion now also LIFTS the account and region onto
+// the workload (ResolveWorkloadIdentity), and Workload.ResourceID feeds them back in
+// here. An alert from one AWS account therefore no longer agrees with a catalog
+// entry filed under a full ARN in another.
+//
+// What remains, by design: an alert that carries NO account — every Kubernetes
+// workload, and any stack whose alert rules omit the account label — is unqualified
+// and still agrees with an ARN in any account. That is required, not tolerated: it
+// is how the live ARN-spelled catalog entries stay reachable at all, and treating
+// unknown as different would silently un-index them.
 func (r ResourceID) Agrees(o ResourceID) bool {
 	return r.Name == o.Name && qualifierAgrees(r.Region, o.Region) && qualifierAgrees(r.Account, o.Account)
 }
@@ -76,11 +82,109 @@ func (r ResourceID) Agrees(o ResourceID) bool {
 // value on either side is unknown rather than different.
 func qualifierAgrees(a, b string) bool { return a == "" || b == "" || a == b }
 
+// cloudAccountLabels are the alert-label spellings an AWS account id arrives under,
+// in precedence order: `account_id` is what yace (the CloudWatch exporter this was
+// written against) stamps on every series it emits, and `aws_account_id` is the
+// cloudwatch_exporter / relabel spelling. A bare `account` is deliberately NOT read:
+// it is a plausible APPLICATION label (a customer account, a billing account) and
+// reading it would qualify a resource by something that is not a cloud scope.
+var cloudAccountLabels = []string{"account_id", "aws_account_id"}
+
+// cloudRegionLabels are the alert-label spellings an AWS region arrives under.
+var cloudRegionLabels = []string{"region", "aws_region"}
+
+// ResolveWorkloadIdentity is the ingestion-side chokepoint that turns a workload as
+// an alert SPELLED it into the identity RunLore keys and matches by: the name is
+// reduced to its bare resource identifier (an ARN loses its scaffolding), and the
+// cloud scope that identifier lives in is recorded on Account/Region.
+//
+// WHY THE SCOPE HAS TO BE LIFTED OFF THE NAME. Reducing an ARN to its identifier is
+// what makes one resource have ONE spelling downstream, and that is load-bearing: a
+// CloudWatch-derived rule templates whichever dimension it has to hand, so one RDS
+// instance arrives as "datagrok" on one firing and as
+// "arn:aws:rds:us-east-1:111111111111:db:datagrok" on the next. But the reduction
+// also DELETED the account, and the surrounding key fields do not put it back — a
+// CloudWatch rule authors `namespace` as the exporter's, one Prometheus stamps one
+// `cluster` label across every account it scrapes, and Kind is empty for a cloud
+// resource. So "datagrok" in two accounts became one identity. Recording the account
+// as its own field is what separates them WITHOUT re-splitting the two spellings,
+// because the field is filled on both paths.
+//
+// RECONCILIATION. The account and region are taken from the ARN when the name is one
+// and from the alert labels otherwise, so a value present on EITHER side survives:
+// an ARN names its account even where the rule drops the label, and a short-spelled
+// firing has only the label. Where both are present and disagree, the ARN wins — it
+// names the resource itself, while a label describes the series that observed it. A
+// value already set on w is never overwritten.
+//
+// KUBERNETES IS EXCLUDED, and that exclusion is the point of the Kind check rather
+// than an optimisation: a Kubernetes object's identity is namespace/name and nothing
+// else, so a cluster whose Prometheus stamps `account_id` as an external label must
+// not acquire a qualifier and must keep byte-identical keys. An ARN-spelled name
+// overrides the check — a name that IS an ARN is a cloud resource whatever label
+// carried it.
+//
+// KNOWN RESIDUAL: a workload that arrives on the `workload` label with no
+// `workload_type` has no Kind, so a Kubernetes object spelled that way on a stack
+// that stamps account labels globally WOULD be qualified. It is the one shape this
+// cannot tell apart — there is no signal left — and the cost is one restarted
+// recurrence count, not a wrong answer.
+func ResolveWorkloadIdentity(w Workload, labels map[string]string) Workload {
+	if w.Name == "" {
+		return w // nothing to qualify: there is no resource
+	}
+	bare, region, account, isARN := parseARN(w.Name)
+	if isARN {
+		w.Name = bare
+	} else if w.Kind != "" {
+		return w // a Kubernetes object: namespace/name is the whole identity
+	}
+	w.Region = cmp.Or(w.Region, region, labelValue(labels, cloudRegionLabels))
+	w.Account = cmp.Or(w.Account, account, labelValue(labels, cloudAccountLabels))
+	return w
+}
+
+// labelValue returns the first non-empty label among keys.
+func labelValue(labels map[string]string, keys []string) string {
+	for _, k := range keys {
+		if v := strings.TrimSpace(labels[k]); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// ResourceID is the identity this workload should be COMPARED by: its name resolved
+// as a cloud identifier, qualified by the scope the name carries or, failing that,
+// by the scope stamped on the workload at ingestion.
+//
+// It unions the two sources on purpose, and that is why it is not what the identity
+// KEYS use. A key must be spelling-invariant — an ARN-spelled and a short-spelled
+// firing of one resource must produce the same bytes — and only the Account field
+// is, because ingestion fills it on both paths while an ARN inside a name is present
+// on one. Comparison has no such constraint: ResourceID.Agrees treats an absent
+// qualifier as compatible rather than different, so reading MORE evidence can only
+// split resources that really are distinct, never fuse two that are not. That
+// asymmetry is what lets a bare alert be told apart from a catalog entry still
+// filed under a full ARN in another account.
+func (w Workload) ResourceID() ResourceID {
+	id := ParseResourceID(w.Name)
+	return ResourceID{
+		Name:    id.Name,
+		Region:  cmp.Or(id.Region, w.Region),
+		Account: cmp.Or(id.Account, w.Account),
+	}
+}
+
 // ARNResourceName reduces an AWS ARN to the resource identifier that the matching
-// CloudWatch dimension carries, and returns any other value byte-for-byte. It is
-// the ingestion-side canonicalisation: applied where a Workload name is derived
-// from alert labels, so only one spelling of a resource is ever stored in a
-// notification, a curated entry's `resource:` frontmatter, or a ledger key.
+// CloudWatch dimension carries, and returns any other value byte-for-byte. It is the
+// name half of the ingestion-side canonicalisation, so only one spelling of a
+// resource is ever stored in a notification, a curated entry's `resource:`
+// frontmatter, or a ledger key.
+//
+// Ingestion itself goes through ResolveWorkloadIdentity, which applies this AND
+// keeps the cloud scope the ARN named; call this directly only where there is no
+// workload to qualify.
 //
 // It deliberately does NOT normalize the pod-template hash. Ingestion records the
 // workload an alert actually fired on — a pod-scoped alert must keep its full pod
@@ -98,42 +202,24 @@ func ARNResourceName(name string) string {
 	return name
 }
 
-// NormalizeResourceName is the canonical single-string form of a resource name: the
-// ARN scaffolding removed, then the pod-hash suffix stripped. It is what the
-// identity keys use — curator.IncidentKey (hence the recurrence ledger's TriggerKey)
+// NormalizeResourceName is the canonical single-string form of a resource NAME: the
+// ARN scaffolding removed, then the pod-hash suffix stripped. It is the name half of
+// the identity keys — curator.IncidentKey (hence the recurrence ledger's TriggerKey)
 // and DupFingerprint — because a map key can only be compared by equality, and a
 // predicate like ResourceID.Agrees cannot be one.
 //
-// KNOWN CONSEQUENCE: collapsing to the bare identifier drops the account and region,
-// so one instance name in two AWS accounts produces ONE key. This is a real accepted
-// exposure, not a neutralised one, and it is worth stating precisely because the
-// fields wrapped around this name look like they close it and do not.
+// It deliberately yields the bare identifier and NOTHING ELSE, dropping the account
+// and region an ARN carried. That is forced: canon(ARN in account A) == canon(short)
+// == canon(ARN in account B) is exactly what fuses the two spellings of one resource,
+// and it equally forces the two accounts equal. No single canonical string can do
+// both.
 //
-// IncidentKey adds alertname, namespace, kind and cluster; DupFingerprint adds the
-// namespace and the cause. For the alert class this function exists for, none of
-// those separates two AWS accounts: a CloudWatch-derived rule authors `namespace` as
-// a literal, one scraping Prometheus stamps a single `cluster` external label across
-// every account it watches, and `kind` is empty for a cloud resource. So two accounts
-// hosting the same instance name and alerting through one stack DO share a key. Via
-// TriggerKey that key reaches outcome.Ledger's byTrigger index, and inside a
-// configured RecurrenceGate cooldown the second account's firing can be suppressed on
-// the first account's conclusion — investigate's loop then returns with no model call
-// and no notification.
-//
-// It is accepted because the collapse is FORCED rather than chosen. A map key is
-// compared by equality, and canon(ARN_A) == canon(short) == canon(ARN_B) would force
-// the two ARNs equal, so no single canonical string can both fuse the two spellings
-// of one resource and split two accounts; adding the account to the key instead
-// re-splits the ARN spelling from the short one, which is the bug being fixed. Nor
-// did the exposure arrive with this function — two SHORT-spelled alerts from two
-// accounts already collided before it existed. What changed is that the ARN spelling
-// no longer accidentally keeps them apart, in exchange for the split being closed on
-// every ARN-shaped alert rather than in a naming coincidence.
-//
-// Closing it properly needs an account discriminator the SHORT spelling also carries
-// — an alert label plumbed into the key — which is a larger change than this one.
-// The matching path uses Agrees, which keeps two QUALIFIED values apart; see its doc
-// for why that does not extend to an ingested alert either.
+// The account is therefore not recovered from the name — it travels BESIDE it, on
+// Workload.Account, stamped at ingestion from the alert labels and from an ARN alike
+// (ResolveWorkloadIdentity) so that it is present under either spelling. IncidentKey
+// appends it as a segment of its own, which is what splits two accounts without
+// re-splitting the two spellings. Read Workload's doc for why the field, and not the
+// name, is the only thing a key can honestly qualify on.
 func NormalizeResourceName(name string) string {
 	return ParseResourceID(name).Name
 }

--- a/internal/providers/resourceid.go
+++ b/internal/providers/resourceid.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package providers
+
+import "strings"
+
+// arnFields is the field count of a well-formed AWS ARN:
+// arn:partition:service:region:account-id:resource. The resource field is last and
+// may itself contain both ":" and "/", so it is never split further here.
+const arnFields = 6
+
+// ResourceID is the identity two resource names are compared by. It exists because
+// one cloud resource reaches RunLore under two different spellings: a CloudWatch
+// alert identifies an RDS instance by its DBInstanceIdentifier dimension
+// ("datagrok-aqemia-shared") on one firing and by its full ARN
+// ("arn:aws:rds:us-east-1:142655614335:db:datagrok-aqemia-shared") on the next.
+// Compared as strings those are two unrelated resources, so one recurring fault
+// looked like two first sightings and a catalog entry filed under either spelling
+// was invisible to the other.
+//
+// Name is the bare identifier both spellings share. Region and Account are the
+// ARN's qualifiers, empty for a short name and for the ARN shapes that carry
+// neither (an S3 bucket ARN is "arn:aws:s3:::my-bucket").
+type ResourceID struct {
+	Name    string // the bare resource identifier, pod-hash normalized
+	Region  string // AWS region; "" when unqualified (a short name, or a global resource)
+	Account string // AWS account id; "" when unqualified
+}
+
+// ParseResourceID resolves a resource name to the identity it should be matched by:
+// an AWS ARN yields its resource identifier plus the region and account that
+// qualify it, and any other value yields itself as the Name with no qualifiers.
+//
+// The Name is passed through NormalizeWorkloadName on BOTH paths, and that
+// symmetry is load-bearing rather than incidental: if the pod-hash strip ran on
+// short names only, a resource whose identifier happens to end in something shaped
+// like a pod hash would normalize to two different Names depending on which
+// spelling the alert used — reintroducing the very split this type exists to close.
+func ParseResourceID(name string) ResourceID {
+	id, region, account, ok := parseARN(name)
+	if !ok {
+		return ResourceID{Name: NormalizeWorkloadName(name)}
+	}
+	return ResourceID{Name: NormalizeWorkloadName(id), Region: region, Account: account}
+}
+
+// Agrees reports whether r and o name the same cloud resource.
+//
+// It is deliberately NOT equality of a canonical bare name. Two accounts (or two
+// regions) can host an instance under the same name and those are genuinely
+// different databases, so a qualifier is compared whenever BOTH sides carry it. A
+// missing qualifier is treated as "unknown, therefore compatible": that is what
+// lets the unqualified short form agree with the ARN it was extracted from, which
+// is the whole point of the type.
+//
+// The relation is symmetric and reflexive but NOT transitive — a short name agrees
+// with two ARNs that do not agree with each other. That is why callers needing a
+// map key use NormalizeResourceName instead (see its doc for the tradeoff), and why
+// this is a predicate rather than a comparable canonical value.
+func (r ResourceID) Agrees(o ResourceID) bool {
+	return r.Name == o.Name && qualifierAgrees(r.Region, o.Region) && qualifierAgrees(r.Account, o.Account)
+}
+
+// qualifierAgrees compares one ARN qualifier: equal values agree, and an absent
+// value on either side is unknown rather than different.
+func qualifierAgrees(a, b string) bool { return a == "" || b == "" || a == b }
+
+// ARNResourceName reduces an AWS ARN to the resource identifier that the matching
+// CloudWatch dimension carries, and returns any other value byte-for-byte. It is
+// the ingestion-side canonicalisation: applied where a Workload name is derived
+// from alert labels, so only one spelling of a resource is ever stored in a
+// notification, a curated entry's `resource:` frontmatter, or a ledger key.
+//
+// It deliberately does NOT normalize the pod-template hash. Ingestion records the
+// workload an alert actually fired on — a pod-scoped alert must keep its full pod
+// name, which downstream normalizes only when comparing — so this narrows the
+// contract to the one rewrite that is pure gain: dropping ARN scaffolding that
+// names nothing the short form does not already name.
+//
+// Nothing is lost by rewriting it: the full ARN still travels verbatim on the
+// request's Labels and reaches the seed prompt, so the model can still see the
+// account and region it names.
+func ARNResourceName(name string) string {
+	if id, _, _, ok := parseARN(name); ok {
+		return id
+	}
+	return name
+}
+
+// NormalizeResourceName is the canonical single-string form of a resource name: the
+// ARN scaffolding removed, then the pod-hash suffix stripped. It is what the
+// identity keys use — curator.IncidentKey (hence the recurrence ledger's TriggerKey)
+// and DupFingerprint — because a map key can only be compared by equality, and a
+// predicate like ResourceID.Agrees cannot be one.
+//
+// KNOWN CONSEQUENCE, and the reason Agrees exists beside it: collapsing to the bare
+// identifier drops the account and region, so one instance name in two AWS accounts
+// produces ONE key. That is accepted here and nowhere else. Every caller folds this
+// name into a key that is already qualified by the surrounding facts — IncidentKey
+// adds alertname, namespace, kind and cluster; DupFingerprint adds the namespace and
+// the cause — so two accounts collide only when the same alert fires on the same
+// resource name, in the same namespace, on the same cluster. The alternative is
+// strictly worse: without the collapse the SAME database recurring under two
+// spellings gets two keys, which is the bug being fixed and is guaranteed to happen
+// on every ARN-shaped alert rather than in a contrived naming coincidence. The
+// structural matching path, where a wrong collapse would apply one database's
+// runbook to another, uses Agrees and keeps the two accounts apart.
+func NormalizeResourceName(name string) string {
+	return ParseResourceID(name).Name
+}
+
+// parseARN splits an AWS ARN into its resource identifier, region and account,
+// reporting false for anything that is not one (leaving the value untouched).
+//
+// The identifier is the resource field with its leading resource-TYPE segment
+// removed, the type being everything up to the first ":" or "/" — the two
+// separators AWS uses interchangeably ("…:db:NAME" for RDS, "…:instance/NAME" for
+// EC2). What remains is exactly what the CloudWatch dimension of that resource
+// carries, including multi-segment paths: an ALB's LoadBalancer dimension really is
+// "app/my-lb/50dc6c4951", so the segments after the type are kept rather than
+// reduced to the last one.
+//
+// Validation is strict on purpose. A value only parses as an ARN with all six
+// fields present and a non-empty partition, service and resource, so ordinary names
+// that merely start with or contain "arn" ("arnica-exporter") and truncated
+// fragments ("arn:aws:rds") fall through unchanged.
+func parseARN(s string) (id, region, account string, ok bool) {
+	if !strings.HasPrefix(s, "arn:") {
+		return "", "", "", false
+	}
+	f := strings.SplitN(s, ":", arnFields)
+	if len(f) != arnFields {
+		return "", "", "", false
+	}
+	partition, service, resource := f[1], f[2], f[5]
+	if partition == "" || service == "" || resource == "" {
+		return "", "", "", false
+	}
+	region, account = f[3], f[4]
+	if i := strings.IndexAny(resource, ":/"); i >= 0 {
+		resource = resource[i+1:]
+	}
+	if resource == "" {
+		return "", "", "", false
+	}
+	return resource, region, account, true
+}

--- a/internal/providers/resourceid.go
+++ b/internal/providers/resourceid.go
@@ -57,6 +57,17 @@ func ParseResourceID(name string) ResourceID {
 // with two ARNs that do not agree with each other. That is why callers needing a
 // map key use NormalizeResourceName instead (see its doc for the tradeoff), and why
 // this is a predicate rather than a comparable canonical value.
+//
+// REACHABILITY, stated because the qualifier check reads stronger than it acts:
+// ingestion rewrites an ARN to its bare identifier (ARNResourceName) before a
+// Workload is built, so a resource name derived from an ALERT carries no qualifiers
+// and both qualifierAgrees calls are vacuously true for it. The check therefore
+// bites only where a qualified value actually survives — a model-written entry
+// resource compared against another qualified value, or a caller that never went
+// through ingestion. It does NOT make the recall gate account-safe for alert
+// traffic: an unqualified short name still agrees with an ARN in ANY account. That
+// is the behaviour the fix requires (it is how the live ARN-spelled catalog entries
+// stay reachable) and the exposure it accepts, not a guarantee this provides.
 func (r ResourceID) Agrees(o ResourceID) bool {
 	return r.Name == o.Name && qualifierAgrees(r.Region, o.Region) && qualifierAgrees(r.Account, o.Account)
 }
@@ -93,18 +104,36 @@ func ARNResourceName(name string) string {
 // and DupFingerprint — because a map key can only be compared by equality, and a
 // predicate like ResourceID.Agrees cannot be one.
 //
-// KNOWN CONSEQUENCE, and the reason Agrees exists beside it: collapsing to the bare
-// identifier drops the account and region, so one instance name in two AWS accounts
-// produces ONE key. That is accepted here and nowhere else. Every caller folds this
-// name into a key that is already qualified by the surrounding facts — IncidentKey
-// adds alertname, namespace, kind and cluster; DupFingerprint adds the namespace and
-// the cause — so two accounts collide only when the same alert fires on the same
-// resource name, in the same namespace, on the same cluster. The alternative is
-// strictly worse: without the collapse the SAME database recurring under two
-// spellings gets two keys, which is the bug being fixed and is guaranteed to happen
-// on every ARN-shaped alert rather than in a contrived naming coincidence. The
-// structural matching path, where a wrong collapse would apply one database's
-// runbook to another, uses Agrees and keeps the two accounts apart.
+// KNOWN CONSEQUENCE: collapsing to the bare identifier drops the account and region,
+// so one instance name in two AWS accounts produces ONE key. This is a real accepted
+// exposure, not a neutralised one, and it is worth stating precisely because the
+// fields wrapped around this name look like they close it and do not.
+//
+// IncidentKey adds alertname, namespace, kind and cluster; DupFingerprint adds the
+// namespace and the cause. For the alert class this function exists for, none of
+// those separates two AWS accounts: a CloudWatch-derived rule authors `namespace` as
+// a literal, one scraping Prometheus stamps a single `cluster` external label across
+// every account it watches, and `kind` is empty for a cloud resource. So two accounts
+// hosting the same instance name and alerting through one stack DO share a key. Via
+// TriggerKey that key reaches outcome.Ledger's byTrigger index, and inside a
+// configured RecurrenceGate cooldown the second account's firing can be suppressed on
+// the first account's conclusion — investigate's loop then returns with no model call
+// and no notification.
+//
+// It is accepted because the collapse is FORCED rather than chosen. A map key is
+// compared by equality, and canon(ARN_A) == canon(short) == canon(ARN_B) would force
+// the two ARNs equal, so no single canonical string can both fuse the two spellings
+// of one resource and split two accounts; adding the account to the key instead
+// re-splits the ARN spelling from the short one, which is the bug being fixed. Nor
+// did the exposure arrive with this function — two SHORT-spelled alerts from two
+// accounts already collided before it existed. What changed is that the ARN spelling
+// no longer accidentally keeps them apart, in exchange for the split being closed on
+// every ARN-shaped alert rather than in a naming coincidence.
+//
+// Closing it properly needs an account discriminator the SHORT spelling also carries
+// — an alert label plumbed into the key — which is a larger change than this one.
+// The matching path uses Agrees, which keeps two QUALIFIED values apart; see its doc
+// for why that does not extend to an ingested alert either.
 func NormalizeResourceName(name string) string {
 	return ParseResourceID(name).Name
 }
@@ -124,6 +153,13 @@ func NormalizeResourceName(name string) string {
 // fields present and a non-empty partition, service and resource, so ordinary names
 // that merely start with or contain "arn" ("arnica-exporter") and truncated
 // fragments ("arn:aws:rds") fall through unchanged.
+//
+// aws-sdk-go-v2's aws/arn.Parse splits identically and is already an indirect
+// dependency, and is deliberately NOT used: it would make the AWS SDK a direct
+// import of internal/providers, which is cloud-SDK-free today (only
+// internal/providers/cloud/aws touches it). It also supplies neither the strictness
+// above nor the resource-TYPE strip below, so the part that would be reused is the
+// one line this shares with it.
 func parseARN(s string) (id, region, account string, ok bool) {
 	if !strings.HasPrefix(s, "arn:") {
 		return "", "", "", false
@@ -137,11 +173,33 @@ func parseARN(s string) (id, region, account string, ok bool) {
 		return "", "", "", false
 	}
 	region, account = f[3], f[4]
-	if i := strings.IndexAny(resource, ":/"); i >= 0 {
-		resource = resource[i+1:]
+	if !typelessResourceServices[service] {
+		if i := strings.IndexAny(resource, ":/"); i >= 0 {
+			resource = resource[i+1:]
+		}
 	}
 	if resource == "" {
 		return "", "", "", false
 	}
 	return resource, region, account, true
 }
+
+// typelessResourceServices are the services whose ARN resource field is the resource
+// ITSELF, with no leading resource-type segment — so a "/" inside it separates two
+// parts of ONE identifier instead of a type from a name.
+//
+// S3 is the case that matters and the reason this exists. "arn:aws:s3:::my-bucket"
+// has no separator and needs no exception, but "arn:aws:s3:::prod-logs/exports"
+// names the "exports" prefix IN "prod-logs": stripping its first segment would
+// reduce prod-logs/exports and staging-logs/exports to the same "exports", and an S3
+// ARN carries NEITHER region nor account, so ResourceID.Agrees has no qualifier left
+// to tell the two buckets apart and would report two different buckets as one
+// resource. That is a false agreement — the failure this whole type exists to
+// prevent — as opposed to a missed one, which merely costs an investigation.
+//
+// It is a per-service exception rather than a general rule because the ARN grammar
+// genuinely cannot distinguish "type/name" from "name/subpath": all three forms
+// (resource, resource-type/resource, resource-type:resource) are legal and the
+// service is the only thing that says which is in use. Typeless-but-separator-free
+// services (SNS topics, SQS queues) need no entry — there is nothing to strip.
+var typelessResourceServices = map[string]bool{"s3": true}

--- a/internal/providers/resourceid_test.go
+++ b/internal/providers/resourceid_test.go
@@ -44,6 +44,16 @@ func TestResourceIDAgreement(t *testing.T) {
 			"arnica-exporter", "exporter", false},
 		{"a truncated arn-looking value is not an arn either",
 			"arn:aws:rds", "rds", false},
+		// An S3 ARN's resource field has NO resource-type segment: it is
+		// "bucket[/key]". Stripping its first segment would leave both of these as
+		// "exports", and an S3 ARN carries neither region nor account, so no
+		// qualifier would be left to tell the two buckets apart.
+		{"two S3 prefixes under different buckets are two resources",
+			"arn:aws:s3:::prod-logs/exports", "arn:aws:s3:::staging-logs/exports", false},
+		{"an S3 prefix agrees with its own bucket-qualified spelling",
+			"arn:aws:s3:::prod-logs/exports", "prod-logs/exports", true},
+		{"an S3 bucket arn still agrees with its bare bucket name",
+			"arn:aws:s3:::prod-logs", "prod-logs", true},
 		{"empty agrees with empty",
 			"", "", true},
 		{"empty never agrees with a named resource",
@@ -78,8 +88,13 @@ func TestARNResourceName(t *testing.T) {
 		"arn:aws:rds:us-east-1:142655614335:db:datagrok-aqemia-shared":               "datagrok-aqemia-shared",
 		"arn:aws:ec2:us-east-1:142655614335:instance/i-0abc123def4567890":            "i-0abc123def4567890",
 		"arn:aws:elasticloadbalancing:us-east-1:1:loadbalancer/app/my-lb/50dc6c4951": "app/my-lb/50dc6c4951",
-		"arn:aws:s3:::my-bucket":                  "my-bucket", // no region, no account
-		"arn:aws-cn:rds:cn-north-1:1:db:datagrok": "datagrok",  // non-default partition
+		"arn:aws:s3:::my-bucket": "my-bucket", // no region, no account
+		// S3 has no resource-TYPE segment, so the bucket is part of the identifier
+		// and must survive: reducing this to "exports" would fuse every bucket that
+		// happens to use the same prefix name.
+		"arn:aws:s3:::prod-logs/exports":          "prod-logs/exports",
+		"arn:aws:ec2:us-east-1:1:instance/i-0abc": "i-0abc",   // a real type segment still goes
+		"arn:aws-cn:rds:cn-north-1:1:db:datagrok": "datagrok", // non-default partition
 		"harbor-registry-59598dbd57-ltkzw":        "harbor-registry-59598dbd57-ltkzw",
 		"observability/datagrok-aqemia-shared":    "observability/datagrok-aqemia-shared",
 		"arnica-exporter":                         "arnica-exporter",

--- a/internal/providers/resourceid_test.go
+++ b/internal/providers/resourceid_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package providers_test
+
+import (
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// TestResourceIDAgreement pins the identity rule that closes the split observed on
+// 2026-08-17/18: one RDS instance fired twice and the two firings were treated as
+// unrelated resources because the alert spelled it as the bare DBInstanceIdentifier
+// once and as the full ARN the next time.
+//
+// Agreement is deliberately NOT plain equality of a canonical bare name: an ARN
+// carries an account and a region, and two accounts hosting the same instance name
+// are two different databases. A qualifier is compared only when BOTH sides carry
+// it — the short form is unqualified and therefore compatible with either account,
+// which is the whole point.
+func TestResourceIDAgreement(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{"rds arn vs its DBInstanceIdentifier dimension",
+			"arn:aws:rds:us-east-1:142655614335:db:datagrok-aqemia-shared", "datagrok-aqemia-shared", true},
+		{"slash-style arn vs its identifier",
+			"arn:aws:ec2:us-east-1:142655614335:instance/i-0abc123def4567890", "i-0abc123def4567890", true},
+		{"slash-style arn keeps the full multi-segment resource path (the CloudWatch dimension)",
+			"arn:aws:elasticloadbalancing:us-east-1:1:loadbalancer/app/my-lb/50dc6c4951", "app/my-lb/50dc6c4951", true},
+		{"same instance name in two different accounts is two different databases",
+			"arn:aws:rds:us-east-1:111111111111:db:datagrok", "arn:aws:rds:us-east-1:222222222222:db:datagrok", false},
+		{"same instance name in two different regions is two different databases",
+			"arn:aws:rds:us-east-1:111111111111:db:datagrok", "arn:aws:rds:eu-west-1:111111111111:db:datagrok", false},
+		{"an arn agrees with itself",
+			"arn:aws:rds:us-east-1:111111111111:db:datagrok", "arn:aws:rds:us-east-1:111111111111:db:datagrok", true},
+		{"a kubernetes workload name is untouched",
+			"harbor-registry", "harbor-registry", true},
+		{"two distinct kubernetes names stay distinct",
+			"harbor-registry", "harbor-core", false},
+		{"a name that merely contains the substring arn is not an arn",
+			"arnica-exporter", "exporter", false},
+		{"a truncated arn-looking value is not an arn either",
+			"arn:aws:rds", "rds", false},
+		{"empty agrees with empty",
+			"", "", true},
+		{"empty never agrees with a named resource",
+			"", "datagrok-aqemia-shared", false},
+		{"pod-template-hash forgiveness still holds",
+			"harbor-registry-59598dbd57-ltkzw", "harbor-registry", true},
+		{"the hash strip runs on BOTH sides of an arn so the two spellings cannot diverge",
+			"arn:aws:rds:us-east-1:1:db:web-7d9c8b6f5-abcde", "web", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			a, b := providers.ParseResourceID(c.a), providers.ParseResourceID(c.b)
+			if got := a.Agrees(b); got != c.want {
+				t.Errorf("ParseResourceID(%q).Agrees(ParseResourceID(%q)) = %v, want %v", c.a, c.b, got, c.want)
+			}
+			// Agreement is symmetric: the gate compares an alert against a catalog
+			// entry and neither side is privileged.
+			if got := b.Agrees(a); got != c.want {
+				t.Errorf("agreement is not symmetric: %q vs %q = %v, want %v", c.b, c.a, got, c.want)
+			}
+		})
+	}
+}
+
+// TestARNResourceName pins the ingestion-side canonicalisation: an ARN reduces to
+// the resource identifier its CloudWatch dimension carries, and every other value is
+// returned byte-for-byte. It must NOT strip a pod-template hash — ingestion stores
+// the workload name a Kubernetes alert fired on, and that name is normalized only at
+// comparison time.
+func TestARNResourceName(t *testing.T) {
+	cases := map[string]string{
+		"arn:aws:rds:us-east-1:142655614335:db:datagrok-aqemia-shared":               "datagrok-aqemia-shared",
+		"arn:aws:ec2:us-east-1:142655614335:instance/i-0abc123def4567890":            "i-0abc123def4567890",
+		"arn:aws:elasticloadbalancing:us-east-1:1:loadbalancer/app/my-lb/50dc6c4951": "app/my-lb/50dc6c4951",
+		"arn:aws:s3:::my-bucket":                  "my-bucket", // no region, no account
+		"arn:aws-cn:rds:cn-north-1:1:db:datagrok": "datagrok",  // non-default partition
+		"harbor-registry-59598dbd57-ltkzw":        "harbor-registry-59598dbd57-ltkzw",
+		"observability/datagrok-aqemia-shared":    "observability/datagrok-aqemia-shared",
+		"arnica-exporter":                         "arnica-exporter",
+		"arn:aws:rds":                             "arn:aws:rds",
+		"arn:::::":                                "arn:::::",
+		"":                                        "",
+	}
+	for in, want := range cases {
+		if got := providers.ARNResourceName(in); got != want {
+			t.Errorf("ARNResourceName(%q) = %q, want %q", in, got, want)
+		}
+		if got := providers.ARNResourceName(want); got != want {
+			t.Errorf("ARNResourceName is not idempotent for %q: %q", want, got)
+		}
+	}
+}
+
+// TestNormalizeResourceNameIsTheCanonicalKeyForm pins the single-string form used
+// where identity has to BE a map key (curator.IncidentKey → the recurrence ledger's
+// TriggerKey, and DupFingerprint): the two spellings of one resource must collapse
+// to the same string, because a key can only ever be compared by equality.
+func TestNormalizeResourceNameIsTheCanonicalKeyForm(t *testing.T) {
+	const short = "datagrok-aqemia-shared"
+	arn := "arn:aws:rds:us-east-1:142655614335:db:" + short
+	if got, want := providers.NormalizeResourceName(arn), short; got != want {
+		t.Fatalf("NormalizeResourceName(%q) = %q, want %q", arn, got, want)
+	}
+	if got := providers.NormalizeResourceName(short); got != short {
+		t.Fatalf("NormalizeResourceName(%q) = %q, want it unchanged", short, got)
+	}
+	// The pod-hash forgiveness the key form already had must survive.
+	if got, want := providers.NormalizeResourceName("harbor-registry-59598dbd57-ltkzw"), "harbor-registry"; got != want {
+		t.Fatalf("NormalizeResourceName lost the pod-hash strip: got %q, want %q", got, want)
+	}
+}

--- a/internal/providers/workload_identity_test.go
+++ b/internal/providers/workload_identity_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package providers
+
+import "testing"
+
+// TestResolveWorkloadIdentityReconcilesTheCloudScope pins the reconciliation
+// contract the ingestion adapters depend on. The behaviour itself is driven by the
+// source-level tests, where it is observable end to end; this table exists so the
+// individual rules — which side wins, what is left alone — cannot drift silently.
+func TestResolveWorkloadIdentityReconcilesTheCloudScope(t *testing.T) {
+	cwLabels := map[string]string{"account_id": "111111111111", "region": "us-east-1"}
+	cases := []struct {
+		name   string
+		in     Workload
+		labels map[string]string
+		want   Workload
+	}{
+		{"an ARN names its own scope, with no labels at all",
+			Workload{Name: "arn:aws:rds:eu-west-1:333333333333:db:compute-stages"}, nil,
+			Workload{Name: "compute-stages", Region: "eu-west-1", Account: "333333333333"}},
+		{"a short name takes the scope from the labels",
+			Workload{Name: "datagrok"}, cwLabels,
+			Workload{Name: "datagrok", Region: "us-east-1", Account: "111111111111"}},
+		{"agreeing sources are a no-op",
+			Workload{Name: "arn:aws:rds:us-east-1:111111111111:db:datagrok"}, cwLabels,
+			Workload{Name: "datagrok", Region: "us-east-1", Account: "111111111111"}},
+		{"the ARN wins a disagreement — it names the resource, the label names the series that saw it",
+			Workload{Name: "arn:aws:rds:eu-west-1:333333333333:db:datagrok"}, cwLabels,
+			Workload{Name: "datagrok", Region: "eu-west-1", Account: "333333333333"}},
+		{"an S3 ARN carries neither qualifier, so the labels supply both",
+			Workload{Name: "arn:aws:s3:::prod-logs/exports"}, cwLabels,
+			Workload{Name: "prod-logs/exports", Region: "us-east-1", Account: "111111111111"}},
+		{"the cloudwatch_exporter label spellings are read too",
+			Workload{Name: "datagrok"}, map[string]string{"aws_account_id": "444444444444", "aws_region": "ap-south-1"},
+			Workload{Name: "datagrok", Region: "ap-south-1", Account: "444444444444"}},
+		{"a bare `account` label is NOT an AWS account — it is a plausible application label",
+			Workload{Name: "datagrok"}, map[string]string{"account": "acme-corp"},
+			Workload{Name: "datagrok"}},
+		{"a Kubernetes object is never qualified, whatever the stack stamps globally",
+			Workload{Kind: "Deployment", Namespace: "apps", Name: "payment-api"}, cwLabels,
+			Workload{Kind: "Deployment", Namespace: "apps", Name: "payment-api"}},
+		{"a pod keeps its template hash — normalization is a comparison-time concern",
+			Workload{Kind: "Pod", Namespace: "tooling", Name: "harbor-registry-59598dbd57-ltkzw"}, cwLabels,
+			Workload{Kind: "Pod", Namespace: "tooling", Name: "harbor-registry-59598dbd57-ltkzw"}},
+		{"an ARN overrides the Kubernetes check — whatever label carried it, it is a cloud resource",
+			Workload{Kind: "Deployment", Name: "arn:aws:rds:eu-west-1:333333333333:db:datagrok"}, nil,
+			Workload{Kind: "Deployment", Name: "datagrok", Region: "eu-west-1", Account: "333333333333"}},
+		{"a name that merely contains arn is not one",
+			Workload{Kind: "Deployment", Name: "arnica-exporter"}, cwLabels,
+			Workload{Kind: "Deployment", Name: "arnica-exporter"}},
+		{"nothing to qualify: no name, no scope",
+			Workload{Namespace: "observability"}, cwLabels,
+			Workload{Namespace: "observability"}},
+		{"a scope already set is authoritative",
+			Workload{Name: "datagrok", Account: "555555555555", Region: "sa-east-1"}, cwLabels,
+			Workload{Name: "datagrok", Account: "555555555555", Region: "sa-east-1"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ResolveWorkloadIdentity(c.in, c.labels)
+			if got != c.want {
+				t.Errorf("ResolveWorkloadIdentity(%+v) = %+v, want %+v", c.in, got, c.want)
+			}
+			if again := ResolveWorkloadIdentity(got, c.labels); again != got {
+				t.Errorf("not idempotent: %+v became %+v", got, again)
+			}
+		})
+	}
+}
+
+// TestWorkloadResourceIDUnionsTheTwoSourcesOfScope pins the asymmetry between the
+// comparison path and the key path: comparison reads the scope from the name AND the
+// fields, because an absent qualifier is compatible rather than different, so extra
+// evidence can only split resources that really are distinct. A key cannot do that —
+// see curator.IncidentKey, which reads the field alone.
+func TestWorkloadResourceIDUnionsTheTwoSourcesOfScope(t *testing.T) {
+	cases := []struct {
+		name string
+		in   Workload
+		want ResourceID
+	}{
+		{"an ARN still in the name is resolved — that is how legacy catalog entries stay comparable",
+			Workload{Namespace: "observability", Name: "arn:aws:rds:us-east-1:195275669196:db:compute-stages"},
+			ResourceID{Name: "compute-stages", Region: "us-east-1", Account: "195275669196"}},
+		{"a bare name is qualified by the scope ingestion stamped on it",
+			Workload{Namespace: "observability", Name: "compute-stages", Account: "195275669196", Region: "us-east-1"},
+			ResourceID{Name: "compute-stages", Region: "us-east-1", Account: "195275669196"}},
+		{"a Kubernetes workload resolves to a bare, unqualified identity",
+			Workload{Namespace: "tooling", Name: "harbor-registry-59598dbd57-ltkzw"},
+			ResourceID{Name: "harbor-registry"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.in.ResourceID(); got != c.want {
+				t.Errorf("%+v.ResourceID() = %+v, want %+v", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/source/alertmanager/alertmanager.go
+++ b/internal/source/alertmanager/alertmanager.go
@@ -55,12 +55,15 @@ type amAlert struct {
 // two spellings that then key, render and index as two unrelated resources. Only an
 // ARN is rewritten; a Kubernetes name (pod hash and all) passes through untouched.
 func workloadFromLabels(labels map[string]string) (kind, name string) {
-	kind, name = workloadLabel(labels)
+	kind, name = rawWorkloadFromLabels(labels)
 	return kind, providers.ARNResourceName(name)
 }
 
-// workloadLabel picks the workload label to trust, in precedence order.
-func workloadLabel(labels map[string]string) (kind, name string) {
+// rawWorkloadFromLabels picks the workload label to trust, in precedence order, and
+// returns it verbatim. The split from workloadFromLabels exists so the ARN
+// canonicalisation is applied once instead of at each of the three returns below —
+// so the name says "raw", which is the only thing that distinguishes the two.
+func rawWorkloadFromLabels(labels map[string]string) (kind, name string) {
 	for _, c := range []struct{ label, kind string }{
 		{"deployment", "Deployment"},
 		{"statefulset", "StatefulSet"},

--- a/internal/source/alertmanager/alertmanager.go
+++ b/internal/source/alertmanager/alertmanager.go
@@ -48,15 +48,21 @@ type amAlert struct {
 // kube-state-metrics has exposed the Job name as job_name since it began setting
 // job="kube-state-metrics" on its own series, so job_name is the only correct source.
 //
-// The name is finally canonicalised through providers.ARNResourceName: a
-// CloudWatch-derived rule templates whichever dimension it has to hand into these
-// labels, so one RDS instance arrives as `datagrok-aqemia-shared` on one firing and
-// as `arn:aws:rds:us-east-1:142655614335:db:datagrok-aqemia-shared` on the next —
-// two spellings that then key, render and index as two unrelated resources. Only an
-// ARN is rewritten; a Kubernetes name (pod hash and all) passes through untouched.
-func workloadFromLabels(labels map[string]string) (kind, name string) {
-	kind, name = rawWorkloadFromLabels(labels)
-	return kind, providers.ARNResourceName(name)
+// The workload is finally resolved through providers.ResolveWorkloadIdentity, which
+// does two things with these labels. It canonicalises the NAME: a CloudWatch-derived
+// rule templates whichever dimension it has to hand, so one RDS instance arrives as
+// `datagrok-aqemia-shared` on one firing and as
+// `arn:aws:rds:us-east-1:142655614335:db:datagrok-aqemia-shared` on the next — two
+// spellings that then key, render and index as two unrelated resources. And it lifts
+// the cloud SCOPE the ARN would otherwise have taken with it onto Account/Region,
+// reading the `account_id`/`region` labels the exporter stamps so the scope is
+// present under either spelling. Only an ARN is rewritten and only a cloud resource
+// is qualified; a Kubernetes name (pod hash and all) passes through untouched and
+// unqualified.
+func workloadFromLabels(labels map[string]string) providers.Workload {
+	kind, name := rawWorkloadFromLabels(labels)
+	return providers.ResolveWorkloadIdentity(
+		providers.Workload{Kind: kind, Name: name, Namespace: labels["namespace"]}, labels)
 }
 
 // rawWorkloadFromLabels picks the workload label to trust, in precedence order, and
@@ -100,7 +106,7 @@ func (Source) Decode(body []byte, _ http.Header) (source.DecodeResult, error) {
 			continue
 		}
 		startsAt, _ := time.Parse(time.RFC3339, a.StartsAt)
-		kind, name := workloadFromLabels(a.Labels)
+		w := workloadFromLabels(a.Labels)
 		var fps []string
 		if a.Fingerprint != "" {
 			fps = []string{a.Fingerprint}
@@ -110,7 +116,7 @@ func (Source) Decode(body []byte, _ http.Header) (source.DecodeResult, error) {
 			Title:       a.Labels["alertname"],
 			Severity:    a.Labels["severity"],
 			Environment: cmp.Or(a.Labels["environment"], a.Labels["env"]),
-			Workload:    providers.Workload{Namespace: a.Labels["namespace"], Kind: kind, Name: name},
+			Workload:    w,
 			Reason:      a.Labels["severity"],
 			// The description/summary annotation is the alert's most informative human
 			// text (the templated "what is wrong") — without it the seed prompt carried
@@ -124,10 +130,11 @@ func (Source) Decode(body []byte, _ http.Header) (source.DecodeResult, error) {
 			Fingerprints: fps,
 			GroupKey:     p.GroupKey,
 			// Host-invariant per-class dedup key (alertname + workload family +
-			// cluster, pod-hash suffix stripped): dedupes re-fires of one series
-			// (#137) AND the same alert on a different pod/node (CORE-681). Attribution
+			// cluster + AWS account, pod-hash suffix stripped): dedupes re-fires of one
+			// series (#137) AND the same alert on a different pod/node (CORE-681), while
+			// keeping two AWS accounts that share an instance name apart. Attribution
 			// still uses the per-series Alertmanager Fingerprint above.
-			TriggerKey: curator.IncidentKey(a.Labels["alertname"], a.Labels["namespace"], kind, name, a.Labels["cluster"]),
+			TriggerKey: curator.IncidentKey(a.Labels["alertname"], w, a.Labels["cluster"]),
 		})
 	}
 	return out, nil

--- a/internal/source/alertmanager/alertmanager.go
+++ b/internal/source/alertmanager/alertmanager.go
@@ -47,7 +47,20 @@ type amAlert struct {
 // k8s-stack" for a Deployment, which was reported as `Job observability/vmagent-…`.
 // kube-state-metrics has exposed the Job name as job_name since it began setting
 // job="kube-state-metrics" on its own series, so job_name is the only correct source.
+//
+// The name is finally canonicalised through providers.ARNResourceName: a
+// CloudWatch-derived rule templates whichever dimension it has to hand into these
+// labels, so one RDS instance arrives as `datagrok-aqemia-shared` on one firing and
+// as `arn:aws:rds:us-east-1:142655614335:db:datagrok-aqemia-shared` on the next —
+// two spellings that then key, render and index as two unrelated resources. Only an
+// ARN is rewritten; a Kubernetes name (pod hash and all) passes through untouched.
 func workloadFromLabels(labels map[string]string) (kind, name string) {
+	kind, name = workloadLabel(labels)
+	return kind, providers.ARNResourceName(name)
+}
+
+// workloadLabel picks the workload label to trust, in precedence order.
+func workloadLabel(labels map[string]string) (kind, name string) {
 	for _, c := range []struct{ label, kind string }{
 		{"deployment", "Deployment"},
 		{"statefulset", "StatefulSet"},

--- a/internal/source/alertmanager/alertmanager_test.go
+++ b/internal/source/alertmanager/alertmanager_test.go
@@ -192,9 +192,9 @@ func TestWorkloadFromLabels(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		k, n := workloadFromLabels(c.labels)
-		if k != c.wantKind || n != c.wantNm {
-			t.Errorf("%s: got (%q,%q), want (%q,%q)", c.name, k, n, c.wantKind, c.wantNm)
+		w := workloadFromLabels(c.labels)
+		if w.Kind != c.wantKind || w.Name != c.wantNm {
+			t.Errorf("%s: got (%q,%q), want (%q,%q)", c.name, w.Kind, w.Name, c.wantKind, c.wantNm)
 		}
 	}
 }

--- a/internal/source/alertmanager/cross_account_test.go
+++ b/internal/source/alertmanager/cross_account_test.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package alertmanager
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// decodeOne decodes a single firing alert with the given labels.
+func decodeOne(t *testing.T, labels map[string]string) (name, account, region, triggerKey string) {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{"alerts": []map[string]any{{
+		"status": "firing", "labels": labels,
+	}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := (&Source{}).Decode(body, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Requests) != 1 {
+		t.Fatalf("want 1 request, got %d", len(res.Requests))
+	}
+	r := res.Requests[0]
+	return r.Workload.Name, r.Workload.Account, r.Workload.Region, r.TriggerKey
+}
+
+// cwLabels builds the labels a yace/CloudWatch-derived alert rule carries for one
+// RDS instance in one account, with the workload spelled as `workload`.
+func cwLabels(workload, account string) map[string]string {
+	return map[string]string{
+		"alertname": "RDSHighCPU", "namespace": "observability",
+		"workload": workload, "cluster": "aqemia-shared", "severity": "warning",
+		"account_id": account, "region": "us-east-1",
+	}
+}
+
+// TestTwoAWSAccountsDoNotShareATriggerKey is the collision this change exists to
+// close. Two AWS accounts scraped by ONE yace/CloudWatch exporter through ONE
+// Prometheus produce alerts that agree on every field the trigger key was built
+// from: the alertname is the rule's, the `namespace` is the EXPORTER's (a literal
+// in a CloudWatch-derived rule, not the resource's), the kind is empty for a cloud
+// resource, and the `cluster` external label is stamped once per Prometheus across
+// every account it watches. So `datagrok` in account 111111111111 and `datagrok` in
+// account 222222222222 keyed identically.
+//
+// That key is the recurrence ledger's grouping key: inside a configured
+// RecurrenceGate cooldown, the second account's firing is suppressed on the FIRST
+// account's conclusion and investigate's loop returns with no model call, no
+// notification and no ledger entry. A genuine production incident in one account is
+// silently dropped because an unrelated account had the same instance name.
+func TestTwoAWSAccountsDoNotShareATriggerKey(t *testing.T) {
+	const instance = "datagrok"
+	_, _, _, keyA := decodeOne(t, cwLabels(instance, "111111111111"))
+	_, _, _, keyB := decodeOne(t, cwLabels(instance, "222222222222"))
+	if keyA == "" {
+		t.Fatal("no trigger key for a well-formed cloud alert")
+	}
+	if keyA == keyB {
+		t.Fatalf("two AWS accounts hosting an instance named %q share one trigger key %q — "+
+			"inside a recurrence cooldown one account's incident is silently dropped on the other's conclusion", instance, keyA)
+	}
+}
+
+// TestARNAndShortSpellingsStillFuse is the property the branch exists for and must
+// not regress: one instance reached RunLore by its DBInstanceIdentifier dimension on
+// one firing and by its full ARN on the next. Both spellings carry the SAME alert
+// labels, so the account reaches the key either way and the two firings stay one
+// incident.
+func TestARNAndShortSpellingsStillFuse(t *testing.T) {
+	const (
+		short   = "datagrok"
+		account = "111111111111"
+		arn     = "arn:aws:rds:us-east-1:" + account + ":db:" + short
+	)
+	arnName, arnAcct, arnRegion, arnKey := decodeOne(t, cwLabels(arn, account))
+	shortName, shortAcct, shortRegion, shortKey := decodeOne(t, cwLabels(short, account))
+
+	if arnName != short || shortName != short {
+		t.Errorf("both spellings must store the bare identifier %q: arn gave %q, short gave %q", short, arnName, shortName)
+	}
+	if arnAcct != account || shortAcct != account {
+		t.Errorf("both spellings must carry the account %q: arn gave %q, short gave %q", account, arnAcct, shortAcct)
+	}
+	if arnRegion != "us-east-1" || shortRegion != "us-east-1" {
+		t.Errorf("both spellings must carry the region: arn gave %q, short gave %q", arnRegion, shortRegion)
+	}
+	if arnKey != shortKey {
+		t.Errorf("the two spellings of one instance produced two trigger keys:\n arn:   %q\n short: %q", arnKey, shortKey)
+	}
+}
+
+// TestARNWithoutAnAccountLabelStillCarriesItsAccount pins the reconciliation: the
+// account reaches the Workload from whichever side has it. An ARN names its account
+// even when the rule drops the label, and a short name has only the label.
+func TestARNWithoutAnAccountLabelStillCarriesItsAccount(t *testing.T) {
+	_, account, region, _ := decodeOne(t, map[string]string{
+		"alertname": "RDSHighCPU", "namespace": "observability",
+		"workload": "arn:aws:rds:eu-west-1:333333333333:db:compute-stages",
+	})
+	if account != "333333333333" || region != "eu-west-1" {
+		t.Fatalf("qualifiers lost when only the ARN carries them: account=%q region=%q", account, region)
+	}
+}
+
+// TestKubernetesWorkloadsAreUnqualifiedAndKeyByteIdentically is the regression this
+// change is most likely to cause. A Kubernetes object's identity is namespace/name
+// and nothing else — it has no AWS account — so a cluster whose Prometheus happens
+// to stamp `account_id`/`region` as external labels must not acquire a qualifier,
+// must not grow a key segment, and must produce the exact key bytes it produced
+// before. The expected value is written out literally rather than compared against a
+// second call, so a change to the key SHAPE cannot pass by moving both sides.
+func TestKubernetesWorkloadsAreUnqualifiedAndKeyByteIdentically(t *testing.T) {
+	cases := []struct {
+		name   string
+		labels map[string]string
+		want   string
+	}{
+		{"deployment with AWS external labels", map[string]string{
+			"alertname": "KubeDeploymentReplicasMismatch", "namespace": "apps",
+			"deployment": "payment-api", "cluster": "aqemia-shared",
+			"account_id": "111111111111", "region": "us-east-1",
+		}, "kubedeploymentreplicasmismatch|apps|deployment|payment-api|aqemia-shared"},
+		{"pod-scoped alert keeps its hash at ingestion and normalizes in the key", map[string]string{
+			"alertname": "KubePodNotReady", "namespace": "observability",
+			"pod": "node-exporter-prometheus-node-exporter-km6ld", "cluster": "shared",
+			"account_id": "111111111111",
+		}, "kubepodnotready|observability|pod|node-exporter-prometheus-node-exporter|shared"},
+		{"workload label with a workload_type is a Kubernetes object", map[string]string{
+			"alertname": "TooManyLogs", "namespace": "observability",
+			"workload": "vmagent", "workload_type": "Deployment", "cluster": "shared",
+			"account_id": "111111111111", "region": "us-east-1",
+		}, "toomanylogs|observability|deployment|vmagent|shared"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, account, region, key := decodeOne(t, c.labels)
+			if account != "" || region != "" {
+				t.Errorf("a Kubernetes workload must carry no cloud qualifier, got account=%q region=%q", account, region)
+			}
+			if key != c.want {
+				t.Errorf("trigger key changed for a Kubernetes workload:\n got  %q\n want %q", key, c.want)
+			}
+		})
+	}
+}
+
+// TestAnARNOnlyAccountDoesNotFuseWithAnUnqualifiedFiring pins the one case the two
+// requirements cannot both be met in, so it is a decision on the record rather than
+// a surprise. A stack that omits the account LABEL leaves the account visible on the
+// ARN spelling and invisible on the short one, and no single key can then both fuse
+// the two spellings and split two accounts — a map key is compared by equality, so
+// fusing them means key(ARN in account A) == key(short) == key(ARN in account B),
+// which forces the two accounts equal again.
+//
+// The account is kept, and the two spellings therefore key apart. That direction is
+// chosen on severity: the cost of splitting is a duplicated recurrence bucket — one
+// extra investigation and one extra KB pull request — while the cost of collapsing
+// is a genuine production incident in one account being silently dropped inside a
+// cooldown armed by another account's conclusion. The reproduced defect this change
+// exists to close is exactly that shape, with BOTH accounts spelled as ARNs, and
+// dropping an ARN-only account would leave it open.
+//
+// Where the label IS present — every yace/CloudWatch deployment, which stamps
+// account_id on every series — the account reaches the key under both spellings and
+// TestARNAndShortSpellingsStillFuse holds.
+func TestAnARNOnlyAccountDoesNotFuseWithAnUnqualifiedFiring(t *testing.T) {
+	base := func(workload string) map[string]string {
+		return map[string]string{
+			"alertname": "RDSHighCPU", "namespace": "observability",
+			"workload": workload, "cluster": "aqemia-shared",
+		}
+	}
+	_, _, _, arnKey := decodeOne(t, base("arn:aws:rds:us-east-1:111111111111:db:datagrok"))
+	_, _, _, shortKey := decodeOne(t, base("datagrok"))
+	if arnKey == shortKey {
+		t.Fatalf("an ARN naming account 111111111111 keyed identically to an unqualified firing (%q) — "+
+			"the account it names was dropped, which is what re-opens the cross-account collision", arnKey)
+	}
+	// Two ARN-spelled firings from two accounts — the reproduced defect — stay apart
+	// even with no label to help.
+	_, _, _, otherKey := decodeOne(t, base("arn:aws:rds:us-east-1:222222222222:db:datagrok"))
+	if arnKey == otherKey {
+		t.Fatal("two accounts' ARNs still share one trigger key")
+	}
+	// And two unqualified firings still fuse: with no account anywhere there is
+	// nothing to split on, and the spelling collapse is unchanged.
+	_, _, _, shortKey2 := decodeOne(t, base("datagrok"))
+	if shortKey != shortKey2 {
+		t.Fatal("two unqualified firings of one instance stopped fusing")
+	}
+}

--- a/internal/source/alertmanager/resource_identity_test.go
+++ b/internal/source/alertmanager/resource_identity_test.go
@@ -30,6 +30,11 @@ func TestDecodeCanonicalisesAnARNWorkloadLabel(t *testing.T) {
 			"labels": map[string]string{
 				"alertname": "RDSHighCPU", "namespace": "observability",
 				"workload": workload, "cluster": "aqemia-shared", "severity": "warning",
+				// The exporter stamps the account on every series, so it reaches the key
+				// under BOTH spellings — see TestARNAndShortSpellingsStillFuse, and
+				// TestAnARNOnlyAccountDoesNotFuseWithAnUnqualifiedFiring for what happens
+				// on a stack that omits it.
+				"account_id": "142655614335",
 			},
 		}}})
 		if err != nil {
@@ -90,9 +95,9 @@ func TestWorkloadFromLabelsLeavesKubernetesNamesAlone(t *testing.T) {
 		{map[string]string{"alertname": "X"}, "", ""},
 	}
 	for _, c := range cases {
-		kind, name := workloadFromLabels(c.labels)
-		if kind != c.kind || name != c.name {
-			t.Errorf("workloadFromLabels(%v) = (%q, %q), want (%q, %q)", c.labels, kind, name, c.kind, c.name)
+		w := workloadFromLabels(c.labels)
+		if w.Kind != c.kind || w.Name != c.name {
+			t.Errorf("workloadFromLabels(%v) = (%q, %q), want (%q, %q)", c.labels, w.Kind, w.Name, c.kind, c.name)
 		}
 	}
 }

--- a/internal/source/alertmanager/resource_identity_test.go
+++ b/internal/source/alertmanager/resource_identity_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package alertmanager
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestDecodeCanonicalisesAnARNWorkloadLabel is the ingestion half of the
+// 2026-08-17/18 split. A CloudWatch-derived alert rule templates the affected
+// resource into the `workload` label, and which dimension it reaches for decides the
+// spelling: the RDS instance datagrok-aqemia-shared arrived as its bare
+// DBInstanceIdentifier on the 21:18Z firing and as its full ARN on the 03:53Z one.
+//
+// Ingestion is where the split has to stop for NEW data: Workload.Name is what a
+// notification renders, what a curated entry's `resource:` frontmatter is indexed
+// under, and what the recurrence key is built from. Storing the identifier means a
+// resource only ever has one spelling downstream. (Entries already written in the
+// ARN form are the comparison side's job — see investigate.refsAgree.)
+func TestDecodeCanonicalisesAnARNWorkloadLabel(t *testing.T) {
+	const (
+		short = "datagrok-aqemia-shared"
+		arn   = "arn:aws:rds:us-east-1:142655614335:db:" + short
+	)
+	decode := func(t *testing.T, workload string) (name, triggerKey string) {
+		t.Helper()
+		body, err := json.Marshal(map[string]any{"alerts": []map[string]any{{
+			"status": "firing",
+			"labels": map[string]string{
+				"alertname": "RDSHighCPU", "namespace": "observability",
+				"workload": workload, "cluster": "aqemia-shared", "severity": "warning",
+			},
+		}}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		res, err := (&Source{}).Decode(body, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(res.Requests) != 1 {
+			t.Fatalf("want 1 request, got %d", len(res.Requests))
+		}
+		return res.Requests[0].Workload.Name, res.Requests[0].TriggerKey
+	}
+
+	arnName, arnKey := decode(t, arn)
+	shortName, shortKey := decode(t, short)
+
+	if arnName != short {
+		t.Errorf("Workload.Name = %q, want the resource identifier %q — the ARN scaffolding names nothing extra", arnName, short)
+	}
+	if shortName != short {
+		t.Errorf("a short workload label must pass through untouched: got %q, want %q", shortName, short)
+	}
+	if arnKey != shortKey {
+		t.Errorf("the two firings of one DB instance produced two trigger keys:\n arn:   %q\n short: %q", arnKey, shortKey)
+	}
+	// The full ARN is not lost — it still travels verbatim on the labels, so the
+	// account and region reach the seed prompt.
+	body, err := json.Marshal(map[string]any{"alerts": []map[string]any{{
+		"status": "firing",
+		"labels": map[string]string{"alertname": "RDSHighCPU", "namespace": "observability", "workload": arn},
+	}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := (&Source{}).Decode(body, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := res.Requests[0].Labels["workload"]; got != arn {
+		t.Errorf("the raw ARN must survive on Labels for the seed prompt: got %q, want %q", got, arn)
+	}
+}
+
+// TestWorkloadFromLabelsLeavesKubernetesNamesAlone guards the conservative half of
+// the rule: only an ARN is rewritten. A pod name keeps its template hash (it is
+// normalized at comparison time, never at ingestion), and a name that merely
+// contains "arn" is not an ARN.
+func TestWorkloadFromLabelsLeavesKubernetesNamesAlone(t *testing.T) {
+	cases := []struct {
+		labels     map[string]string
+		kind, name string
+	}{
+		{map[string]string{"pod": "harbor-registry-59598dbd57-ltkzw"}, "Pod", "harbor-registry-59598dbd57-ltkzw"},
+		{map[string]string{"deployment": "arnica-exporter"}, "Deployment", "arnica-exporter"},
+		{map[string]string{"statefulset": "arn:aws:rds"}, "StatefulSet", "arn:aws:rds"}, // truncated: not an ARN
+		{map[string]string{"alertname": "X"}, "", ""},
+	}
+	for _, c := range cases {
+		kind, name := workloadFromLabels(c.labels)
+		if kind != c.kind || name != c.name {
+			t.Errorf("workloadFromLabels(%v) = (%q, %q), want (%q, %q)", c.labels, kind, name, c.kind, c.name)
+		}
+	}
+}

--- a/internal/source/custom/custom.go
+++ b/internal/source/custom/custom.go
@@ -109,8 +109,17 @@ func (s *Source) Decode(body []byte, h http.Header) (source.DecodeResult, error)
 		// arrives as its bare DBInstanceIdentifier on one firing and as its full ARN
 		// on the next — and Workload.Name is what the notification renders, what a
 		// curated entry is indexed under, and what the recurrence key is built from.
-		// Only an ARN is rewritten; a Kubernetes name passes through untouched, and
-		// the raw value still travels on Labels.
+		// Only an ARN is rewritten; a Kubernetes name passes through untouched.
+		//
+		// Unlike the Alertmanager adapter, this path does NOT keep the raw value: the
+		// labels map above is built from the instance name plus the operator's own
+		// `labels:` mapping, and workload_name is not copied into it. So unless that
+		// mapping happens to carry the ARN, the account and region are gone from the
+		// Request entirely and never reach the seed prompt. That is a real loss of
+		// context for a vendor webhook, and the reason it is tolerated is only that
+		// the alternative — inventing a label key here — would collide with whatever
+		// the operator already maps. Restoring it belongs with the ingestion
+		// canonicalisation moving to the source.Pipeline chokepoint.
 		wname = providers.ARNResourceName(wname)
 		var fps []string
 		if fingerprint != "" {

--- a/internal/source/custom/custom.go
+++ b/internal/source/custom/custom.go
@@ -104,6 +104,14 @@ func (s *Source) Decode(body []byte, h http.Header) (source.DecodeResult, error)
 			}
 		}
 		ns, kind, wname := get("namespace"), get("workload_kind"), get("workload_name")
+		// One cloud resource must have ONE spelling downstream. A vendor rule
+		// templates whichever identifier it has to hand, so the same RDS instance
+		// arrives as its bare DBInstanceIdentifier on one firing and as its full ARN
+		// on the next — and Workload.Name is what the notification renders, what a
+		// curated entry is indexed under, and what the recurrence key is built from.
+		// Only an ARN is rewritten; a Kubernetes name passes through untouched, and
+		// the raw value still travels on Labels.
+		wname = providers.ARNResourceName(wname)
 		var fps []string
 		if fingerprint != "" {
 			fps = []string{fingerprint}

--- a/internal/source/custom/custom.go
+++ b/internal/source/custom/custom.go
@@ -114,13 +114,13 @@ func (s *Source) Decode(body []byte, h http.Header) (source.DecodeResult, error)
 		// Unlike the Alertmanager adapter, this path does NOT keep the raw value: the
 		// labels map above is built from the instance name plus the operator's own
 		// `labels:` mapping, and workload_name is not copied into it. So unless that
-		// mapping happens to carry the ARN, the account and region are gone from the
-		// Request entirely and never reach the seed prompt. That is a real loss of
-		// context for a vendor webhook, and the reason it is tolerated is only that
-		// the alternative — inventing a label key here — would collide with whatever
-		// the operator already maps. Restoring it belongs with the ingestion
-		// canonicalisation moving to the source.Pipeline chokepoint.
-		wname = providers.ARNResourceName(wname)
+		// mapping happens to carry the ARN, the raw spelling is gone from the Request
+		// entirely and never reaches the seed prompt. What is no longer lost is the
+		// cloud SCOPE: ResolveWorkloadIdentity lifts the ARN's account and region onto
+		// the Workload (and reads them from the operator's mapped labels when the name
+		// is short), so a vendor webhook keys per account like an Alertmanager one.
+		w := providers.ResolveWorkloadIdentity(
+			providers.Workload{Kind: kind, Name: wname, Namespace: ns}, labels)
 		var fps []string
 		if fingerprint != "" {
 			fps = []string{fingerprint}
@@ -133,7 +133,7 @@ func (s *Source) Decode(body []byte, h http.Header) (source.DecodeResult, error)
 			Title:        title,
 			Severity:     severity,
 			Environment:  get("environment"),
-			Workload:     providers.Workload{Namespace: ns, Kind: kind, Name: wname},
+			Workload:     w,
 			Reason:       severity,
 			Message:      get("message"),
 			Labels:       labels,
@@ -142,7 +142,7 @@ func (s *Source) Decode(body []byte, h http.Header) (source.DecodeResult, error)
 			Fingerprints: fps,
 			// Instance takes the cluster slot (PagerDuty precedent: its service
 			// does) so two vendors reporting the same workload stay distinct.
-			TriggerKey: curator.IncidentKey(title, ns, kind, wname, name),
+			TriggerKey: curator.IncidentKey(title, w, name),
 		})
 	}
 	return out, nil

--- a/internal/source/custom/resource_identity_test.go
+++ b/internal/source/custom/resource_identity_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package custom
+
+import (
+	"testing"
+)
+
+// TestDecodeCanonicalisesAnARNWorkloadName pins the same ingestion rule the
+// Alertmanager adapter carries, on the mapper every vendor webhook (and
+// sources.grafana, which delegates here) goes through: a mapped workload_name that
+// is an AWS ARN is stored as the resource identifier, so one cloud resource has one
+// spelling in notifications, curated entries and the recurrence key — whichever
+// dimension the vendor's alert rule happened to template in. Anything that is not an
+// ARN is stored byte-for-byte.
+func TestDecodeCanonicalisesAnARNWorkloadName(t *testing.T) {
+	insts, err := parseConfig(mustNode(t, `
+instances:
+  cw:
+    items: alerts
+    fields:
+      title: labels.alertname
+      namespace: labels.namespace
+      workload_name: labels.resource
+      fingerprint: fingerprint
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &Source{instances: insts}
+	body := `{"alerts":[
+  {"fingerprint":"fp1","labels":{"alertname":"RDSHighCPU","namespace":"observability","resource":"arn:aws:rds:us-east-1:142655614335:db:datagrok-aqemia-shared"}},
+  {"fingerprint":"fp2","labels":{"alertname":"RDSHighCPU","namespace":"observability","resource":"datagrok-aqemia-shared"}},
+  {"fingerprint":"fp3","labels":{"alertname":"PodNotReady","namespace":"tooling","resource":"harbor-registry-59598dbd57-ltkzw"}}
+]}`
+	res, err := s.Decode([]byte(body), hdr("cw"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Requests) != 3 {
+		t.Fatalf("want 3 requests, got %d", len(res.Requests))
+	}
+	arn, short, pod := res.Requests[0], res.Requests[1], res.Requests[2]
+	if arn.Workload.Name != "datagrok-aqemia-shared" {
+		t.Errorf("Workload.Name = %q, want the resource identifier the ARN names", arn.Workload.Name)
+	}
+	if arn.TriggerKey != short.TriggerKey {
+		t.Errorf("the two spellings of one DB instance produced two trigger keys:\n arn:   %q\n short: %q", arn.TriggerKey, short.TriggerKey)
+	}
+	if pod.Workload.Name != "harbor-registry-59598dbd57-ltkzw" {
+		t.Errorf("a Kubernetes pod name must reach the request untouched, got %q", pod.Workload.Name)
+	}
+}

--- a/internal/source/custom/resource_identity_test.go
+++ b/internal/source/custom/resource_identity_test.go
@@ -23,14 +23,17 @@ instances:
       namespace: labels.namespace
       workload_name: labels.resource
       fingerprint: fingerprint
+    labels: labels
 `))
 	if err != nil {
 		t.Fatal(err)
 	}
 	s := &Source{instances: insts}
+	// The account travels as a mapped label, which is what lets it reach the trigger
+	// key under BOTH spellings — see TestVendorWebhookKeysPerAWSAccount.
 	body := `{"alerts":[
-  {"fingerprint":"fp1","labels":{"alertname":"RDSHighCPU","namespace":"observability","resource":"arn:aws:rds:us-east-1:142655614335:db:datagrok-aqemia-shared"}},
-  {"fingerprint":"fp2","labels":{"alertname":"RDSHighCPU","namespace":"observability","resource":"datagrok-aqemia-shared"}},
+  {"fingerprint":"fp1","labels":{"alertname":"RDSHighCPU","namespace":"observability","account_id":"142655614335","resource":"arn:aws:rds:us-east-1:142655614335:db:datagrok-aqemia-shared"}},
+  {"fingerprint":"fp2","labels":{"alertname":"RDSHighCPU","namespace":"observability","account_id":"142655614335","resource":"datagrok-aqemia-shared"}},
   {"fingerprint":"fp3","labels":{"alertname":"PodNotReady","namespace":"tooling","resource":"harbor-registry-59598dbd57-ltkzw"}}
 ]}`
 	res, err := s.Decode([]byte(body), hdr("cw"))
@@ -49,5 +52,55 @@ instances:
 	}
 	if pod.Workload.Name != "harbor-registry-59598dbd57-ltkzw" {
 		t.Errorf("a Kubernetes pod name must reach the request untouched, got %q", pod.Workload.Name)
+	}
+}
+
+// TestVendorWebhookKeysPerAWSAccount pins that the cross-account split reaches the
+// mapper every vendor webhook (and sources.grafana) goes through, not just the
+// Alertmanager adapter: two accounts hosting an instance of the same name agree on
+// the title, the namespace, the kind and the instance slot, so without the account
+// they were one recurrence bucket — and inside a cooldown one account's incident is
+// dropped on the other's conclusion.
+func TestVendorWebhookKeysPerAWSAccount(t *testing.T) {
+	insts, err := parseConfig(mustNode(t, `
+instances:
+  cw:
+    items: alerts
+    fields:
+      title: labels.alertname
+      namespace: labels.namespace
+      workload_name: labels.resource
+      fingerprint: fingerprint
+    labels: labels
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &Source{instances: insts}
+	body := `{"alerts":[
+  {"fingerprint":"fp1","labels":{"alertname":"RDSHighCPU","namespace":"observability","account_id":"111111111111","resource":"datagrok"}},
+  {"fingerprint":"fp2","labels":{"alertname":"RDSHighCPU","namespace":"observability","account_id":"222222222222","resource":"datagrok"}},
+  {"fingerprint":"fp3","labels":{"alertname":"PodNotReady","namespace":"tooling","resource":"harbor-registry"}}
+]}`
+	res, err := s.Decode([]byte(body), hdr("cw"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Requests) != 3 {
+		t.Fatalf("want 3 requests, got %d", len(res.Requests))
+	}
+	a, b, k8s := res.Requests[0], res.Requests[1], res.Requests[2]
+	if a.Workload.Account != "111111111111" || b.Workload.Account != "222222222222" {
+		t.Errorf("mapped account labels did not reach the workload: %q / %q", a.Workload.Account, b.Workload.Account)
+	}
+	if a.TriggerKey == b.TriggerKey {
+		t.Errorf("two AWS accounts hosting an instance named \"datagrok\" share one trigger key %q", a.TriggerKey)
+	}
+	// A workload with no cloud scope keeps the five-segment key it always had.
+	if k8s.Workload.Account != "" {
+		t.Errorf("an unqualified workload acquired an account %q", k8s.Workload.Account)
+	}
+	if want := "podnotready|tooling||harbor-registry|cw"; k8s.TriggerKey != want {
+		t.Errorf("trigger key changed for an unqualified workload:\n got  %q\n want %q", k8s.TriggerKey, want)
 	}
 }

--- a/internal/source/pagerduty/pagerduty.go
+++ b/internal/source/pagerduty/pagerduty.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/curator"
 	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/source"
 )
 
@@ -137,9 +138,10 @@ func toRequest(ev pdEvent) investigate.Request {
 		Fingerprint:  inc.ID,
 		Fingerprints: fps,
 		// Host-invariant per-class dedup key. PagerDuty's only scoping dimension is
-		// the service, so it takes the cluster slot; namespace/kind/name stay empty.
+		// the service, so it takes the cluster slot; the workload is empty (a PagerDuty
+		// incident names no object, hence no namespace/kind/name and no cloud account).
 		// Re-fires of the same incident title on the same service dedupe to one PR (#137).
-		TriggerKey: curator.IncidentKey(inc.Title, "", "", "", inc.Service.Summary),
+		TriggerKey: curator.IncidentKey(inc.Title, providers.Workload{}, inc.Service.Summary),
 	}
 }
 

--- a/website/content/docs/concepts/learning-loop.md
+++ b/website/content/docs/concepts/learning-loop.md
@@ -214,9 +214,16 @@ Why each gate exists:
   (`tooling/harbor-registry-59598dbd57-ltkzw` → `tooling/harbor-registry`), and a
   **cloud** resource is matched through its ARN — a CloudWatch alert names one RDS
   instance by its `DBInstanceIdentifier` on one firing and by its full ARN on the
-  next, and both reach the same entry. An ARN's account and region still have to
-  agree when both sides carry them, so the same instance name in two AWS accounts
-  stays two resources. A **workload-less**
+  next, and both reach the same entry.
+
+  Be aware of the limit of that last one. Alerts are canonicalised to the bare
+  identifier when they are ingested, so the incoming side carries no account or
+  region and agrees with an ARN-form entry from **any** account; the account/region
+  check only separates two values that both still carry them (two legacy ARN-form
+  entries). The same collapse keys the recurrence ledger, so if you run one instance
+  name in two AWS accounts and alert on both through a single Prometheus, treat them
+  as one identity for recall and recurrence — or give the two alerts different
+  `alertname`s. A **workload-less**
   incident (PagerDuty carries no Kubernetes namespace/name) agrees only with entries
   that are themselves resource-less — the weakest ("scopeless") tier: it always
   requires `solo_floor` + `min_score`, starts at reduced confidence, and

--- a/website/content/docs/concepts/learning-loop.md
+++ b/website/content/docs/concepts/learning-loop.md
@@ -209,7 +209,14 @@ Why each gate exists:
   symptoms → one cause": a `CrashLoopBackOff` in `apps/web` should not recall an OOM
   runbook for `apps/worker`. It's a **pre-filter** over a wide candidate set (k=20),
   not a check of only the top lexical hit, so the structurally-correct entry can win
-  even when a wrong-workload entry scores higher on symptom words. A **workload-less**
+  even when a wrong-workload entry scores higher on symptom words. Agreement is by
+  **identity, not spelling**: a per-pod name reduces to its controller family
+  (`tooling/harbor-registry-59598dbd57-ltkzw` → `tooling/harbor-registry`), and a
+  **cloud** resource is matched through its ARN — a CloudWatch alert names one RDS
+  instance by its `DBInstanceIdentifier` on one firing and by its full ARN on the
+  next, and both reach the same entry. An ARN's account and region still have to
+  agree when both sides carry them, so the same instance name in two AWS accounts
+  stays two resources. A **workload-less**
   incident (PagerDuty carries no Kubernetes namespace/name) agrees only with entries
   that are themselves resource-less — the weakest ("scopeless") tier: it always
   requires `solo_floor` + `min_score`, starts at reduced confidence, and

--- a/website/content/docs/concepts/learning-loop.md
+++ b/website/content/docs/concepts/learning-loop.md
@@ -216,14 +216,16 @@ Why each gate exists:
   instance by its `DBInstanceIdentifier` on one firing and by its full ARN on the
   next, and both reach the same entry.
 
-  Be aware of the limit of that last one. Alerts are canonicalised to the bare
-  identifier when they are ingested, so the incoming side carries no account or
-  region and agrees with an ARN-form entry from **any** account; the account/region
-  check only separates two values that both still carry them (two legacy ARN-form
-  entries). The same collapse keys the recurrence ledger, so if you run one instance
-  name in two AWS accounts and alert on both through a single Prometheus, treat them
-  as one identity for recall and recurrence — or give the two alerts different
-  `alertname`s. A **workload-less**
+  What is forgiven is the spelling, never the **scope**. Ingestion reduces the name
+  to its bare identifier but keeps the AWS account and region beside it, read from
+  the alert's `account_id`/`region` labels *and* from an ARN-spelled name — so one
+  instance name in two accounts is two identities for recall and two buckets in the
+  recurrence ledger, while the two spellings of one instance stay one. An alert that
+  carries no account at all (every Kubernetes workload, and any rule that omits the
+  label) is unqualified and still matches an ARN-form entry in any account: an absent
+  qualifier means *unknown*, not *different*, which is what keeps entries already
+  filed under a full ARN reachable. So if you run one instance name in two accounts,
+  make sure the account label reaches the alert. A **workload-less**
   incident (PagerDuty carries no Kubernetes namespace/name) agrees only with entries
   that are themselves resource-less — the weakest ("scopeless") tier: it always
   requires `solo_floor` + `min_score`, starts at reduced confidence, and


### PR DESCRIPTION
The same RDS instance produced two investigations that could not recognise each other. The alert identified it as the bare `DBInstanceIdentifier` on the 21:18Z firing (`observability/datagrok-aqemia-shared`) and as the full ARN on the 03:53Z one (`observability/arn:aws:rds:us-east-1:142655614335:db:…`).

Resource identity is compared by string equality everywhere, so **one recurring fault read as two unrelated first sightings** and the recurrence gate never armed. The same split reached the catalog: a live entry is indexed as `observability/arn:aws:rds:…:db:compute-stages` while its neighbours use short names, so recall's structural filter misses across the two conventions.

### Fixed on both sides, because neither alone is enough

Canonicalising at ingestion cannot reach entries already written in the ARN form; an ARN-aware comparison alone would keep writing two spellings into new data.

- **`providers.ParseResourceID`** resolves a name to the identity it should be matched by. ARNs reduce to the resource identifier their CloudWatch dimension carries, handling both separators (`:db:NAME` and `:type/NAME`), and keep account and region as qualifiers. `Agrees()` compares those **only when both sides carry them**, so the unqualified short form agrees with the ARN it came from, while two accounts hosting the same instance name stay distinct.
- The recall structural gate (`resourceAgrees`) compares refs through it.
- `curator.IncidentKey` and `DupFingerprint` collapse to the bare identifier — unavoidable for a map key — but every field they wrap around the name (alertname, namespace, kind, cluster, cause) still qualifies it.
- The Alertmanager and custom/Grafana adapters store the identifier, so one resource has one spelling in notifications, entries and ledger keys. The raw ARN still travels on `Labels` and reaches the seed prompt.

Nothing about Kubernetes matching moves: a `namespace/name` passes through untouched, a name merely *containing* "arn" is not an ARN, and the pod-template-hash forgiveness is unchanged.

### The review pass found a real false agreement

`parseARN` stripped everything up to the first `:` or `/` in the ARN resource field, assuming a leading resource-**type** segment. **S3 has no type segment** — its resource field is `bucket[/key]` — so `arn:aws:s3:::prod-logs/exports` and `arn:aws:s3:::staging-logs/exports` both reduced to `exports`. An S3 ARN carries neither region nor account, so `Agrees` had no qualifier left and **reported two different buckets as one resource**.

A false agreement is the failure this type exists to prevent, unlike a missed one, which only costs an investigation. Fixed with a per-service exception, because the ARN grammar genuinely cannot tell `type/name` from `name/subpath` — all three resource forms are legal and only the service says which is in use. The regression test fails without the guard.

It also caught **docs promising more than the code delivers**: ingestion collapses an ARN to its bare identifier before a `Workload` is built, so the request side is always unqualified and the account/region check is vacuously true for alert traffic. It separates two *qualified* values (two legacy ARN-form entries), not an alert from an entry. The docs now say that.

### One commit added while gating against current `main`

The egress redaction guard merged in #522 failed on all ten reachable occurrences of the new `Account` and `Region` fields. `providers.Workload` is a `redactionSkipTypes` entry written when the struct held only kind/name/namespace, so the two new fields **inherited an egress exemption nobody decided to give them** — exactly the shape that guard was rebuilt to refuse. The claim is now made explicitly in `egressVerbatim`, per occurrence, with the rationale that they carry the same provenance and trust level as the identifiers beside them.

Gate: `build` · `vet` · `go test ./... -race` · `gofmt -l .` silent · `golangci-lint run ./...` **0 issues**.
