### PR TITLE
fix(investigate): canonicalise the resource the MODEL names, not only the alert's

### DIFF
--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -1497,16 +1497,34 @@ func stampMatchedKnowledge(inv *providers.Investigation, best *providers.Matched
 // preferDiscoveredResource keeps the workload the investigation identified,
 // defaulting a missing namespace to the originating alert's, and falls back to the
 // alert workload only when the model named none.
+//
+// It is also the MODEL edge of resource-identity canonicalisation, and deliberately
+// the only one. `submit_findings.affected_resource` is the second place a resource
+// identity enters RunLore — an alert is the first, canonicalised at ingestion by
+// providers.ResolveWorkloadIdentity — and the model writes that name freely, in
+// practice often as the full ARN it read off the request labels in the seed prompt.
+// Delivered verbatim it produced an identity that did not canonicalise the way an
+// ingested one does, so a finding's recurrence key and dedup fingerprint disagreed
+// with the key of the alert that produced it.
+//
+// This function is the seam rather than tools.go's parse because reconciling the
+// model's resource against the alert's is already its whole job (the namespace
+// default above is the same act), and because a canonicalisation applied at the parse
+// would have no origin to reconcile against — which is exactly what makes the
+// difference between qualifying the identity and DOWNGRADING it. The model has no
+// alert labels, so providers.ReconcileWorkloadIdentity takes the fallback scope from
+// the originating workload: an account ingestion established survives a model that
+// spells the resource without one. Kubernetes is untouched on both sides.
 func preferDiscoveredResource(discovered, origin providers.Workload) providers.Workload {
 	if discovered.Name != "" && discovered.Namespace == "" {
 		discovered.Namespace = origin.Namespace
 	}
 	if discovered.Ref() == "" {
-		return origin
+		return origin // the originating workload, already resolved by its source adapter
 	}
 	// A discovered resource with a namespace but no name (Ref()=="ns") is kept as-is —
 	// the model named a namespace-scoped resource even without a specific workload.
-	return discovered
+	return providers.ReconcileWorkloadIdentity(discovered, origin)
 }
 
 // autoExecuting reports whether a remediation this investigation proposes could be

--- a/internal/investigate/model_resource_identity_test.go
+++ b/internal/investigate/model_resource_identity_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/Smana/runlore/internal/curator"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// cloudAlertWorkload is the RDS instance as INGESTION left it: the bare identifier
+// (an ARN has already been reduced) with the cloud scope on its own fields, which is
+// what providers.ResolveWorkloadIdentity produces for either spelling of the alert.
+func cloudAlertWorkload() providers.Workload {
+	return providers.Workload{Namespace: "observability", Name: "datagrok",
+		Region: "us-east-1", Account: "111111111111"}
+}
+
+// TestModelWrittenResourceIsCanonicalisedLikeAnIngestedOne is the model edge of the
+// identity split. `submit_findings.affected_resource` is a second place a resource
+// identity enters RunLore, and the model routinely writes the full ARN — it reads it
+// off the request labels in the seed prompt. Delivered verbatim, that finding is keyed
+// and deduped under a spelling no ingested alert ever produces, so one recurring fault
+// files a second knowledge-base entry and its recurrence count restarts.
+func TestModelWrittenResourceIsCanonicalisedLikeAnIngestedOne(t *testing.T) {
+	got := investigateWithSubmittedResource(t,
+		`{"kind":"","namespace":"observability","name":"arn:aws:rds:us-east-1:111111111111:db:datagrok"}`,
+		cloudAlertWorkload())
+	if got.Resource.Name != "datagrok" {
+		t.Errorf("a model-written ARN must be reduced to the identifier ingestion stores, got %q", got.Resource.Name)
+	}
+	if got.Resource.Account != "111111111111" || got.Resource.Region != "us-east-1" {
+		t.Errorf("the scope the ARN names must be lifted onto the workload, got account=%q region=%q",
+			got.Resource.Account, got.Resource.Region)
+	}
+}
+
+// TestModelWrittenResourceCannotDowngradeTheIngestedIdentity is the regression this
+// seam is most likely to cause, and the one that matters most: the model names the
+// resource WITHOUT the account (it has no labels to hand, and nothing obliges it to
+// spell one). If the model's value simply replaced the alert's, the account ingestion
+// established would be silently dropped and two AWS accounts' findings would collapse
+// onto one dedup fingerprint — the cross-account collision reopened from the model
+// edge.
+func TestModelWrittenResourceCannotDowngradeTheIngestedIdentity(t *testing.T) {
+	origin := cloudAlertWorkload()
+	got := investigateWithSubmittedResource(t,
+		`{"kind":"","namespace":"observability","name":"datagrok"}`, origin)
+	if got.Resource.Account != origin.Account || got.Resource.Region != origin.Region {
+		t.Fatalf("a model-written name must not blank the scope ingestion established: got account=%q region=%q, want %q/%q",
+			got.Resource.Account, got.Resource.Region, origin.Account, origin.Region)
+	}
+	// The consequence the field exists for: two accounts stay two findings.
+	other := cloudAlertWorkload()
+	other.Account = "222222222222"
+	got2 := investigateWithSubmittedResource(t,
+		`{"kind":"","namespace":"observability","name":"datagrok"}`, other)
+	if curator.DupFingerprint(got) == curator.DupFingerprint(got2) {
+		t.Fatal("two AWS accounts' findings share one dup fingerprint once the model names the resource — " +
+			"the model edge dropped the account and re-opened the collision")
+	}
+}
+
+// TestModelWrittenKubernetesResourceIsUntouched pins that nothing about Kubernetes
+// moves. namespace/name is the whole identity of a Kubernetes object, so a discovered
+// object must not acquire a cloud qualifier even when the alert that led there was a
+// cloud resource in a real AWS account.
+func TestModelWrittenKubernetesResourceIsUntouched(t *testing.T) {
+	got := investigateWithSubmittedResource(t,
+		`{"kind":"Pod","namespace":"tooling","name":"harbor-registry-59598dbd57-ltkzw"}`,
+		cloudAlertWorkload())
+	want := providers.Workload{Kind: "Pod", Namespace: "tooling", Name: "harbor-registry-59598dbd57-ltkzw"}
+	if got.Resource != want {
+		t.Fatalf("a discovered Kubernetes object must be delivered exactly as the model named it:\n got  %+v\n want %+v",
+			got.Resource, want)
+	}
+}
+
+// TestModelWrittenARNInAnotherAccountKeepsItsOwnScope pins the direction of the
+// reconciliation: the ARN names the resource, the origin names the alert that led
+// here, so an explicitly spelled account wins over the inherited one rather than
+// being ignored.
+func TestModelWrittenARNInAnotherAccountKeepsItsOwnScope(t *testing.T) {
+	got := investigateWithSubmittedResource(t,
+		`{"namespace":"observability","name":"arn:aws:rds:eu-west-1:333333333333:db:datagrok"}`,
+		cloudAlertWorkload())
+	if got.Resource.Account != "333333333333" || got.Resource.Region != "eu-west-1" {
+		t.Fatalf("an ARN the model spelled must name its own scope, got account=%q region=%q",
+			got.Resource.Account, got.Resource.Region)
+	}
+}
+
+// investigateWithSubmittedResource runs the real loop with a scripted model that
+// submits findings naming the given affected_resource, and returns the delivered
+// investigation. It goes through Investigate rather than calling the reconciliation
+// directly so the wire between submit_findings and the delivered identity is
+// exercised — a helper that skipped the loop would pass with the seam unhooked.
+func investigateWithSubmittedResource(t *testing.T, resourceJSON string, alert providers.Workload) providers.Investigation {
+	t.Helper()
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{{ID: "1", Name: submitFindingsName,
+			Args: `{"confidence":0.9,"verdict":"action_suggested","affected_resource":` + resourceJSON +
+				`,"root_causes":[{"summary":"connection pool exhausted by the nightly backfill","confidence":0.9}]}`}}},
+	}}
+	var got *providers.Investigation
+	li := &LoopInvestigator{
+		Model:      model,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OnComplete: func(inv providers.Investigation) { got = &inv },
+	}
+	req := Request{
+		Title:    "RDSHighCPU",
+		Workload: alert,
+		Labels:   map[string]string{"alertname": "RDSHighCPU", "account_id": alert.Account, "region": alert.Region},
+	}
+	if err := li.Investigate(context.Background(), req); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if got == nil {
+		t.Fatal("OnComplete not called")
+	}
+	return *got
+}

