### PR TITLE
fix(notify): don't render the alert's namespace as the resource's own

### DIFF
--- a/internal/notify/format.go
+++ b/internal/notify/format.go
@@ -245,8 +245,11 @@ func Format(inv providers.Investigation) string {
 	// detail, not the thing to lead with, so it sits below the answer (root
 	// causes) and the action (suggested steps) rather than above them, mirroring
 	// the Slack card's move.
-	if ref := inv.Resource.Ref(); ref != "" {
-		fmt.Fprintf(&b, "Resource: %s\n", strings.TrimSpace(inv.Resource.Kind+" "+ref))
+	// resourceLine, not Resource.Ref(): a cluster-scoped or cloud object has no
+	// namespace to qualify, and the namespace an alert-driven investigation carries
+	// is the exporter's, not the object's. See resourceRef.
+	if line := resourceLine(inv.Resource); line != "" {
+		fmt.Fprintf(&b, "Resource: %s\n", line)
 	}
 	if meta := metadataLine(inv); meta != "" {
 		fmt.Fprintf(&b, "%s\n", meta)
@@ -300,11 +303,15 @@ func metadataLine(inv providers.Investigation) string {
 	if inv.Environment != "" {
 		parts = append(parts, "env "+inv.Environment)
 	}
-	if inv.Cluster != "" {
-		parts = append(parts, "cluster "+inv.Cluster)
+	// The tenant is dropped when it only repeats the cluster's name — "cluster shared
+	// · tenant shared" states one fact twice. Same decision function as the Slack
+	// card's Cluster field, so the two cannot collapse differently.
+	cluster, tenant := scopeIdentity(inv.Cluster, inv.Tenant)
+	if cluster != "" {
+		parts = append(parts, "cluster "+cluster)
 	}
-	if inv.Tenant != "" {
-		parts = append(parts, "tenant "+inv.Tenant)
+	if tenant != "" {
+		parts = append(parts, "tenant "+tenant)
 	}
 	return strings.Join(parts, " · ")
 }

--- a/internal/notify/format.go
+++ b/internal/notify/format.go
@@ -245,9 +245,8 @@ func Format(inv providers.Investigation) string {
 	// detail, not the thing to lead with, so it sits below the answer (root
 	// causes) and the action (suggested steps) rather than above them, mirroring
 	// the Slack card's move.
-	// resourceLine, not Resource.Ref(): a cluster-scoped or cloud object has no
-	// namespace to qualify, and the namespace an alert-driven investigation carries
-	// is the exporter's, not the object's. See resourceRef.
+	// resourceLine, not Resource.Ref(): the namespace an alert-driven investigation
+	// carries is the exporter's, not the object's. See resourceRef.
 	if line := resourceLine(inv.Resource); line != "" {
 		fmt.Fprintf(&b, "Resource: %s\n", line)
 	}
@@ -303,9 +302,8 @@ func metadataLine(inv providers.Investigation) string {
 	if inv.Environment != "" {
 		parts = append(parts, "env "+inv.Environment)
 	}
-	// The tenant is dropped when it only repeats the cluster's name — "cluster shared
-	// · tenant shared" states one fact twice. Same decision function as the Slack
-	// card's Cluster field, so the two cannot collapse differently.
+	// The tenant is dropped when it only repeats the cluster — see scopeIdentity,
+	// which the Slack card's header and Cluster field also go through.
 	cluster, tenant := scopeIdentity(inv.Cluster, inv.Tenant)
 	if cluster != "" {
 		parts = append(parts, "cluster "+cluster)

--- a/internal/notify/matrix_thread.go
+++ b/internal/notify/matrix_thread.go
@@ -219,8 +219,14 @@ func stampEncodedBytes(s threadStamp) int {
 // every re-investigation.
 func stampFor(inv providers.Investigation) threadStamp {
 	return boundStamp(threadStamp{
-		TriggerKey:    cmp.Or(inv.TriggerKey, inv.Fingerprint),
-		Title:         inv.Title,
+		TriggerKey: cmp.Or(inv.TriggerKey, inv.Fingerprint),
+		Title:      inv.Title,
+		// Ref(), NOT resourceRef, and deliberately so: this is the stamp's identity
+		// key, not card text. internal/thread/registry.go builds thread.Context.Resource
+		// from the same Ref(), and note.go derives the KB entry's `resource:` frontmatter
+		// from it — narrowing it here alone would desync the two stamp builders and
+		// orphan every thread already stamped. The namespace this carries can still be
+		// the alert exporter's; fixing that belongs where the workload is assembled.
 		Resource:      inv.Resource.Ref(),
 		Verdict:       string(inv.Verdict),
 		CuratedURL:    inv.CuratedURL,

--- a/internal/notify/payload.go
+++ b/internal/notify/payload.go
@@ -73,6 +73,13 @@ func NewPayload(inv providers.Investigation) Payload {
 	}
 	return Payload{
 		Title: inv.Title, Confidence: inv.Confidence,
+		// Namespace is the RAW field, not the card's rendered scope: Payload is a
+		// declared external wire format, so blanking a known-wrong namespace here is
+		// observable to every existing consumer and needs its own change, not a
+		// side effect of a card-rendering fix. Known gap, stated so it is not read as
+		// an oversight: Text above is already the corrected render, and an operator
+		// template (internal/notify/templated) doing "{{.Namespace}}/{{.Resource}}"
+		// still reproduces "observability/ip-10-11-132-8.ec2.internal" for a Node.
 		Namespace: inv.Resource.Namespace, Resource: inv.Resource.Name,
 		CuratedURL: inv.CuratedURL, Text: Format(inv), Verdict: string(inv.Verdict),
 		Severity: inv.Severity, Cluster: inv.Cluster, Environment: inv.Environment,

--- a/internal/notify/resource_scope.go
+++ b/internal/notify/resource_scope.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package notify
+
+import (
+	"strings"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// clusterScopedKinds are Kubernetes kinds that HAVE no namespace, so a namespace
+// qualifier on one is never a fact about the object — it is whatever namespace
+// happened to be in scope when the workload was assembled (see resourceRef).
+//
+// Keys are lowercased; lookups go through kindKey.
+//
+// Well-known built-ins first, then the third-party CRDs whose objects show up in
+// alert-driven investigations on a typical cluster. The list is deliberately allowed
+// to be incomplete: an unlisted kind falls through to "namespaced", which is what
+// the renderer already did, so a missing entry costs nothing that is not already the
+// status quo — while a WRONG entry would strip a real namespace off a real object.
+// That asymmetry is why nothing is guessed here.
+var clusterScopedKinds = map[string]struct{}{
+	// core
+	"node":             {},
+	"namespace":        {},
+	"persistentvolume": {},
+	"componentstatus":  {},
+	// rbac.authorization.k8s.io
+	"clusterrole":        {},
+	"clusterrolebinding": {},
+	// storage.k8s.io
+	"storageclass":     {},
+	"volumeattachment": {},
+	"csidriver":        {},
+	"csinode":          {},
+	// apiextensions / apiregistration
+	"customresourcedefinition": {},
+	"apiservice":               {},
+	// admissionregistration.k8s.io
+	"mutatingwebhookconfiguration":     {},
+	"validatingwebhookconfiguration":   {},
+	"validatingadmissionpolicy":        {},
+	"validatingadmissionpolicybinding": {},
+	// scheduling / node / networking / certificates / flowcontrol
+	"priorityclass":              {},
+	"runtimeclass":               {},
+	"ingressclass":               {},
+	"certificatesigningrequest":  {},
+	"flowschema":                 {},
+	"prioritylevelconfiguration": {},
+	// third-party, cluster-scoped by design
+	"gatewayclass":  {}, // gateway.networking.k8s.io
+	"clusterissuer": {}, // cert-manager.io
+	"clusterpolicy": {}, // kyverno.io
+	"nodepool":      {}, // karpenter.sh
+	"nodeclaim":     {}, // karpenter.sh
+	"ec2nodeclass":  {}, // karpenter.k8s.aws
+}
+
+// nonKubernetesKinds are cloud resources RunLore reasons about that are not
+// Kubernetes objects at all — an RDS instance has no namespace to be in, so
+// "DBInstance observability/datagrok-aqemia-shared" names a namespace that does not
+// exist anywhere in the world the reader can go and look at.
+//
+// Only names with no namespaced Kubernetes homonym are listed. "Queue", "Function"
+// and "Volume" are pointedly ABSENT even though AWS has all three: each is also a
+// namespaced CRD kind in a widely-deployed operator (RabbitMQ, OpenFaaS, Longhorn),
+// and stripping a real namespace off a real object is the failure this whole file
+// exists to avoid. Kinds spelled as a cloud identifier rather than a Kubernetes kind
+// — CloudTrail's "AWS::RDS::DBInstance", an ARN — need no entry here:
+// notKubernetesShaped rejects them structurally.
+var nonKubernetesKinds = map[string]struct{}{
+	// RDS — the family the delivered "DBInstance observability/…" card came from.
+	"dbinstance":        {},
+	"dbcluster":         {},
+	"dbsnapshot":        {},
+	"dbclustersnapshot": {},
+	"dbparametergroup":  {},
+	"dbsubnetgroup":     {},
+	"cachecluster":      {}, // ElastiCache
+	// The AWS objects RunLore's own cloud readers describe by name
+	// (internal/providers/cloud/aws): EKS node groups, ASGs and their load balancing.
+	"nodegroup":        {},
+	"autoscalinggroup": {},
+	"launchtemplate":   {},
+	"loadbalancer":     {}, // ELB/ALB — the Kubernetes spelling is Service or Ingress
+	"targetgroup":      {},
+}
+
+// kindKey normalizes a kind for lookup: the field is free text (submit_findings lets
+// the model write it), so "node", "Node" and " Node " are the same kind.
+func kindKey(kind string) string {
+	return strings.ToLower(strings.TrimSpace(kind))
+}
+
+// notKubernetesShaped reports whether kind holds a character no Kubernetes kind can
+// contain — ':', '/' or whitespace — so it names something outside Kubernetes
+// entirely: a CloudTrail resource type ("AWS::RDS::DBInstance"), an ARN, a phrase.
+// Enumerating every cloud type would be endless, so the shape answers for them.
+//
+// Deliberately narrow, and narrower than "is this a well-formed Kubernetes kind":
+// a dotted or hyphenated spelling ("helmreleases.helm.toolkit.fluxcd.io",
+// "helm-release") is not a well-formed kind either, but it is how a model spells a
+// REAL CRD whose objects are namespaced. Those keep their namespace and render
+// exactly as they do today, because stripping a true namespace off a real object is
+// the one new failure this file must not introduce.
+func notKubernetesShaped(kind string) bool {
+	return strings.ContainsAny(strings.TrimSpace(kind), ":/ \t\n")
+}
+
+// unnamespacedKind reports whether a namespace qualifier on this kind is certainly
+// not a fact about the object: a cluster-scoped Kubernetes kind, or something that
+// is not a Kubernetes object at all.
+//
+// Fail-safe by construction — it answers false for an empty kind and for every kind
+// it does not recognize, so the renderer keeps doing exactly what it does today
+// unless the namespace is KNOWN to be wrong.
+func unnamespacedKind(kind string) bool {
+	k := kindKey(kind)
+	if k == "" {
+		return false
+	}
+	if _, ok := clusterScopedKinds[k]; ok {
+		return true
+	}
+	if _, ok := nonKubernetesKinds[k]; ok {
+		return true
+	}
+	return notKubernetesShaped(kind)
+}
+
+// resourceRef renders the affected resource's identity for a card: "namespace/name"
+// for a namespaced object, and the bare name for one that has no namespace.
+//
+// It exists because Workload.Ref() is namespace-first unconditionally, and the
+// namespace on an alert-driven investigation is NOT necessarily the object's own.
+// The alert's `namespace` label is the namespace of whatever exported the series —
+// kube-state-metrics, the exporter, the alerting rule — and the investigation loop
+// defaults a nameless-namespace discovery to it (investigate.preferDiscoveredResource).
+// For a cluster-scoped or cloud object that produced delivered cards reading
+// "Node observability/ip-10-11-132-8.ec2.internal" and "DBInstance
+// observability/datagrok-aqemia-shared": `observability` is where the metrics come
+// from, not where the node or the database is, and an operator who believes the card
+// goes looking in the wrong place.
+//
+// This is the RENDERING half of the fix only. The conflation upstream is real — the
+// same wrong namespace still reaches recall matching, the curated entry's
+// `resource:` frontmatter and the outcome ledger — and belongs where the workload is
+// assembled, not here.
+func resourceRef(w providers.Workload) string {
+	if unnamespacedKind(w.Kind) {
+		return strings.TrimSpace(w.Name)
+	}
+	return w.Ref()
+}
+
+// resourceLine renders the whole "Kind namespace/name" value every surface prints
+// for the affected resource — "Node ip-10-11-132-8.ec2.internal" for a cluster-scoped
+// object, "Pod observability/vector-7f9c" for a namespaced one — or "" when the
+// investigation named no resource, so the caller omits the line entirely.
+//
+// One function for both the Slack card and Format, because a resource line that says
+// two different things about one investigation on two surfaces is the drift Format's
+// own doc comment is written against.
+func resourceLine(w providers.Workload) string {
+	ref := resourceRef(w)
+	// Nothing to name AND nothing to scope it to: the line would carry no fact
+	// beyond the kind, which is what the renderer already omitted. A cluster-scoped
+	// kind whose name is unknown but whose namespace was stamped lands here with
+	// ref == "" and a namespace — it renders as the kind alone, because the one
+	// thing that must never happen is printing that namespace as the object's own.
+	if ref == "" && strings.TrimSpace(w.Namespace) == "" {
+		return ""
+	}
+	return strings.TrimSpace(w.Kind + " " + ref)
+}
+
+// scopeIdentity returns the cluster and tenant a card should render, blanking the
+// tenant when it only repeats the cluster's own name.
+//
+// "Cluster: shared · shared" is what a single-tenant cluster produced: both labels
+// carry the same value and the card says it twice, which reads like a rendering
+// fault and costs a line of the fold budget. Where they genuinely differ
+// ("tmem175 · tmem175-0" — the tenant and the cluster it lives on) the pair is the
+// point, so only the equal case collapses; the tenant is never simply dropped.
+//
+// Compared trimmed, and the surviving value is the trimmed one: when the two agree
+// modulo whitespace they name the same thing, so the canonical spelling is the one
+// to print.
+func scopeIdentity(cluster, tenant string) (outCluster, outTenant string) {
+	if strings.TrimSpace(cluster) == strings.TrimSpace(tenant) {
+		return strings.TrimSpace(cluster), ""
+	}
+	return cluster, tenant
+}

--- a/internal/notify/resource_scope.go
+++ b/internal/notify/resource_scope.go
@@ -53,7 +53,7 @@ var clusterScopedKinds = map[string]struct{}{
 	"gatewayclass":  {}, // gateway.networking.k8s.io
 	"clusterissuer": {}, // cert-manager.io
 	"clusterpolicy": {}, // kyverno.io
-	"nodepool":      {}, // karpenter.sh
+	"nodepool":      {}, // karpenter.sh — NOT hypershift.openshift.io's, which is namespaced
 	"nodeclaim":     {}, // karpenter.sh
 	"ec2nodeclass":  {}, // karpenter.k8s.aws
 }
@@ -63,13 +63,25 @@ var clusterScopedKinds = map[string]struct{}{
 // "DBInstance observability/datagrok-aqemia-shared" names a namespace that does not
 // exist anywhere in the world the reader can go and look at.
 //
-// Only names with no namespaced Kubernetes homonym are listed. "Queue", "Function"
-// and "Volume" are pointedly ABSENT even though AWS has all three: each is also a
-// namespaced CRD kind in a widely-deployed operator (RabbitMQ, OpenFaaS, Longhorn),
-// and stripping a real namespace off a real object is the failure this whole file
-// exists to avoid. Kinds spelled as a cloud identifier rather than a Kubernetes kind
-// — CloudTrail's "AWS::RDS::DBInstance", an ARN — need no entry here:
-// notKubernetesShaped rejects them structurally.
+// The bar for an entry is that the name is unambiguous ON THE PLATFORM RunLore runs
+// against. "Queue", "Function" and "Volume" are pointedly ABSENT even though AWS has
+// all three: each is also a namespaced CRD kind in a widely-deployed operator
+// (RabbitMQ, OpenFaaS, Longhorn), and stripping a real namespace off a real object is
+// the failure this whole file exists to avoid.
+//
+// That bar is NOT the stronger "no namespaced homonym exists anywhere", and the gap
+// is the first thing whoever edits this list next needs to know. AWS Controllers for
+// Kubernetes (ACK) ships NAMESPACED CRDs spelled exactly like most of these —
+// DBInstance, DBCluster, DBSubnetGroup, DBParameterGroup, CacheCluster, Nodegroup,
+// LoadBalancer, TargetGroup, LaunchTemplate — and Crossplane v2 made its managed
+// resources namespaced too. Workload carries only Kind/Name/Namespace, no group and
+// no apiVersion, so nothing here can tell an ACK DBInstance from the RDS instance the
+// delivered card misnamed. On a cluster running ACK or Crossplane v2 these entries
+// WOULD strip a true namespace; revisit the list before pointing RunLore at one.
+//
+// Kinds spelled as a cloud identifier rather than a Kubernetes kind — CloudTrail's
+// "AWS::RDS::DBInstance", an ARN — need no entry here: notKubernetesShaped rejects
+// them structurally.
 var nonKubernetesKinds = map[string]struct{}{
 	// RDS — the family the delivered "DBInstance observability/…" card came from.
 	"dbinstance":        {},
@@ -94,28 +106,39 @@ func kindKey(kind string) string {
 	return strings.ToLower(strings.TrimSpace(kind))
 }
 
-// notKubernetesShaped reports whether kind holds a character no Kubernetes kind can
-// contain — ':', '/' or whitespace — so it names something outside Kubernetes
-// entirely: a CloudTrail resource type ("AWS::RDS::DBInstance"), an ARN, a phrase.
+// notKubernetesShaped reports whether kind holds a colon — a character no Kubernetes
+// kind can contain — so it names something outside Kubernetes entirely: a CloudTrail
+// resource type ("AWS::RDS::DBInstance"), an ARN ("arn:aws:rds:eu-west-1:…:db/x").
 // Enumerating every cloud type would be endless, so the shape answers for them.
 //
-// Deliberately narrow, and narrower than "is this a well-formed Kubernetes kind":
-// a dotted or hyphenated spelling ("helmreleases.helm.toolkit.fluxcd.io",
-// "helm-release") is not a well-formed kind either, but it is how a model spells a
-// REAL CRD whose objects are namespaced. Those keep their namespace and render
-// exactly as they do today, because stripping a true namespace off a real object is
-// the one new failure this file must not introduce.
+// ':' ALONE, deliberately, and narrower than "is this a well-formed Kubernetes kind".
+// The field is model-written free text — submit_findings declares it as a bare
+// {"kind":{"type":"string"}} with no enum — and every OTHER malformed spelling a
+// model reaches for is a real, NAMESPACED object wearing a bad name:
+//
+//   - dotted or hyphenated: "helmreleases.helm.toolkit.fluxcd.io", "helm-release"
+//   - slash-qualified:      "apps/Deployment", "v1/Pod", "Deployment/checkout-api"
+//   - spaced:               "Stateful Set", "Persistent Volume Claim", "Cron Job"
+//
+// Reading '/' or whitespace as "not Kubernetes" would strip a true namespace off
+// every one of those — the one new failure this file must not introduce — and would
+// buy nothing, because both motivating examples above carry a ':' anyway.
 func notKubernetesShaped(kind string) bool {
-	return strings.ContainsAny(strings.TrimSpace(kind), ":/ \t\n")
+	return strings.Contains(kind, ":")
 }
 
-// unnamespacedKind reports whether a namespace qualifier on this kind is certainly
-// not a fact about the object: a cluster-scoped Kubernetes kind, or something that
-// is not a Kubernetes object at all.
+// unnamespacedKind reports whether a namespace qualifier on this kind is not a fact
+// about the object: a cluster-scoped Kubernetes kind, or something that is not a
+// Kubernetes object at all.
 //
 // Fail-safe by construction — it answers false for an empty kind and for every kind
 // it does not recognize, so the renderer keeps doing exactly what it does today
-// unless the namespace is KNOWN to be wrong.
+// unless the namespace is known to be wrong.
+//
+// "Known" is as strong as this layer can be, not a guarantee: Workload carries no
+// group or apiVersion, so the nonKubernetesKinds caveat above (ACK and Crossplane v2
+// ship NAMESPACED CRDs under several of those names) is a limit on this function too.
+// Read it before adding an entry.
 func unnamespacedKind(kind string) bool {
 	k := kindKey(kind)
 	if k == "" {
@@ -127,7 +150,7 @@ func unnamespacedKind(kind string) bool {
 	if _, ok := nonKubernetesKinds[k]; ok {
 		return true
 	}
-	return notKubernetesShaped(kind)
+	return notKubernetesShaped(k)
 }
 
 // resourceRef renders the affected resource's identity for a card: "namespace/name"
@@ -149,10 +172,21 @@ func unnamespacedKind(kind string) bool {
 // `resource:` frontmatter and the outcome ledger — and belongs where the workload is
 // assembled, not here.
 func resourceRef(w providers.Workload) string {
-	if unnamespacedKind(w.Kind) {
-		return strings.TrimSpace(w.Name)
+	if !unnamespacedKind(w.Kind) {
+		return w.Ref()
 	}
-	return w.Ref()
+	if name := strings.TrimSpace(w.Name); name != "" {
+		return name
+	}
+	// A Namespace object is the one cluster-scoped kind whose OWN identity can arrive
+	// in the namespace field: "the coder-engineering namespace" is a resource a model
+	// names with no workload inside it, and preferDiscoveredResource deliberately keeps
+	// that shape (a namespace, no name). Here alone the qualifier is not foreign, so
+	// reading it as one and dropping it would discard the object's actual name.
+	if kindKey(w.Kind) == "namespace" {
+		return strings.TrimSpace(w.Namespace)
+	}
+	return ""
 }
 
 // resourceLine renders the whole "Kind namespace/name" value every surface prints
@@ -164,16 +198,24 @@ func resourceRef(w providers.Workload) string {
 // two different things about one investigation on two surfaces is the drift Format's
 // own doc comment is written against.
 func resourceLine(w providers.Workload) string {
-	ref := resourceRef(w)
-	// Nothing to name AND nothing to scope it to: the line would carry no fact
-	// beyond the kind, which is what the renderer already omitted. A cluster-scoped
-	// kind whose name is unknown but whose namespace was stamped lands here with
-	// ref == "" and a namespace — it renders as the kind alone, because the one
-	// thing that must never happen is printing that namespace as the object's own.
-	if ref == "" && strings.TrimSpace(w.Namespace) == "" {
+	// The kind is trimmed BEFORE it is joined, not after: the field is model-written
+	// free text, and trimming the joined string leaves a padded " Node " rendering as
+	// "Node␣␣ip-10-11-132-8.ec2.internal" — the ends are clean, the seam is not.
+	kind, ref := strings.TrimSpace(w.Kind), resourceRef(w)
+	switch {
+	case ref == "" && strings.TrimSpace(w.Namespace) == "":
+		// Nothing to name and nothing to scope it to: no fact beyond the kind, which
+		// is what the renderer already omitted.
 		return ""
+	case ref == "":
+		// A cluster-scoped kind whose name is unknown but whose namespace was stamped:
+		// the kind alone, because printing that namespace as the object's own is the
+		// one thing that must never happen.
+		return kind
+	case kind == "":
+		return ref
 	}
-	return strings.TrimSpace(w.Kind + " " + ref)
+	return kind + " " + ref
 }
 
 // scopeIdentity returns the cluster and tenant a card should render, blanking the
@@ -185,12 +227,15 @@ func resourceLine(w providers.Workload) string {
 // ("tmem175 · tmem175-0" — the tenant and the cluster it lives on) the pair is the
 // point, so only the equal case collapses; the tenant is never simply dropped.
 //
-// Compared trimmed, and the surviving value is the trimmed one: when the two agree
-// modulo whitespace they name the same thing, so the canonical spelling is the one
-// to print.
+// Compared trimmed AND returned trimmed, in both branches: when the two agree modulo
+// whitespace they name the same thing, so the canonical spelling is the one to print
+// — and when they differ, padding is no more worth rendering than it was in the case
+// that collapses. Trimming only the collapse branch left "  shared · shared-0" on the
+// card, which is the same rendering fault this function exists to remove.
 func scopeIdentity(cluster, tenant string) (outCluster, outTenant string) {
-	if strings.TrimSpace(cluster) == strings.TrimSpace(tenant) {
-		return strings.TrimSpace(cluster), ""
+	cluster, tenant = strings.TrimSpace(cluster), strings.TrimSpace(tenant)
+	if cluster == tenant {
+		tenant = ""
 	}
 	return cluster, tenant
 }

--- a/internal/notify/resource_scope_test.go
+++ b/internal/notify/resource_scope_test.go
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package notify
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// formatResourceLine returns what Format printed after "Resource: ", or "" when it
+// printed no resource line at all. Asserting on the rendered line (rather than on
+// the helper that builds it) is what makes these tests about the card a human reads.
+func formatResourceLine(t *testing.T, out string) string {
+	t.Helper()
+	for _, l := range strings.Split(out, "\n") {
+		if after, ok := strings.CutPrefix(l, "Resource: "); ok {
+			return after
+		}
+	}
+	return ""
+}
+
+// formatScopeLine returns the Format metadata line carrying the cluster/tenant
+// facts, or "" when none was printed.
+func formatScopeLine(t *testing.T, out string) string {
+	t.Helper()
+	for _, l := range strings.Split(out, "\n") {
+		if strings.Contains(l, "cluster ") || strings.Contains(l, "tenant ") {
+			return l
+		}
+	}
+	return ""
+}
+
+// TestCardResourceLineOmitsNamespaceForUnnamespacedKinds proves the defect observed
+// in delivered cards on 2026-08-17/18: the ALERTING RULE's namespace was rendered as
+// though it were the resource's own, producing "Node observability/ip-10-11-132-8.
+// ec2.internal" for a cluster-scoped Node and "DBInstance observability/datagrok-
+// aqemia-shared" for an RDS instance that has no Kubernetes namespace at all. Both
+// actively mislead — an operator goes looking in a namespace the object was never in.
+//
+// Namespaced kinds must be untouched: this is a suppression of a qualifier that
+// cannot be true, not a reshuffle of the resource line.
+func TestCardResourceLineOmitsNamespaceForUnnamespacedKinds(t *testing.T) {
+	tests := []struct {
+		name string
+		res  providers.Workload
+		want string // the whole rendered "Resource: " value
+	}{
+		{
+			name: "Node is cluster-scoped: the alert rule's namespace is dropped",
+			res:  providers.Workload{Kind: "Node", Namespace: "observability", Name: "ip-10-11-132-8.ec2.internal"},
+			want: "Node ip-10-11-132-8.ec2.internal",
+		},
+		{
+			name: "PersistentVolume is cluster-scoped",
+			res:  providers.Workload{Kind: "PersistentVolume", Namespace: "observability", Name: "pvc-8a1f"},
+			want: "PersistentVolume pvc-8a1f",
+		},
+		{
+			name: "Namespace is cluster-scoped, and is not inside itself",
+			res:  providers.Workload{Kind: "Namespace", Namespace: "observability", Name: "coder-engineering"},
+			want: "Namespace coder-engineering",
+		},
+		{
+			name: "ClusterRole is cluster-scoped",
+			res:  providers.Workload{Kind: "ClusterRole", Namespace: "kube-system", Name: "view"},
+			want: "ClusterRole view",
+		},
+		{
+			name: "StorageClass is cluster-scoped",
+			res:  providers.Workload{Kind: "StorageClass", Namespace: "kube-system", Name: "gp3"},
+			want: "StorageClass gp3",
+		},
+		{
+			name: "CustomResourceDefinition is cluster-scoped",
+			res:  providers.Workload{Kind: "CustomResourceDefinition", Namespace: "flux-system", Name: "helmreleases.helm.toolkit.fluxcd.io"},
+			want: "CustomResourceDefinition helmreleases.helm.toolkit.fluxcd.io",
+		},
+		{
+			name: "DBInstance is not a Kubernetes object at all",
+			res:  providers.Workload{Kind: "DBInstance", Namespace: "observability", Name: "datagrok-aqemia-shared"},
+			want: "DBInstance datagrok-aqemia-shared",
+		},
+		{
+			name: "a CloudTrail resource type is not a Kubernetes kind",
+			res:  providers.Workload{Kind: "AWS::RDS::DBInstance", Namespace: "observability", Name: "datagrok-aqemia-shared"},
+			want: "AWS::RDS::DBInstance datagrok-aqemia-shared",
+		},
+		{
+			name: "a cluster-scoped kind with no name renders the kind alone, never the namespace",
+			res:  providers.Workload{Kind: "Node", Namespace: "observability"},
+			want: "Node",
+		},
+		{
+			name: "Pod stays namespaced",
+			res:  providers.Workload{Kind: "Pod", Namespace: "observability", Name: "vector-7f9c"},
+			want: "Pod observability/vector-7f9c",
+		},
+		{
+			name: "DaemonSet stays namespaced",
+			res:  providers.Workload{Kind: "DaemonSet", Namespace: "observability", Name: "vector"},
+			want: "DaemonSet observability/vector",
+		},
+		{
+			name: "an unknown kind is assumed namespaced — only a known-wrong qualifier is dropped",
+			res:  providers.Workload{Kind: "VerticalPodAutoscaler", Namespace: "observability", Name: "vector"},
+			want: "VerticalPodAutoscaler observability/vector",
+		},
+		{
+			name: "a CRD spelled as its group-qualified plural keeps its namespace: the object is real and namespaced",
+			res:  providers.Workload{Kind: "helmreleases.helm.toolkit.fluxcd.io", Namespace: "flux-system", Name: "harbor"},
+			want: "helmreleases.helm.toolkit.fluxcd.io flux-system/harbor",
+		},
+		{
+			name: "a lowercased, hyphenated kind spelling keeps its namespace too",
+			res:  providers.Workload{Kind: "helm-release", Namespace: "flux-system", Name: "harbor"},
+			want: "helm-release flux-system/harbor",
+		},
+		{
+			name: "an empty kind renders exactly as before",
+			res:  providers.Workload{Namespace: "payments", Name: "api"},
+			want: "payments/api",
+		},
+		{
+			name: "an empty kind with no name renders the namespace, as before",
+			res:  providers.Workload{Namespace: "payments"},
+			want: "payments",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			inv := providers.Investigation{
+				Title:     "something is wrong",
+				AlertName: "KubeNodeNotReady",
+				Resource:  tc.res,
+			}
+
+			if got := formatResourceLine(t, Format(inv)); got != tc.want {
+				t.Errorf("Format resource line = %q, want %q", got, tc.want)
+			}
+
+			card := blocksText(t, summaryBlocks(inv))
+			if !strings.Contains(card, tc.want) {
+				t.Errorf("Slack card does not render %q:\n%s", tc.want, card)
+			}
+			// The header appends the same ref next to the tenant/cluster scope, so a
+			// forged namespace there is the same lie in a more prominent place.
+			if bad := tc.res.Namespace + "/" + tc.res.Name; !strings.Contains(tc.want, bad) && tc.res.Name != "" {
+				if strings.Contains(card, bad) {
+					t.Errorf("Slack card still stamps the alert rule's namespace on the resource (%q):\n%s", bad, card)
+				}
+			}
+		})
+	}
+}
+
+// TestCardCollapsesDuplicateClusterIdentity proves the second delivered-card defect:
+// "Cluster: shared · shared", where the tenant merely repeats the cluster name. The
+// pair is genuinely informative when the two differ ("tmem175 · tmem175-0"), so only
+// the equal case collapses — the tenant is never simply dropped.
+func TestCardCollapsesDuplicateClusterIdentity(t *testing.T) {
+	tests := []struct {
+		name        string
+		cluster     string
+		tenant      string
+		wantCard    string // the Slack "Cluster" field value
+		wantFormat  string // the Format metadata line
+		absentInAll string // text neither surface may contain ("" = no such check)
+	}{
+		{
+			name:    "tenant equals cluster: say it once",
+			cluster: "shared", tenant: "shared",
+			wantCard: "shared", wantFormat: "cluster shared", absentInAll: "shared · shared",
+		},
+		{
+			name:    "tenant differs from cluster: both are useful",
+			cluster: "tmem175-0", tenant: "tmem175",
+			wantCard: "tmem175 · tmem175-0", wantFormat: "cluster tmem175-0 · tenant tmem175",
+		},
+		{
+			name:    "equality is compared trimmed",
+			cluster: "shared", tenant: "  shared ",
+			wantCard: "shared", wantFormat: "cluster shared",
+		},
+		{
+			name:     "cluster alone is unchanged",
+			cluster:  "eu-west-1",
+			wantCard: "eu-west-1", wantFormat: "cluster eu-west-1",
+		},
+		{
+			name:     "tenant alone is unchanged",
+			tenant:   "platform",
+			wantCard: "platform", wantFormat: "tenant platform",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			inv := providers.Investigation{
+				Title:     "something is wrong",
+				AlertName: "KubeNodeNotReady",
+				Cluster:   tc.cluster,
+				Tenant:    tc.tenant,
+			}
+
+			if got := formatScopeLine(t, Format(inv)); !strings.HasSuffix(got, tc.wantFormat) {
+				t.Errorf("Format scope line = %q, want it to end with %q", got, tc.wantFormat)
+			}
+
+			card := blocksText(t, summaryBlocks(inv))
+			if !strings.Contains(card, "*Cluster:*\\n"+tc.wantCard) {
+				t.Errorf("Slack Cluster field is not %q:\n%s", tc.wantCard, card)
+			}
+			if tc.absentInAll != "" {
+				if strings.Contains(card, tc.absentInAll) {
+					t.Errorf("Slack card repeats the same name twice (%q):\n%s", tc.absentInAll, card)
+				}
+				if out := Format(inv); strings.Contains(out, tc.absentInAll) {
+					t.Errorf("Format repeats the same name twice (%q):\n%s", tc.absentInAll, out)
+				}
+			}
+		})
+	}
+}

--- a/internal/notify/resource_scope_test.go
+++ b/internal/notify/resource_scope_test.go
@@ -12,8 +12,7 @@ import (
 // formatResourceLine returns what Format printed after "Resource: ", or "" when it
 // printed no resource line at all. Asserting on the rendered line (rather than on
 // the helper that builds it) is what makes these tests about the card a human reads.
-func formatResourceLine(t *testing.T, out string) string {
-	t.Helper()
+func formatResourceLine(out string) string {
 	for _, l := range strings.Split(out, "\n") {
 		if after, ok := strings.CutPrefix(l, "Resource: "); ok {
 			return after
@@ -24,8 +23,7 @@ func formatResourceLine(t *testing.T, out string) string {
 
 // formatScopeLine returns the Format metadata line carrying the cluster/tenant
 // facts, or "" when none was printed.
-func formatScopeLine(t *testing.T, out string) string {
-	t.Helper()
+func formatScopeLine(out string) string {
 	for _, l := range strings.Split(out, "\n") {
 		if strings.Contains(l, "cluster ") || strings.Contains(l, "tenant ") {
 			return l
@@ -120,6 +118,46 @@ func TestCardResourceLineOmitsNamespaceForUnnamespacedKinds(t *testing.T) {
 			want: "helm-release flux-system/harbor",
 		},
 		{
+			// A model spelling a kind group-qualified is spelling a REAL namespaced
+			// object, not naming a cloud resource. Treating '/' as "not Kubernetes"
+			// would strip a namespace that was correct — the regression this file
+			// exists to avoid, in the guise of the fix.
+			name: "a slash-qualified kind keeps its namespace",
+			res:  providers.Workload{Kind: "apps/Deployment", Namespace: "payments", Name: "checkout-api"},
+			want: "apps/Deployment payments/checkout-api",
+		},
+		{
+			name: "a kind/name spelling keeps its namespace",
+			res:  providers.Workload{Kind: "Deployment/checkout-api", Namespace: "payments", Name: "checkout-api"},
+			want: "Deployment/checkout-api payments/checkout-api",
+		},
+		{
+			// Same argument for whitespace: "Stateful Set" is a StatefulSet, which is
+			// namespaced, not a phrase naming something outside Kubernetes.
+			name: "a spaced kind spelling keeps its namespace",
+			res:  providers.Workload{Kind: "Stateful Set", Namespace: "payments", Name: "api"},
+			want: "Stateful Set payments/api",
+		},
+		{
+			// The kind is model-written free text, so it arrives padded; joining before
+			// trimming left a double space mid-line, which TrimSpace cannot reach.
+			name: "a padded kind is trimmed at the seam, not just at the ends",
+			res:  providers.Workload{Kind: " Node ", Namespace: "observability", Name: "ip-10-11-132-8.ec2.internal"},
+			want: "Node ip-10-11-132-8.ec2.internal",
+		},
+		{
+			name: "kind matching is case-insensitive",
+			res:  providers.Workload{Kind: "node", Namespace: "observability", Name: "ip-10-11-132-8.ec2.internal"},
+			want: "node ip-10-11-132-8.ec2.internal",
+		},
+		{
+			// The one cluster-scoped kind whose own identity lives in the namespace
+			// field: dropping the qualifier here would discard the object's name.
+			name: "a Namespace named with no workload inside it keeps its own name",
+			res:  providers.Workload{Kind: "Namespace", Namespace: "coder-engineering"},
+			want: "Namespace coder-engineering",
+		},
+		{
 			name: "an empty kind renders exactly as before",
 			res:  providers.Workload{Namespace: "payments", Name: "api"},
 			want: "payments/api",
@@ -139,20 +177,21 @@ func TestCardResourceLineOmitsNamespaceForUnnamespacedKinds(t *testing.T) {
 				Resource:  tc.res,
 			}
 
-			if got := formatResourceLine(t, Format(inv)); got != tc.want {
+			if got := formatResourceLine(Format(inv)); got != tc.want {
 				t.Errorf("Format resource line = %q, want %q", got, tc.want)
 			}
 
 			card := blocksText(t, summaryBlocks(inv))
-			if !strings.Contains(card, tc.want) {
-				t.Errorf("Slack card does not render %q:\n%s", tc.want, card)
+			// The metadata FIELD, not "somewhere on the card": a bare want of "Node" is
+			// a substring of the alert name "KubeNodeNotReady", so a card-wide Contains
+			// passes even when the field still carries the alert rule's namespace.
+			if !strings.Contains(card, "*Resource:*\\n"+tc.want) {
+				t.Errorf("Slack card Resource field is not %q:\n%s", tc.want, card)
 			}
 			// The header appends the same ref next to the tenant/cluster scope, so a
 			// forged namespace there is the same lie in a more prominent place.
-			if bad := tc.res.Namespace + "/" + tc.res.Name; !strings.Contains(tc.want, bad) && tc.res.Name != "" {
-				if strings.Contains(card, bad) {
-					t.Errorf("Slack card still stamps the alert rule's namespace on the resource (%q):\n%s", bad, card)
-				}
+			if bad := tc.res.Namespace + "/" + tc.res.Name; tc.res.Name != "" && !strings.Contains(tc.want, bad) && strings.Contains(card, bad) {
+				t.Errorf("Slack card still stamps the alert rule's namespace on the resource (%q):\n%s", bad, card)
 			}
 		})
 	}
@@ -168,33 +207,34 @@ func TestCardCollapsesDuplicateClusterIdentity(t *testing.T) {
 		cluster     string
 		tenant      string
 		wantCard    string // the Slack "Cluster" field value
+		wantHeader  string // the scope the Slack card HEADER renders (the fourth surface)
 		wantFormat  string // the Format metadata line
 		absentInAll string // text neither surface may contain ("" = no such check)
 	}{
 		{
 			name:    "tenant equals cluster: say it once",
 			cluster: "shared", tenant: "shared",
-			wantCard: "shared", wantFormat: "cluster shared", absentInAll: "shared · shared",
+			wantCard: "shared", wantHeader: "shared", wantFormat: "cluster shared", absentInAll: "shared · shared",
 		},
 		{
 			name:    "tenant differs from cluster: both are useful",
 			cluster: "tmem175-0", tenant: "tmem175",
-			wantCard: "tmem175 · tmem175-0", wantFormat: "cluster tmem175-0 · tenant tmem175",
+			wantCard: "tmem175 · tmem175-0", wantHeader: "tmem175", wantFormat: "cluster tmem175-0 · tenant tmem175",
 		},
 		{
 			name:    "equality is compared trimmed",
 			cluster: "shared", tenant: "  shared ",
-			wantCard: "shared", wantFormat: "cluster shared",
+			wantCard: "shared", wantHeader: "shared", wantFormat: "cluster shared",
 		},
 		{
 			name:     "cluster alone is unchanged",
 			cluster:  "eu-west-1",
-			wantCard: "eu-west-1", wantFormat: "cluster eu-west-1",
+			wantCard: "eu-west-1", wantHeader: "eu-west-1", wantFormat: "cluster eu-west-1",
 		},
 		{
 			name:     "tenant alone is unchanged",
 			tenant:   "platform",
-			wantCard: "platform", wantFormat: "tenant platform",
+			wantCard: "platform", wantHeader: "platform", wantFormat: "tenant platform",
 		},
 	}
 
@@ -207,7 +247,8 @@ func TestCardCollapsesDuplicateClusterIdentity(t *testing.T) {
 				Tenant:    tc.tenant,
 			}
 
-			if got := formatScopeLine(t, Format(inv)); !strings.HasSuffix(got, tc.wantFormat) {
+			out := Format(inv)
+			if got := formatScopeLine(out); !strings.HasSuffix(got, tc.wantFormat) {
 				t.Errorf("Format scope line = %q, want it to end with %q", got, tc.wantFormat)
 			}
 
@@ -215,11 +256,17 @@ func TestCardCollapsesDuplicateClusterIdentity(t *testing.T) {
 			if !strings.Contains(card, "*Cluster:*\\n"+tc.wantCard) {
 				t.Errorf("Slack Cluster field is not %q:\n%s", tc.wantCard, card)
 			}
+			// The header is the fourth scope surface and used to pick the tenant with
+			// its own hand-rolled fallback, so it could collapse differently from the
+			// field two lines above it.
+			if !strings.Contains(card, "KubeNodeNotReady — "+tc.wantHeader) {
+				t.Errorf("Slack card header scope is not %q:\n%s", tc.wantHeader, card)
+			}
 			if tc.absentInAll != "" {
 				if strings.Contains(card, tc.absentInAll) {
 					t.Errorf("Slack card repeats the same name twice (%q):\n%s", tc.absentInAll, card)
 				}
-				if out := Format(inv); strings.Contains(out, tc.absentInAll) {
+				if strings.Contains(out, tc.absentInAll) {
 					t.Errorf("Format repeats the same name twice (%q):\n%s", tc.absentInAll, out)
 				}
 			}

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -492,7 +492,10 @@ func summaryBlocks(inv providers.Investigation) []map[string]any {
 		if scope != "" {
 			loc = append(loc, scope)
 		}
-		if ref := inv.Resource.Ref(); ref != "" {
+		// resourceRef, not Resource.Ref(): the header is the most-read line on the
+		// card, so it is the last place to print a namespace a cluster-scoped or
+		// cloud object was never in. See resourceRef.
+		if ref := resourceRef(inv.Resource); ref != "" {
 			loc = append(loc, ref)
 		}
 		if len(loc) > 0 {
@@ -743,16 +746,22 @@ func metadataFields(inv providers.Investigation) []map[string]any {
 		}
 		add("Alert", name)
 	}
+	// One name, not the same name twice: scopeIdentity blanks the tenant when it only
+	// repeats the cluster ("shared · shared") and keeps both when they genuinely
+	// differ ("tmem175 · tmem175-0"). Format's metadata line shares the decision.
+	cluster, tenant := scopeIdentity(inv.Cluster, inv.Tenant)
 	scope := make([]string, 0, 2)
-	if inv.Tenant != "" {
-		scope = append(scope, escapeMrkdwn(inv.Tenant))
+	if tenant != "" {
+		scope = append(scope, escapeMrkdwn(tenant))
 	}
-	if inv.Cluster != "" {
-		scope = append(scope, escapeMrkdwn(inv.Cluster))
+	if cluster != "" {
+		scope = append(scope, escapeMrkdwn(cluster))
 	}
 	add("Cluster", strings.Join(scope, " · "))
-	if ref := inv.Resource.Ref(); ref != "" {
-		add("Resource", escapeMrkdwn(strings.TrimSpace(inv.Resource.Kind+" "+ref)))
+	// resourceLine, not Resource.Ref(): a cluster-scoped or cloud object has no
+	// namespace to qualify. See resourceRef.
+	if line := resourceLine(inv.Resource); line != "" {
+		add("Resource", escapeMrkdwn(line))
 	}
 	add("Started", slackDate(inv.StartedAt))
 	// Only rendered when the investigation actually established a change. change_ref

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -484,17 +484,18 @@ func summaryBlocks(inv providers.Investigation) []map[string]any {
 	head := "🔍 "
 	if inv.AlertName != "" {
 		head += inv.AlertName
-		scope := inv.Tenant
-		if scope == "" {
-			scope = inv.Cluster
-		}
+		// scopeIdentity here too, so the header collapses a tenant that only repeats
+		// the cluster exactly as the Cluster field does. cmp.Or then prefers the
+		// tenant, which is the narrower of the two names when both survive.
+		cluster, tenant := scopeIdentity(inv.Cluster, inv.Tenant)
+		scope := cmp.Or(tenant, cluster)
 		loc := make([]string, 0, 2)
 		if scope != "" {
 			loc = append(loc, scope)
 		}
-		// resourceRef, not Resource.Ref(): the header is the most-read line on the
-		// card, so it is the last place to print a namespace a cluster-scoped or
-		// cloud object was never in. See resourceRef.
+		// resourceRef, not Resource.Ref() — see resourceRef. The header is the
+		// most-read line, so it is the last place to print a namespace an object
+		// was never in.
 		if ref := resourceRef(inv.Resource); ref != "" {
 			loc = append(loc, ref)
 		}
@@ -746,9 +747,8 @@ func metadataFields(inv providers.Investigation) []map[string]any {
 		}
 		add("Alert", name)
 	}
-	// One name, not the same name twice: scopeIdentity blanks the tenant when it only
-	// repeats the cluster ("shared · shared") and keeps both when they genuinely
-	// differ ("tmem175 · tmem175-0"). Format's metadata line shares the decision.
+	// One name, not the same name twice — see scopeIdentity, which the header and
+	// Format's metadata line also go through.
 	cluster, tenant := scopeIdentity(inv.Cluster, inv.Tenant)
 	scope := make([]string, 0, 2)
 	if tenant != "" {
@@ -758,8 +758,7 @@ func metadataFields(inv providers.Investigation) []map[string]any {
 		scope = append(scope, escapeMrkdwn(cluster))
 	}
 	add("Cluster", strings.Join(scope, " · "))
-	// resourceLine, not Resource.Ref(): a cluster-scoped or cloud object has no
-	// namespace to qualify. See resourceRef.
+	// resourceLine, not Resource.Ref() — see resourceRef.
 	if line := resourceLine(inv.Resource); line != "" {
 		add("Resource", escapeMrkdwn(line))
 	}


### PR DESCRIPTION
Delivered cards on 2026-08-17/18 read **"Node observability/ip-10-11-132-8.ec2.internal"** and **"DBInstance observability/datagrok-aqemia-shared"**.

A Kubernetes Node is cluster-scoped and an RDS instance is not a Kubernetes object at all: `observability` is where kube-state-metrics and the alerting rule live, not where either object is. **The card sent an operator looking in a namespace the resource was never in.**

`Workload.Ref()` is namespace-first unconditionally, so every surface that renders a resource inherited the conflation. `resourceLine`/`resourceRef` decide per kind and are shared by the Slack card (header and metadata field) and `Format`, so the two cannot drift.

**Fail-safe by construction:** only a namespace *known* to be wrong is dropped — a cluster-scoped Kubernetes kind, a listed cloud kind, or a kind holding a character no Kubernetes kind can (`AWS::RDS::DBInstance`). Every unknown, unlisted or empty kind renders exactly as it does today. A dotted or hyphenated CRD spelling keeps its namespace: that is how a model spells a real namespaced object.

Also collapses "Cluster: shared · shared" to "Cluster: shared" when the tenant only repeats the cluster's name. Where they genuinely differ ("tmem175 · tmem175-0") the pair is the point, so only the equal case collapses.

### The review pass caught it committing the regression its own doc forbids

Dropping a namespace that was genuinely correct:

- **`notKubernetesShaped` keyed on `:`, `/` *or whitespace*.** A model writes the kind as free text (`submit_findings` declares a bare `{"kind":{"type":"string"}}`), so `"apps/Deployment"`, `"Deployment/checkout-api"` and `"Stateful Set"` are all real **namespaced** objects spelled badly — each lost its namespace. Narrowed to `:` alone, which still catches every motivating case, since `AWS::RDS::DBInstance` and an ARN both carry a colon anyway.
- **A Namespace object's own identity** arrives in the namespace field when the model names a namespace with no workload inside it — a shape `preferDiscoveredResource` deliberately preserves. Reading it as a foreign qualifier rendered "Resource: Namespace" and threw the name away.
- `resourceLine` trimmed the kind *after* joining, so a padded `" Node "` rendered with a double space at the seam.
- `scopeIdentity` compared trimmed but returned untrimmed when the two differed, leaving `"  shared · shared-0"` on the card.

### Scope

**This is the rendering half only.** The conflation upstream is real — `investigate.preferDiscoveredResource` defaults a namespace-less discovery to the alert's namespace, and that value still reaches recall matching, the curated entry's `resource:` frontmatter and the outcome ledger.

The incident-card golden is untouched: no fixture uses a cluster-scoped kind or an equal cluster/tenant pair, so the shipped screenshots still depict what the renderer draws.

Rebased onto current `main`; the `matrix_thread.go` conflict was additive — #526's `boundStamp` wrapper and this branch's `Ref()`-vs-`resourceRef` rationale are both kept.

Gate: `build` · `vet` · `go test ./... -race` · `gofmt -l .` silent · `golangci-lint run ./...` **0 issues**.
