### PR TITLE
fix(curate): group a recurrence by resource identity, not by its spelling

### DIFF
--- a/internal/curate/recurrence.go
+++ b/internal/curate/recurrence.go
@@ -21,6 +21,13 @@ const gapTitlePrefix = "knowledge-gap: "
 // from the outcome ledger every run and opens an issue only when no knowledge-gap
 // issue for that pattern already exists — so re-running never double-opens (no mutable
 // store or watermark).
+//
+// ONE-OFF MIGRATION: patterns are grouped (and titled) by resource IDENTITY rather
+// than by the raw persisted string — see recurrencePattern. A gap issue already open
+// under a pod-scoped or ARN-spelled title no longer matches the pattern it guarded,
+// so at most one duplicate issue can be opened per affected pattern on the first run
+// after the upgrade; thereafter the new title guards it. Titles for a plain
+// namespace/name are byte-identical and are unaffected.
 type Recurrence struct {
 	Forge  Forge
 	Ledger interface {
@@ -168,9 +175,69 @@ func reasonSuffix(reason string) string {
 
 // recurrencePattern groups unresolved incidents by the affected resource, falling
 // back to the incident title when no resource was identified.
+//
+// The resource is grouped by its IDENTITY, not by the string it was persisted as —
+// the same rule the rest of the system keys and matches on. Two of the ways one
+// resource is spelled two ways used to open two buckets here, so one recurring fault
+// looked like two or three first sightings, each short of the threshold, and the
+// knowledge gap was never reported:
+//
+//   - The volatile pod-hash suffix (CORE-681). A pod-scoped alert carries the full
+//     pod name (KubePodNotReady has only a `pod` label), so three pods of one
+//     Deployment counted as three resources. resourceAgrees and curator.IncidentKey
+//     have forgiven this since CORE-681; this pass did not.
+//   - The ARN and the short spelling of a cloud resource. inv.Resource is
+//     model-written free text, so whichever spelling the model echoed back from the
+//     seed prompt is what the ledger holds.
+//
+// The pattern is also the issue TITLE, and the title is this pass's idempotency key
+// against already-open issues, so the grouping key and the rendered key are
+// deliberately the same value.
 func recurrencePattern(e outcome.Episode) string {
 	if e.Resource != "" {
-		return e.Resource
+		return resourceIdentityRef(e.Resource)
 	}
 	return e.Title
+}
+
+// resourceIdentityRef rewrites a rendered "namespace/name" resource ref to the
+// identity it should be GROUPED by, reusing providers.ParseResourceID — the single
+// source of truth the recall gate (investigate.refsAgree) and the curator keys
+// (curator.IncidentKey, DupFingerprint) already read. It restates none of it: a
+// private fourth copy of resource normalisation is exactly the drift this programme
+// has twice found in the BM25 query builders.
+//
+// Only the NAME half is rewritten, and the ref is cut on the FIRST "/" for the same
+// reason refsAgree is: a Kubernetes namespace never contains one, so a slash-style
+// ARN ("…:instance/i-0abc") survives whole in the name half. A ref with no "/" is a
+// bare namespace and is returned untouched, as refsAgree also treats it.
+//
+// THE ACCOUNT IS APPENDED WHEN THE NAME CARRIED ONE, with "@" and only when present
+// — the same shape DupFingerprint qualifies its ref with, so this is not a third
+// rule. It is what stops two AWS accounts hosting an instance of the same name from
+// grooming as one recurrence, which matters because collapsing an ARN to its bare
+// identifier is precisely what forces the two accounts equal (see
+// providers.NormalizeResourceName). A Kubernetes ref never has an account, so its
+// pattern grows no suffix and its bytes are unchanged.
+//
+// KNOWN RESIDUAL. IncidentKey and DupFingerprint read the account off the Workload
+// FIELD, which ingestion fills under EITHER spelling, so they qualify without
+// re-splitting the spellings. Nothing of the sort is available here: outcome.Episode
+// carries the resource as a rendered ref and Workload.Ref() renders namespace/name
+// only, so the account exists only where the persisted spelling was an ARN. An
+// ARN-spelled episode therefore knows its account and a short-spelled one does not,
+// and the two group apart — the same residual the base change pinned, resolved the
+// same way. Splitting costs a duplicate gap issue; collapsing would groom one
+// account's production incident under another account's.
+func resourceIdentityRef(ref string) string {
+	namespace, name, scoped := strings.Cut(ref, "/")
+	if !scoped {
+		return ref // a bare namespace: no name half to resolve
+	}
+	id := providers.ParseResourceID(name)
+	out := namespace + "/" + id.Name
+	if id.Account != "" {
+		out += "@" + id.Account
+	}
+	return out
 }

--- a/internal/curate/resource_identity_test.go
+++ b/internal/curate/resource_identity_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package curate
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/Smana/runlore/internal/outcome"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+const (
+	rdsShortRef = "observability/datagrok-aqemia-shared"
+	rdsARNRefA  = "observability/arn:aws:rds:us-east-1:111111111111:db:datagrok-aqemia-shared"
+	rdsARNRefB  = "observability/arn:aws:rds:us-east-1:222222222222:db:datagrok-aqemia-shared"
+)
+
+// gapTitles runs the pass over eps and returns the knowledge-gap issue titles it
+// opened, sorted so a map-ordered pass compares deterministically.
+func gapTitles(t *testing.T, eps []outcome.Episode) []string {
+	t.Helper()
+	gf := &gapForge{recordingForge: &recordingForge{}}
+	r := Recurrence{Forge: gf, Ledger: fakeLedger{eps: eps}, Threshold: 3, Log: discardLog()}
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	got := append([]string(nil), gf.openedTitles...)
+	sort.Strings(got)
+	return got
+}
+
+// TestRecurrenceGroupsPodsOfOneDeployment is the CORE-681 half of the finding. Three
+// pods of ONE Deployment recur; a pod-scoped alert (KubePodNotReady carries only a
+// `pod` label) arrives with the full pod name, so grouping on the raw ref read three
+// unrelated resources, each one short of the threshold, and the knowledge gap was
+// never reported at all. resourceAgrees and curator.IncidentKey already forgive this
+// suffix; this pass did not.
+func TestRecurrenceGroupsPodsOfOneDeployment(t *testing.T) {
+	eps := []outcome.Episode{
+		{Resource: "tooling/harbor-registry-59598dbd57-ltkzw", Resolved: false},
+		{Resource: "tooling/harbor-registry-59598dbd57-9q2xd", Resolved: false},
+		{Resource: "tooling/harbor-registry-7f4b9c8d6-mnp4q", Resolved: false},
+	}
+	if got := gapTitles(t, eps); len(got) != 1 || got[0] != "knowledge-gap: tooling/harbor-registry" {
+		t.Fatalf("three pods of one Deployment must be one recurrence, got %v", got)
+	}
+}
+
+// TestRecurrenceKubernetesRefUnchanged is the regression this change is most likely
+// to cause, so the expected bytes are written out literally. A plain namespace/name
+// ref carries no ARN scaffolding and no pod hash, so its pattern — which is also the
+// issue TITLE, and therefore the idempotency key against already-open issues — must
+// be byte-identical to what it was.
+func TestRecurrenceKubernetesRefUnchanged(t *testing.T) {
+	for _, ref := range []string{"apps/web", "apps/redis-cache", "apps"} {
+		if got := gapTitles(t, unresolved(ref, 3)); len(got) != 1 || got[0] != "knowledge-gap: "+ref {
+			t.Fatalf("Kubernetes ref %q must group unchanged, got %v", ref, got)
+		}
+	}
+}
+
+// TestRecurrenceGroupsTheTwoSpellingsOfOneResource is the cloud half of the finding.
+// One S3 bucket reaches the ledger under its ARN on one investigation and under its
+// bare name on the next (inv.Resource is model-written, so whichever spelling the
+// model echoed from the seed prompt is what was persisted). Grouped as raw strings
+// those were two unrelated resources: one recurring fault, two buckets of two, and
+// no gap issue.
+func TestRecurrenceGroupsTheTwoSpellingsOfOneResource(t *testing.T) {
+	eps := append(unresolved("observability/arn:aws:s3:::prod-logs", 2), unresolved("observability/prod-logs", 1)...)
+	if got := gapTitles(t, eps); len(got) != 1 || got[0] != "knowledge-gap: observability/prod-logs" {
+		t.Fatalf("the ARN and short spellings of one bucket must be one recurrence, got %v", got)
+	}
+}
+
+// TestRecurrenceSplitsTwoAWSAccounts pins the split the base change established. Two
+// AWS accounts can host an instance under the same name and those are genuinely
+// different databases, so collapsing an ARN to its bare identifier must not fuse
+// them — the curation backlog would then groom two production incidents as one.
+func TestRecurrenceSplitsTwoAWSAccounts(t *testing.T) {
+	eps := append(unresolved(rdsARNRefA, 3), unresolved(rdsARNRefB, 3)...)
+	want := []string{
+		"knowledge-gap: " + rdsShortRef + "@111111111111",
+		"knowledge-gap: " + rdsShortRef + "@222222222222",
+	}
+	got := gapTitles(t, eps)
+	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("two accounts must stay two recurrences:\n got:  %v\n want: %v", got, want)
+	}
+}
+
+// TestRecurrenceAccountResidualKeepsTheSpellingsApart pins what this layer CANNOT
+// recover, so nobody reads the two tests above as a full fix. outcome.Episode carries
+// the resource as a rendered ref string and Workload.Ref() drops Account, so the
+// account is present only when the persisted spelling was an ARN. An ARN-spelled
+// firing therefore knows its account and a short-spelled one does not, and no single
+// grouping key can fuse the two spellings without re-fusing the two accounts. The
+// account is kept — splitting costs a duplicate gap issue, collapsing costs grooming
+// one account's incident under another's.
+func TestRecurrenceAccountResidualKeepsTheSpellingsApart(t *testing.T) {
+	eps := append(unresolved(rdsARNRefA, 3), unresolved(rdsShortRef, 3)...)
+	want := []string{
+		"knowledge-gap: " + rdsShortRef,
+		"knowledge-gap: " + rdsShortRef + "@111111111111",
+	}
+	got := gapTitles(t, eps)
+	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("the qualified/unqualified residual is not what was pinned:\n got:  %v\n want: %v", got, want)
+	}
+}
+
+// TestRecurrenceSuppressedEscalationGroupsPodFamily checks the suppressed
+// (closed-unmerged) branch reads the same identity: it keys its COUNT on the
+// fingerprint but renders and idempotency-guards on the pattern, so a pod-scoped
+// escalation must title itself with the controller family too.
+func TestRecurrenceSuppressedEscalationGroupsPodFamily(t *testing.T) {
+	eps := []outcome.Episode{
+		{Resource: "tooling/harbor-registry-59598dbd57-ltkzw", DupFingerprint: "fp", Resolved: false},
+		{Resource: "tooling/harbor-registry-59598dbd57-9q2xd", DupFingerprint: "fp", Resolved: false},
+		{Resource: "tooling/harbor-registry-7f4b9c8d6-mnp4q", DupFingerprint: "fp", Resolved: false},
+	}
+	gf := &gapForge{recordingForge: &recordingForge{}}
+	r := Recurrence{
+		Forge:      gf,
+		Ledger:     fakeLedger{eps: eps},
+		Threshold:  3,
+		Suppressed: fakeSuppression{set: map[string]SuppressedEntry{"fp": {Fingerprint: "fp", PRNumber: 7}}},
+		Log:        discardLog(),
+	}
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(gf.openedTitles) != 1 || gf.openedTitles[0] != "knowledge-gap: tooling/harbor-registry" {
+		t.Fatalf("the escalation must name the controller family, got %v", gf.openedTitles)
+	}
+}
+
+// TestRecurrencePatternReusesProvidersIdentity asserts the grouping key is the shared
+// helper's output and not a private restatement of it: a fourth copy of resource
+// normalisation is exactly the drift this programme has already found twice.
+func TestRecurrencePatternReusesProvidersIdentity(t *testing.T) {
+	for _, name := range []string{
+		"harbor-registry-59598dbd57-ltkzw",
+		"arn:aws:s3:::prod-logs",
+		"arn:aws:ec2:eu-west-1:111111111111:instance/i-0abc",
+		"redis-cache",
+	} {
+		got := recurrencePattern(outcome.Episode{Resource: "ns/" + name})
+		id := providers.ParseResourceID(name)
+		want := "ns/" + id.Name
+		if id.Account != "" {
+			want += "@" + id.Account
+		}
+		if got != want {
+			t.Fatalf("recurrencePattern(%q) = %q, want %q (providers.ParseResourceID)", name, got, want)
+		}
+	}
+}


### PR DESCRIPTION
The third consumer of resource identity, and the one that decides whether a fault is *seen before*.

#535 fixed the matching side, but recurrence grouping still compared spellings. So the same RDS instance arriving once as a bare `DBInstanceIdentifier` and once as a full ARN produced two first sightings, the recurrence gate never armed, and the "seen before" card never rendered — the exact operator-visible symptom that started this line of work.

Grouping now goes through the same identity path, so one recurring fault is one recurrence regardless of which spelling each firing used.

Replanted onto current `main`: its parent branch was squash-merged as #535, so this carries only its own commit.

Gate: `build` · `vet` · `go test ./... -race` · `gofmt -l .` silent · `golangci-lint run ./...` **0 issues**.