--- a/internal/providers/model_identity_test.go
+++ b/internal/providers/model_identity_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package providers
+
+import "testing"
+
+// TestReconcileWorkloadIdentityNeverDowngradesAnIngestedScope pins the MODEL edge of
+// the same canonicalisation ResolveWorkloadIdentity applies at ingestion.
+//
+// A resource identity enters RunLore from two places, and until now only one of them
+// canonicalised: an alert (ResolveWorkloadIdentity) and the model itself, which names
+// the affected resource in submit_findings. A model that echoes the full ARN back out
+// of the seed prompt produced an identity that keyed and matched differently from the
+// ingested one — the spelling split the alert edge closes, still open here.
+//
+// The model has no alert labels, so the fallback scope is the one the ORIGINATING
+// workload already carries. That is what makes this a reconciliation rather than a
+// second normalizer: the account ingestion established must survive a model that
+// spells the resource without it.
+func TestReconcileWorkloadIdentityNeverDowngradesAnIngestedScope(t *testing.T) {
+	// The alert workload as ingestion left it: bare identifier, scope on its own fields.
+	cloudOrigin := Workload{Namespace: "observability", Name: "datagrok",
+		Region: "us-east-1", Account: "111111111111"}
+	k8sOrigin := Workload{Kind: "HelmRelease", Namespace: "tooling", Name: "harbor"}
+
+	cases := []struct {
+		name   string
+		in     Workload
+		origin Workload
+		want   Workload
+	}{
+		{"a model-written short name keeps the account ingestion established",
+			Workload{Namespace: "observability", Name: "datagrok"}, cloudOrigin,
+			Workload{Namespace: "observability", Name: "datagrok", Region: "us-east-1", Account: "111111111111"}},
+		{"a model-written ARN is reduced exactly as an ingested one",
+			Workload{Namespace: "observability", Name: "arn:aws:rds:us-east-1:111111111111:db:datagrok"}, cloudOrigin,
+			Workload{Namespace: "observability", Name: "datagrok", Region: "us-east-1", Account: "111111111111"}},
+		{"the ARN wins a disagreement — it names the resource, the origin names the alert that led here",
+			Workload{Namespace: "observability", Name: "arn:aws:rds:eu-west-1:333333333333:db:datagrok"}, cloudOrigin,
+			Workload{Namespace: "observability", Name: "datagrok", Region: "eu-west-1", Account: "333333333333"}},
+		{"a deeper cloud resource found in the same investigation inherits its scope",
+			Workload{Namespace: "observability", Name: "datagrok-replica"}, cloudOrigin,
+			Workload{Namespace: "observability", Name: "datagrok-replica", Region: "us-east-1", Account: "111111111111"}},
+		{"an S3 ARN carries neither qualifier, so the origin supplies both",
+			Workload{Namespace: "observability", Name: "arn:aws:s3:::prod-logs/exports"}, cloudOrigin,
+			Workload{Namespace: "observability", Name: "prod-logs/exports", Region: "us-east-1", Account: "111111111111"}},
+		{"a scope the model named itself is authoritative",
+			Workload{Name: "datagrok", Account: "555555555555", Region: "sa-east-1"}, cloudOrigin,
+			Workload{Name: "datagrok", Account: "555555555555", Region: "sa-east-1"}},
+		{"a Kubernetes object never acquires a cloud scope, whatever the alert carried",
+			Workload{Kind: "Pod", Namespace: "apps", Name: "payment-api-59598dbd57-ltkzw"}, cloudOrigin,
+			Workload{Kind: "Pod", Namespace: "apps", Name: "payment-api-59598dbd57-ltkzw"}},
+		{"an ARN overrides the Kubernetes check — whatever kind the model claimed, it is a cloud resource",
+			Workload{Kind: "Deployment", Name: "arn:aws:rds:eu-west-1:333333333333:db:datagrok"}, k8sOrigin,
+			Workload{Kind: "Deployment", Name: "datagrok", Region: "eu-west-1", Account: "333333333333"}},
+		{"a name that merely contains arn is not one",
+			Workload{Kind: "Deployment", Namespace: "apps", Name: "arnica-exporter"}, cloudOrigin,
+			Workload{Kind: "Deployment", Namespace: "apps", Name: "arnica-exporter"}},
+		{"nothing to qualify: no name",
+			Workload{Namespace: "observability"}, cloudOrigin,
+			Workload{Namespace: "observability"}},
+		{"an unqualified origin adds nothing",
+			Workload{Namespace: "tooling", Name: "harbor-registry"}, k8sOrigin,
+			Workload{Namespace: "tooling", Name: "harbor-registry"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ReconcileWorkloadIdentity(c.in, c.origin)
+			if got != c.want {
+				t.Errorf("ReconcileWorkloadIdentity(%+v, %+v) = %+v, want %+v", c.in, c.origin, got, c.want)
+			}
+			if again := ReconcileWorkloadIdentity(got, c.origin); again != got {
+				t.Errorf("not idempotent: %+v became %+v", got, again)
+			}
+		})
+	}
+}
+
+// TestBothIdentityEdgesCanonicaliseIdentically is the property the review asked for:
+// ONE canonicalisation covering both the alert edge and the model edge, not two hooks
+// that can drift. Whatever the alert says about a resource, a model naming the SAME
+// resource must land on the same identity — otherwise the recurrence key of a finding
+// disagrees with the key of the alert that produced it.
+func TestBothIdentityEdgesCanonicaliseIdentically(t *testing.T) {
+	labels := map[string]string{"account_id": "111111111111", "region": "us-east-1"}
+	for _, spelling := range []string{
+		"datagrok",
+		"arn:aws:rds:us-east-1:111111111111:db:datagrok",
+	} {
+		ingested := ResolveWorkloadIdentity(Workload{Namespace: "observability", Name: spelling}, labels)
+		modelled := ReconcileWorkloadIdentity(Workload{Namespace: "observability", Name: spelling}, ingested)
+		if ingested != modelled {
+			t.Errorf("the two identity edges disagree on %q:\n ingested: %+v\n model:    %+v", spelling, ingested, modelled)
+		}
+	}
+}

--- a/internal/providers/resourceid.go
+++ b/internal/providers/resourceid.go
@@ -129,18 +129,73 @@ var cloudRegionLabels = []string{"region", "aws_region"}
 // that stamps account labels globally WOULD be qualified. It is the one shape this
 // cannot tell apart — there is no signal left — and the cost is one restarted
 // recurrence count, not a wrong answer.
+//
+// THE OTHER EDGE. An alert is not the only way a resource identity enters RunLore:
+// the model names one too, in submit_findings' `affected_resource`. That edge runs
+// ReconcileWorkloadIdentity, which differs only in where the fallback scope is read
+// from, and shares the rule itself (resolveWorkloadIdentity) so the two cannot drift.
 func ResolveWorkloadIdentity(w Workload, labels map[string]string) Workload {
+	return resolveWorkloadIdentity(w, labelValue(labels, cloudRegionLabels), labelValue(labels, cloudAccountLabels))
+}
+
+// ReconcileWorkloadIdentity is the MODEL-side half of that same chokepoint: it
+// canonicalises the resource an investigation NAMES in submit_findings'
+// `affected_resource`, reconciling it against the workload the investigation
+// originated on.
+//
+// WHY THIS EXISTS AT ALL. A resource identity enters RunLore from two edges, not one.
+// An alert is canonicalised at ingestion (ResolveWorkloadIdentity); the model is the
+// other edge, and it writes a name freely — routinely the full ARN it just read out
+// of the seed prompt, since the ARN travels verbatim on the request's labels. Left
+// alone, that produced an identity that did NOT canonicalise the way an ingested one
+// does: the finding's recurrence key and dedup fingerprint disagreed with the key of
+// the very alert that produced it, which is the spelling-dependent split the
+// ingestion edge exists to close, reopened from the other side.
+//
+// WHY THE ORIGIN AND NOT LABELS. The model has no alert labels to hand — it names a
+// resource, not a series — so the fallback scope is whatever the ORIGINATING workload
+// carries, which ingestion has already reconciled from the ARN and the labels alike.
+// The two edges therefore differ only in where the fallback scope comes from, and
+// share the canonicalisation itself (resolveWorkloadIdentity), which is the point:
+// one rule, reachable from both edges, rather than a second normalizer to drift
+// against.
+//
+// NO DOWNGRADE. This is the regression the seam is built to prevent, and it is why
+// the origin's scope is a FALLBACK rather than being ignored: a model that spells the
+// resource without its account must not blank an account ingestion established. So a
+// value present on either side survives, exactly as at ingestion — and where both are
+// present and disagree, the ARN wins, because it names the resource itself while the
+// origin names the alert that led here. A model naming a DEEPER cloud resource in the
+// same investigation inherits the scope too: the account is a property of the
+// environment being investigated, not of the one object the alert happened to fire on.
+//
+// Kubernetes is excluded by the shared core, so a discovered Kubernetes object never
+// acquires a cloud qualifier from a cloud-scoped origin and keys byte-identically.
+func ReconcileWorkloadIdentity(w, origin Workload) Workload {
+	return resolveWorkloadIdentity(w, origin.Region, origin.Account)
+}
+
+// resolveWorkloadIdentity is the one canonicalisation both identity edges run: the
+// name is reduced to its bare resource identifier and the cloud scope is recorded on
+// its own fields, taken from the ARN first and from the caller's fallback scope
+// otherwise. A scope already set on w is authoritative and is never overwritten.
+//
+// It is unexported and takes the fallback as two plain strings on purpose: the two
+// edges disagree only about where that scope is READ from (alert labels at ingestion,
+// the originating workload for a model-written resource), and nothing else about the
+// rule may differ between them.
+func resolveWorkloadIdentity(w Workload, region, account string) Workload {
 	if w.Name == "" {
 		return w // nothing to qualify: there is no resource
 	}
-	bare, region, account, isARN := parseARN(w.Name)
+	bare, arnRegion, arnAccount, isARN := parseARN(w.Name)
 	if isARN {
 		w.Name = bare
 	} else if w.Kind != "" {
 		return w // a Kubernetes object: namespace/name is the whole identity
 	}
-	w.Region = cmp.Or(w.Region, region, labelValue(labels, cloudRegionLabels))
-	w.Account = cmp.Or(w.Account, account, labelValue(labels, cloudAccountLabels))
+	w.Region = cmp.Or(w.Region, arnRegion, region)
+	w.Account = cmp.Or(w.Account, arnAccount, account)
 	return w
 }
 

--- a/website/content/docs/concepts/learning-loop.md
+++ b/website/content/docs/concepts/learning-loop.md
@@ -225,7 +225,13 @@ Why each gate exists:
   label) is unqualified and still matches an ARN-form entry in any account: an absent
   qualifier means *unknown*, not *different*, which is what keeps entries already
   filed under a full ARN reachable. So if you run one instance name in two accounts,
-  make sure the account label reaches the alert. A **workload-less**
+  make sure the account label reaches the alert.
+
+  The alert is not the only way a resource is named: the investigation names one too,
+  in its findings. That value runs the same reduction, reconciled against the alert's
+  identity — so a model that echoes back the full ARN it read in the prompt cannot
+  file the entry under a second spelling, and a model that writes the bare name cannot
+  drop an account the alert established. A **workload-less**
   incident (PagerDuty carries no Kubernetes namespace/name) agrees only with entries
   that are themselves resource-less — the weakest ("scopeless") tier: it always
   requires `solo_floor` + `min_score`, starts at reduced confidence, and


### PR DESCRIPTION
Follow-on to #535, which canonicalised the resource identity an **alert** carries. The model writes one too, and it was left alone.

`submit_findings` lets the model name the resource it concluded about, and that value goes into the same identity keys — recall's structural gate, the dedup fingerprint, the curated entry's `resource:` frontmatter. So a model that spelled an RDS instance as its ARN while the alert used the bare identifier reintroduced exactly the split #535 closed, one layer later.

The same `providers.ParseResourceID` path now normalises it, so both writers agree on one spelling and neither can reopen the two-identities-for-one-resource defect.

Replanted onto current `main`: its parent branch was squash-merged as #535, so this carries only its own commit.

Gate: `build` · `vet` · `go test ./... -race` · `gofmt -l .` silent · `golangci-lint run ./...` **0 issues**.
