### PR TITLE
feat(providers): carry namespaced-ness from discovery, not a kind list

### DIFF
--- a/internal/app/curator.go
+++ b/internal/app/curator.go
@@ -160,7 +160,8 @@ func BuildReinvestigator(cfg *config.Config, deps *Deps, metrics *telemetry.Metr
 			MaxTokensPerInvestigation: cfg.Investigation.MaxTokensPerInvestigation,
 			MaxCostPerInvestigation:   cfg.Investigation.MaxCostPerInvestigation,
 			Timeout:                   cfg.Investigation.Timeout.Std(),
-			KBMatchScore:              kbMatchScore(recall), // visibility bar tracks the configured recall floor
+			KBMatchScore:              kbMatchScore(recall),       // visibility bar tracks the configured recall floor
+			KindScope:                 kindScoperFromTools(tools), // discovery decides namespaced-ness, not a kind list
 			OnComplete:                func(inv providers.Investigation) { res, got = inv, true },
 		}
 		if err := li.Investigate(ctx, req); err != nil {

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -668,6 +668,11 @@ func BuildInvestigator(ctx context.Context, cfg *config.Config, deps *Deps, appr
 		Actions:    actions,
 		Recall:     recall,
 		Recurrence: recurrence,
+		// The cluster's own answer for the delivered resource's kind, taken from the
+		// resource_spec tool's reader so the process keeps one memoised discovery
+		// client. nil when no cluster is reachable, which leaves every workload at
+		// ScopeUnknown and every consumer on its prior behaviour.
+		KindScope: kindScoperFromTools(tools),
 		// Unconditional, unlike the opt-in cooldown above: the seed's known-recurrence
 		// block needs a trigger's history whether or not suppression is on. A disabled
 		// ledger answers with zero values (as with cur.Confirmations).

--- a/internal/app/investigate_cmd.go
+++ b/internal/app/investigate_cmd.go
@@ -83,7 +83,8 @@ func RunInvestigate(args []string) error {
 		MaxTokensPerInvestigation: cfg.Investigation.MaxTokensPerInvestigation,
 		MaxCostPerInvestigation:   cfg.Investigation.MaxCostPerInvestigation,
 		Timeout:                   cfg.Investigation.Timeout.Std(),
-		KBMatchScore:              kbMatchScore(recall), // visibility bar tracks the configured recall floor
+		KBMatchScore:              kbMatchScore(recall),       // visibility bar tracks the configured recall floor
+		KindScope:                 kindScoperFromTools(tools), // discovery decides namespaced-ness, not a kind list
 		OnComplete:                func(inv providers.Investigation) { result = &inv },
 	}
 	title := *alert

--- a/internal/app/kind_scope_wiring_test.go
+++ b/internal/app/kind_scope_wiring_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/providers/cluster"
+)
+
+// scopelessReader is a spec reader with no discovery behind it — the shape a future
+// implementation (a recorded fixture, a test double, another backend) could take.
+type scopelessReader struct{}
+
+func (scopelessReader) ResourceSpec(context.Context, providers.ResourceSpecQuery) (providers.ResourceSpec, error) {
+	return providers.ResourceSpec{}, nil
+}
+
+// TestKindScoperForRecognisesTheDiscoveryBackedReader pins the wiring hop that can
+// break in total silence.
+//
+// The investigator reaches the cluster's namespaced-ness answer through a TYPE
+// ASSERTION on the spec reader, for the same reason resource_spec reaches Invalidate()
+// through one — and a type assertion that stops matching does not fail to compile. It
+// just stops resolving scopes, every delivered Workload falls back to ScopeUnknown, and
+// the renderer silently returns to guessing from hardcoded kind lists. Nothing else
+// would notice.
+func TestKindScoperForRecognisesTheDiscoveryBackedReader(t *testing.T) {
+	if ks := kindScoperFor(cluster.NewSpecReader(nil, nil)); ks == nil {
+		t.Fatal("the discovery-backed spec reader no longer answers as a providers.KindScoper: " +
+			"delivered resources now carry no scope and the card is back to guessing from kind names")
+	}
+	if ks := kindScoperFor(nil); ks != nil {
+		t.Error("no reader must mean no scoper — a non-nil interface holding nothing would be " +
+			"asked for scopes it cannot resolve")
+	}
+	if ks := kindScoperFor(scopelessReader{}); ks != nil {
+		t.Error("a reader with no discovery behind it must not be advertised as a scoper")
+	}
+}
+
+// TestKindScoperFromToolsReusesTheOneSpecReader pins where the scoper comes from.
+//
+// It is deliberately taken from the ALREADY-BUILT resource_spec tool rather than by
+// calling BuildResourceSpecReader a second time: a second call means a second memoised
+// discovery client, so the process pays two full discovery fan-outs and the two caches
+// go stale independently. Deps exists to stop exactly that class of duplication for the
+// catalog; the same argument applies here.
+func TestKindScoperFromToolsReusesTheOneSpecReader(t *testing.T) {
+	reader := cluster.NewSpecReader(nil, nil)
+	tools := []investigate.Tool{
+		investigate.KBSearchTool{},
+		investigate.ResourceSpecTool{Reader: reader},
+	}
+	ks := kindScoperFromTools(tools)
+	if ks == nil {
+		t.Fatal("the scoper must be taken from the registered resource_spec tool")
+	}
+	if ks != providers.KindScoper(reader) {
+		t.Error("the scoper must be the SAME reader the tool holds, not a second discovery client")
+	}
+	// No cluster ⇒ no resource_spec tool ⇒ nothing to ask, which is the ordinary case
+	// for an eval run, the demo, and any local run without a kubeconfig.
+	if ks := kindScoperFromTools([]investigate.Tool{investigate.KBSearchTool{}}); ks != nil {
+		t.Error("with no resource_spec tool registered there is no discovery to reach")
+	}
+	if ks := kindScoperFromTools(nil); ks != nil {
+		t.Error("no tools must mean no scoper")
+	}
+}
+
+// TestBuildInvestigatorWiresTheKindScoper pins the last hop: the scoper reaching the
+// LOOP. Everything else can be correct — discovery answering, the renderer preferring
+// the carried scope — and the feature still be a complete no-op if the field is never
+// set on the investigator that runs.
+func TestBuildInvestigatorWiresTheKindScoper(t *testing.T) {
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "nonexistent-kubeconfig"))
+	log := discardLog()
+	cfg := &config.Config{Model: config.Model{
+		Provider: "openai", BaseURL: "http://vllm:8000/v1", Model: "test-model",
+	}}
+	deps := BuildDeps(context.Background(), cfg, nil, nil, nil, log)
+	if deps == nil {
+		t.Fatal("BuildDeps returned nil for a configured model")
+	}
+	// No cluster here (the kubeconfig above does not exist), so resource_spec is not
+	// registered and there is nothing to scope with — the ordinary degraded case. Stand
+	// one in, exactly as the production wiring would have.
+	reader := cluster.NewSpecReader(nil, nil)
+	deps.Tools = append(deps.Tools, investigate.ResourceSpecTool{Reader: reader})
+
+	inv, _, _, err := BuildInvestigator(context.Background(), cfg, deps, nil, nil, nil, nil, nil, log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	li, ok := inv.(*investigate.LoopInvestigator)
+	if !ok {
+		t.Fatalf("want *LoopInvestigator, got %T", inv)
+	}
+	if li.KindScope == nil {
+		t.Fatal("the investigator carries no KindScope: every delivered resource falls back to " +
+			"ScopeUnknown and the card guesses from kind names again")
+	}
+}

--- a/internal/app/kube.go
+++ b/internal/app/kube.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/Smana/runlore/internal/investigate"
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/providers/cluster"
 )
@@ -79,4 +80,42 @@ func BuildResourceSpecReader(log *slog.Logger) providers.ResourceSpecReader {
 	// assertion on Invalidate(); TestResourceSpecDiscoveryIsInvalidatable pins that the
 	// client wired here satisfies it.
 	return cluster.NewSpecReader(dc, memory.NewMemCacheClient(disco))
+}
+
+// kindScoperFor exposes the discovery-backed scope resolver a spec reader also
+// provides, or nil when it provides none.
+//
+// The assertion is what lets Workload.Scope be populated from the API server's own
+// discovery instead of guessed downstream from a kind's NAME — and it is silent when it
+// stops holding: nothing fails to compile, delivered resources simply carry
+// ScopeUnknown again and every consumer falls back to its old behaviour. That is safe,
+// which is exactly why it takes a test to notice — see kind_scope_wiring_test.go.
+//
+// Nil in, nil out — a nil reader must not become a non-nil interface holding nothing.
+func kindScoperFor(sr providers.ResourceSpecReader) providers.KindScoper {
+	if sr == nil {
+		return nil
+	}
+	ks, ok := sr.(providers.KindScoper)
+	if !ok {
+		return nil
+	}
+	return ks
+}
+
+// kindScoperFromTools takes the scope resolver from the resource_spec tool already
+// registered, or nil when none was (no cluster, no discovery — an eval replay, the
+// demo, a local run without a kubeconfig).
+//
+// Reading it back off the built tool rather than calling BuildResourceSpecReader again
+// keeps ONE memoised discovery client in the process. A second one would mean a second
+// full discovery fan-out and two caches going stale independently — the same
+// build-it-twice defect Deps was introduced to fix for the catalog.
+func kindScoperFromTools(tools []investigate.Tool) providers.KindScoper {
+	for _, t := range tools {
+		if rst, ok := t.(investigate.ResourceSpecTool); ok {
+			return kindScoperFor(rst.Reader)
+		}
+	}
+	return nil
 }

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -197,6 +197,19 @@ type LoopInvestigator struct {
 	Recurrence *RecurrenceGate               // optional: suppress re-investigating a just-answered trigger
 	Verify     bool                          // run an adversarial review of root causes before delivery
 
+	// KindScope asks the cluster's own discovery whether the delivered resource's kind
+	// is namespaced, so the answer travels with the workload (providers.Workload.Scope)
+	// instead of being re-guessed from the kind's NAME by whoever renders it. No list of
+	// names can be right for arbitrary CRDs — ACK and Crossplane v2 ship namespaced CRDs
+	// spelled like cluster-scoped and cloud things — and this process already reads the
+	// discovery that settles it.
+	//
+	// Optional, and its absence is ordinary rather than exceptional: no cluster access,
+	// an eval replay, the demo. nil (and any lookup that fails or does not resolve)
+	// leaves Scope at ScopeUnknown, which every consumer reads as "keep doing what you
+	// did before" — never as "cluster-scoped".
+	KindScope providers.KindScoper
+
 	// TriggerHistory reads the outcome ledger's per-TriggerKey index: how often this
 	// incident has been investigated and what the last CONCLUSIVE run concluded. Read
 	// once per investigation and shared by its two consumers — the Recurrence gate's
@@ -395,6 +408,12 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 		// chokepoint — every exit (happy path, recall short-circuit, timeout, refusal, budget
 		// kill, max-steps) routes through it, so no delivered investigation can miss it.
 		inv.InvestigationStartedAt = start
+		// Stamp what the cluster itself says about the delivered resource's kind, here
+		// for the same reason as the line above: finish is the single terminal-delivery
+		// chokepoint, so the recall short-circuit and every synthetic result carry the
+		// fact too — and a card rendered from a recalled answer would otherwise be the
+		// one place still guessing.
+		inv.Resource = li.scopeResource(ctx, inv.Resource)
 		// Every caller sets `result` BEFORE calling finish, so the usage histograms carry
 		// the same completion label the deferred completion metric records — which is what
 		// lets a dashboard read a recall's cost and a full loop's off the same instrument
@@ -1492,6 +1511,40 @@ func stampMatchedKnowledge(inv *providers.Investigation, best *providers.Matched
 		return
 	}
 	inv.MatchedKnowledge = best
+}
+
+// scopeResource stamps the cluster's own answer for w's kind onto w, so the fact
+// travels with the workload instead of being inferred downstream from the kind's name.
+//
+// Every way of not knowing lands on the same conservative outcome — Scope untouched,
+// i.e. ScopeUnknown — and they are all ordinary: no scoper wired (no cluster access, an
+// eval run, the demo), a finding that named no kind, discovery unreachable, or a kind
+// this cluster does not serve (every non-Kubernetes resource RunLore reasons about, and
+// that is the case the renderer's cloud-kind list still exists to cover). None of them
+// may fail the investigation, and none may put a guess on the workload: reading unknown
+// as cluster-scoped would strip a namespace that was a fact about the object, which is
+// the regression the whole area exists to prevent.
+//
+// The kind is TRIMMED before it is asked about, because it is model-written free text
+// and arrives padded — " Node " must resolve like "Node". The workload's own Kind is
+// left exactly as written: it is what the card prints, and rewriting it here would be a
+// silent second change riding along with this one.
+func (li *LoopInvestigator) scopeResource(ctx context.Context, w providers.Workload) providers.Workload {
+	kind := strings.TrimSpace(w.Kind)
+	if li.KindScope == nil || kind == "" {
+		return w
+	}
+	scope, err := li.KindScope.KindScope(ctx, kind)
+	if err != nil {
+		// Debug, not Warn: on a cluster RunLore cannot reach this fires on every
+		// investigation, and the consequence is that a card renders exactly as it did
+		// before the field existed.
+		li.Log.Debug("resource scope unavailable; the card falls back to its kind lists",
+			"kind", kind, "err", err)
+		return w
+	}
+	w.Scope = scope
+	return w
 }
 
 // preferDiscoveredResource keeps the workload the investigation identified,

--- a/internal/investigate/resource_scope_stamp_test.go
+++ b/internal/investigate/resource_scope_stamp_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// stubScoper answers from a fixed table, so the loop's use of discovery is testable
+// without an API server. err, when set, models discovery being unreachable.
+type stubScoper struct {
+	scopes map[string]providers.ResourceScope
+	err    error
+	calls  int
+}
+
+func (s *stubScoper) KindScope(_ context.Context, kind string) (providers.ResourceScope, error) {
+	s.calls++
+	if s.err != nil {
+		return providers.ScopeUnknown, s.err
+	}
+	return s.scopes[kind], nil
+}
+
+// scopeLoop runs one investigation whose submit_findings names args, and returns the
+// resource the loop delivered.
+func scopeLoop(t *testing.T, ks providers.KindScoper, findings string, origin providers.Workload) providers.Workload {
+	t.Helper()
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{{ID: "1", Name: submitFindingsName, Args: findings}}},
+	}}
+	var got *providers.Investigation
+	li := &LoopInvestigator{
+		Model:      model,
+		KindScope:  ks,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OnComplete: func(inv providers.Investigation) { got = &inv },
+	}
+	req := Request{
+		Title:       "RDSInstanceHighCPU",
+		Fingerprint: "fp-scope",
+		Workload:    origin,
+		Labels:      map[string]string{"alertname": "RDSInstanceHighCPU"},
+	}
+	if err := li.Investigate(context.Background(), req); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if got == nil {
+		t.Fatal("OnComplete not called")
+	}
+	return got.Resource
+}
+
+// TestLoopStampsTheDiscoveredScopeOnTheResource closes the wire this change exists to
+// open: discovery already knows whether a kind is namespaced, and until the loop
+// stamps that on the delivered Workload, the renderer has nothing to read and falls
+// back to guessing from the kind's NAME.
+//
+// It is the same class of gap TestLoopStampsAlertResourceFromRequest closes for
+// AlertResource — both halves can be green with the wire between them cut.
+func TestLoopStampsTheDiscoveredScopeOnTheResource(t *testing.T) {
+	ks := &stubScoper{scopes: map[string]providers.ResourceScope{
+		"DBInstance": providers.ScopeNamespaced, // an ACK CRD, not an RDS instance
+		"Node":       providers.ScopeClusterScoped,
+	}}
+	origin := providers.Workload{Namespace: "observability"}
+
+	got := scopeLoop(t, ks, `{"confidence":0.9,"affected_resource":{"kind":"DBInstance","namespace":"ack-system","name":"datagrok"},"root_causes":[{"summary":"x","confidence":0.9}]}`, origin)
+	if got.Scope != providers.ScopeNamespaced {
+		t.Errorf("Resource.Scope = %v, want ScopeNamespaced (discovery said the CRD is namespaced)", got.Scope)
+	}
+	if got.Ref() != "ack-system/datagrok" {
+		t.Errorf("scoping must not disturb the workload's identity; got %q", got.Ref())
+	}
+
+	got = scopeLoop(t, ks, `{"confidence":0.9,"affected_resource":{"kind":"Node","name":"ip-10-11-132-8"},"root_causes":[{"summary":"x","confidence":0.9}]}`, origin)
+	if got.Scope != providers.ScopeClusterScoped {
+		t.Errorf("Resource.Scope = %v, want ScopeClusterScoped", got.Scope)
+	}
+}
+
+// TestLoopScopesTheAlertResourceItFellBackTo covers the other half of
+// preferDiscoveredResource: when the model names no resource the alert's workload IS
+// the delivered resource, and it needs the same answer. Scoping only the model's
+// resource would leave every alert-only card guessing.
+func TestLoopScopesTheAlertResourceItFellBackTo(t *testing.T) {
+	ks := &stubScoper{scopes: map[string]providers.ResourceScope{"Node": providers.ScopeClusterScoped}}
+	origin := providers.Workload{Kind: "Node", Namespace: "observability", Name: "ip-10-11-132-8"}
+
+	got := scopeLoop(t, ks, `{"confidence":0.9,"root_causes":[{"summary":"x","confidence":0.9}]}`, origin)
+	if got.Scope != providers.ScopeClusterScoped {
+		t.Errorf("Resource.Scope = %v, want ScopeClusterScoped on the fallen-back-to alert workload", got.Scope)
+	}
+}
+
+// TestLoopLeavesTheScopeUnknownWhenDiscoveryCannotAnswer is the conservative half, and
+// the one that must not regress: unknown is NOT cluster-scoped, and every path that
+// cannot reach a real answer has to say so rather than assert one.
+//
+// A nil scoper is the ordinary case, not an edge one — no cluster access, an eval run,
+// the demo. An erroring scoper is a live API server that is having a bad day. Neither
+// may fail the investigation, and neither may put a fact on the workload.
+func TestLoopLeavesTheScopeUnknownWhenDiscoveryCannotAnswer(t *testing.T) {
+	findings := `{"confidence":0.9,"affected_resource":{"kind":"DBInstance","namespace":"observability","name":"datagrok"},"root_causes":[{"summary":"x","confidence":0.9}]}`
+	origin := providers.Workload{Namespace: "observability"}
+
+	for _, tc := range []struct {
+		name string
+		ks   providers.KindScoper
+	}{
+		{"no scoper wired at all", nil},
+		{"discovery unreachable", &stubScoper{err: errors.New("connection refused")}},
+		{"this cluster serves no such kind", &stubScoper{scopes: map[string]providers.ResourceScope{}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scopeLoop(t, tc.ks, findings, origin)
+			if got.Scope != providers.ScopeUnknown {
+				t.Errorf("Resource.Scope = %v, want ScopeUnknown — an unanswerable question must not "+
+					"become an answer", got.Scope)
+			}
+			if got.Ref() != "observability/datagrok" {
+				t.Errorf("the workload's identity must survive a failed scope lookup; got %q", got.Ref())
+			}
+		})
+	}
+}
+
+// TestLoopAsksDiscoveryNothingForANamelessResource keeps the lookup off the hot path
+// when there is nothing to ask about: a finding that names no kind has no kind to
+// resolve, and a discovery round trip for "" would be pure cost.
+func TestLoopAsksDiscoveryNothingForANamelessResource(t *testing.T) {
+	ks := &stubScoper{scopes: map[string]providers.ResourceScope{}}
+	scopeLoop(t, ks, `{"confidence":0.9,"root_causes":[{"summary":"x","confidence":0.9}]}`,
+		providers.Workload{Namespace: "observability"})
+	if ks.calls != 0 {
+		t.Errorf("KindScope called %d times for a resource with no kind, want 0", ks.calls)
+	}
+}

--- a/internal/notify/resource_scope.go
+++ b/internal/notify/resource_scope.go
@@ -12,6 +12,13 @@ import (
 // qualifier on one is never a fact about the object — it is whatever namespace
 // happened to be in scope when the workload was assembled (see resourceRef).
 //
+// THIS LIST IS THE FALLBACK, not the answer. The answer is providers.Workload.Scope,
+// stamped from the cluster's own discovery (providers.KindScoper), which is right for
+// every kind the API server serves and needs no list at all. unnamespacedWorkload reads
+// the carried scope first and only reaches these maps when the workload arrived without
+// one: a cached or replayed alert, a run with no cluster access, a kind no served
+// resource matches. So what is written here is what RunLore does when it could not ask.
+//
 // Keys are lowercased; lookups go through kindKey.
 //
 // Well-known built-ins first, then the third-party CRDs whose objects show up in
@@ -74,10 +81,21 @@ var clusterScopedKinds = map[string]struct{}{
 // Kubernetes (ACK) ships NAMESPACED CRDs spelled exactly like most of these —
 // DBInstance, DBCluster, DBSubnetGroup, DBParameterGroup, CacheCluster, Nodegroup,
 // LoadBalancer, TargetGroup, LaunchTemplate — and Crossplane v2 made its managed
-// resources namespaced too. Workload carries only Kind/Name/Namespace, no group and
-// no apiVersion, so nothing here can tell an ACK DBInstance from the RDS instance the
-// delivered card misnamed. On a cluster running ACK or Crossplane v2 these entries
-// WOULD strip a true namespace; revisit the list before pointing RunLore at one.
+// resources namespaced too. A name cannot tell an ACK DBInstance from the RDS instance
+// the delivered card misnamed, because they are spelled identically.
+//
+// Discovery can, and now does: on a cluster running ACK the kind resolves to a
+// namespaced resource, Workload.Scope says ScopeNamespaced, and unnamespacedWorkload
+// answers from that before ever reading this map. What is left here is the case with no
+// discovery answer — no cluster access, a replayed alert, or a kind the API server does
+// not serve, which is precisely the RDS instance. So these entries are read when the
+// resource is MOST LIKELY to be the cloud one, and the ACK collision they cannot
+// resolve is the one case where something else already resolved it.
+//
+// The residual gap is narrow but real, and is the thing to check before adding an
+// entry: an ACK/Crossplane object whose workload reached the renderer WITHOUT a scope
+// (a cached alert, an investigation run with no cluster reachable) still falls back to
+// this map and still loses a true namespace.
 //
 // Kinds spelled as a cloud identifier rather than a Kubernetes kind — CloudTrail's
 // "AWS::RDS::DBInstance", an ARN — need no entry here: notKubernetesShaped rejects
@@ -131,14 +149,19 @@ func notKubernetesShaped(kind string) bool {
 // about the object: a cluster-scoped Kubernetes kind, or something that is not a
 // Kubernetes object at all.
 //
+// It answers from the kind's NAME alone and is therefore the FALLBACK layer:
+// unnamespacedWorkload consults the workload's carried scope first and only calls this
+// when none travelled with it. Nothing here is consulted for a workload the cluster
+// itself answered for.
+//
 // Fail-safe by construction — it answers false for an empty kind and for every kind
 // it does not recognize, so the renderer keeps doing exactly what it does today
 // unless the namespace is known to be wrong.
 //
-// "Known" is as strong as this layer can be, not a guarantee: Workload carries no
-// group or apiVersion, so the nonKubernetesKinds caveat above (ACK and Crossplane v2
-// ship NAMESPACED CRDs under several of those names) is a limit on this function too.
-// Read it before adding an entry.
+// "Known" is as strong as a NAME can be, not a guarantee: this function sees no group
+// and no apiVersion, so the nonKubernetesKinds caveat above (ACK and Crossplane v2 ship
+// NAMESPACED CRDs under several of those names) is a limit on it too, for the workloads
+// that reach it. Read it before adding an entry.
 func unnamespacedKind(kind string) bool {
 	k := kindKey(kind)
 	if k == "" {
@@ -151,6 +174,32 @@ func unnamespacedKind(kind string) bool {
 		return true
 	}
 	return notKubernetesShaped(k)
+}
+
+// unnamespacedWorkload reports whether a namespace qualifier on this workload is not
+// a fact about the object — the same question unnamespacedKind answers from the kind's
+// NAME, asked first of the workload's own carried scope.
+//
+// The carried scope wins because it is knowledge and the lists are a guess. Workload.
+// Scope is set from the cluster's own discovery (providers.KindScoper), which is right
+// for every kind the API server serves, CRDs included, and is the only thing that can
+// tell an ACK DBInstance (namespaced, in a real namespace) from the RDS instance that
+// produced the misnamed card — the two are spelled identically and nonKubernetesKinds
+// cannot distinguish them.
+//
+// ScopeUnknown is NOT "cluster-scoped". A workload assembled from a cached alert, from
+// a cloud event, or on a run with no cluster access carries no answer, and there the
+// kind lists still decide exactly as they did before — which is what keeps the RDS
+// DBInstance, the CloudTrail resource type and every unlisted kind rendering as they
+// do today.
+func unnamespacedWorkload(w providers.Workload) bool {
+	switch w.Scope {
+	case providers.ScopeNamespaced:
+		return false
+	case providers.ScopeClusterScoped:
+		return true
+	}
+	return unnamespacedKind(w.Kind)
 }
 
 // resourceRef renders the affected resource's identity for a card: "namespace/name"
@@ -170,9 +219,10 @@ func unnamespacedKind(kind string) bool {
 // This is the RENDERING half of the fix only. The conflation upstream is real — the
 // same wrong namespace still reaches recall matching, the curated entry's
 // `resource:` frontmatter and the outcome ledger — and belongs where the workload is
-// assembled, not here.
+// assembled, not here. Workload.Scope is carried alongside those, so a later fix has
+// the cluster's answer available where the namespace is actually chosen.
 func resourceRef(w providers.Workload) string {
-	if !unnamespacedKind(w.Kind) {
+	if !unnamespacedWorkload(w) {
 		return w.Ref()
 	}
 	if name := strings.TrimSpace(w.Name); name != "" {

--- a/internal/notify/resource_scope_discovery_test.go
+++ b/internal/notify/resource_scope_discovery_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package notify
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// TestCardResourceLineTrustsTheDiscoveredScope proves the renderer prefers the
+// namespaced-ness the API server itself reported over the kind lists in
+// resource_scope.go.
+//
+// The lists were a stopgap for a fact the process already obtains: discovery
+// (ServerPreferredResources) answers correctly for EVERY kind the cluster serves,
+// including CRDs the lists cannot enumerate. Their stated invariant — "only names
+// with no namespaced Kubernetes homonym are listed" — is false: AWS Controllers for
+// Kubernetes and Crossplane v2 ship NAMESPACED CRDs spelled DBInstance, DBCluster,
+// CacheCluster, Nodegroup, TargetGroup, LaunchTemplate, LoadBalancer, and HyperShift's
+// NodePool is namespaced where Karpenter's is not. On such a cluster the lists strip a
+// namespace that was a fact about the object, which is the exact failure this whole
+// area exists to prevent — and only discovery can tell the two apart.
+func TestCardResourceLineTrustsTheDiscoveredScope(t *testing.T) {
+	tests := []struct {
+		name string
+		res  providers.Workload
+		want string
+	}{
+		{
+			name: "an ACK DBInstance discovered as namespaced keeps its namespace, list or no list",
+			res: providers.Workload{
+				Kind: "DBInstance", Namespace: "ack-system", Name: "datagrok-aqemia-shared",
+				Scope: providers.ScopeNamespaced,
+			},
+			want: "DBInstance ack-system/datagrok-aqemia-shared",
+		},
+		{
+			name: "HyperShift's NodePool is namespaced where Karpenter's is not",
+			res: providers.Workload{
+				Kind: "NodePool", Namespace: "clusters", Name: "dev-workers",
+				Scope: providers.ScopeNamespaced,
+			},
+			want: "NodePool clusters/dev-workers",
+		},
+		{
+			name: "a CRD no list could enumerate, discovered as cluster-scoped, loses the alert's namespace",
+			res: providers.Workload{
+				Kind: "ClusterCompliancePolicy", Namespace: "observability", Name: "nsa",
+				Scope: providers.ScopeClusterScoped,
+			},
+			want: "ClusterCompliancePolicy nsa",
+		},
+		{
+			name: "a discovered cluster-scoped Node renders exactly as the list already made it",
+			res: providers.Workload{
+				Kind: "Node", Namespace: "observability", Name: "ip-10-11-132-8.ec2.internal",
+				Scope: providers.ScopeClusterScoped,
+			},
+			want: "Node ip-10-11-132-8.ec2.internal",
+		},
+		{
+			// The one cluster-scoped kind whose own identity arrives in the namespace
+			// field. Discovery agreeing with the list must not change that carve-out.
+			name: "a discovered cluster-scoped Namespace with no name still renders its own name",
+			res: providers.Workload{
+				Kind: "Namespace", Namespace: "coder-engineering",
+				Scope: providers.ScopeClusterScoped,
+			},
+			want: "Namespace coder-engineering",
+		},
+		{
+			// Unknown is NOT cluster-scoped: no discovery answer means the lists still
+			// decide, which is what keeps an RDS alert's DBInstance working.
+			name: "with no discovered scope the cloud-kind list still strips a namespace no RDS instance has",
+			res: providers.Workload{
+				Kind: "DBInstance", Namespace: "observability", Name: "datagrok-aqemia-shared",
+			},
+			want: "DBInstance datagrok-aqemia-shared",
+		},
+		{
+			name: "with no discovered scope an unlisted kind keeps its namespace, exactly as before",
+			res: providers.Workload{
+				Kind: "VerticalPodAutoscaler", Namespace: "observability", Name: "vector",
+			},
+			want: "VerticalPodAutoscaler observability/vector",
+		},
+		{
+			// A namespaced answer for a kind the cloud list names is the whole point:
+			// on an ACK cluster the qualifier is real, and the list must not win.
+			name: "a discovered namespaced LoadBalancer beats the cloud list",
+			res: providers.Workload{
+				Kind: "LoadBalancer", Namespace: "ack-system", Name: "public",
+				Scope: providers.ScopeNamespaced,
+			},
+			want: "LoadBalancer ack-system/public",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			inv := providers.Investigation{
+				Title:     "something is wrong",
+				AlertName: "KubeNodeNotReady",
+				Resource:  tc.res,
+			}
+			if got := formatResourceLine(Format(inv)); got != tc.want {
+				t.Errorf("Format resource line = %q, want %q", got, tc.want)
+			}
+			card := blocksText(t, summaryBlocks(inv))
+			if !strings.Contains(card, "*Resource:*\\n"+tc.want) {
+				t.Errorf("Slack card Resource field is not %q:\n%s", tc.want, card)
+			}
+		})
+	}
+}

--- a/internal/providers/cluster/kindscope.go
+++ b/internal/providers/cluster/kindscope.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster
+
+import (
+	"context"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+var _ providers.KindScoper = (*SpecReader)(nil)
+
+// KindScope reports whether kind is namespaced on this cluster, from the API server's
+// own discovery — the same ServerPreferredResources listing ResourceSpec resolves
+// against, whose APIResource.Namespaced is authoritative for every served kind,
+// including CRDs no compiled-in table could enumerate.
+//
+// It is the supply side of Workload.Scope: without it, downstream code that needs to
+// know whether an object HAS a namespace has to infer it from the kind's name, and no
+// list of names can be right for arbitrary CRDs.
+//
+// Unknown, not a guess, in three cases — this is the contract, not a fallback:
+//
+//   - no served resource matches the kind. The cluster may simply not run the operator,
+//     or the "kind" may name something outside Kubernetes entirely (an RDS instance, a
+//     CloudTrail resource type). Discovery cannot tell those apart and does not try.
+//   - two API groups serve the kind and DISAGREE about namespacing. A bare kind carries
+//     no group, so nothing here can say which was meant; picking one is exactly the
+//     quiet wrongness ResourceSpec refuses to commit for the same ambiguity. Groups that
+//     AGREE do answer — that is knowledge, and withholding it would buy nothing.
+//   - the kind is empty. Nothing was asked, so nothing is known.
+//
+// Unlike ResourceSpec's resolution it does NOT invalidate and re-fetch discovery on a
+// miss. A miss here is the common case — every non-Kubernetes resource RunLore reasons
+// about misses — and it is not a dead end: the answer is "unknown", the caller keeps
+// whatever it had, and nothing is reported to a model as a fact about the cluster. That
+// makes a full discovery fan-out per miss a cost with no matching benefit. The
+// consequence is stated rather than hidden: a CRD installed AFTER this process's
+// discovery cache was filled reads as unknown until something else invalidates it.
+func (r *SpecReader) KindScope(_ context.Context, kind string) (providers.ResourceScope, error) {
+	if kind == "" {
+		return providers.ScopeUnknown, nil
+	}
+	matches, err := r.resolveKindCached(kind)
+	if err != nil {
+		return providers.ScopeUnknown, err
+	}
+	scope := providers.ScopeUnknown
+	for _, m := range matches {
+		got := providers.ScopeClusterScoped
+		if m.namespaced {
+			got = providers.ScopeNamespaced
+		}
+		if scope != providers.ScopeUnknown && scope != got {
+			return providers.ScopeUnknown, nil // groups disagree; a bare kind cannot choose
+		}
+		scope = got
+	}
+	return scope, nil
+}

--- a/internal/providers/cluster/kindscope_test.go
+++ b/internal/providers/cluster/kindscope_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// errNoGroups is what client-go reports when discovery came back with nothing usable.
+var errNoGroups = errors.New("unable to retrieve the complete list of server APIs")
+
+// TestKindScopeAnswersFromDiscovery pins the fact this reader already had and nobody
+// downstream could see: ServerPreferredResources reports Namespaced per resource, so
+// the API server itself settles a question the renderer was guessing from a hardcoded
+// list of kind NAMES.
+//
+// The two ACK cases are the reason the guess had to go. rds.services.k8s.aws serves a
+// NAMESPACED DBInstance spelled exactly like the RDS instance an alert names, and the
+// list of "kinds that are not Kubernetes objects" cannot tell them apart. Discovery
+// can: on a cluster running ACK the kind resolves, on one that is not it does not.
+func TestKindScopeAnswersFromDiscovery(t *testing.T) {
+	tests := []struct {
+		name  string
+		disco fakeDiscovery
+		kind  string
+		want  providers.ResourceScope
+	}{
+		{
+			name:  "a namespaced kind is reported namespaced",
+			disco: discoServing("v1", metav1.APIResource{Name: "pods", Kind: "Pod", Namespaced: true}),
+			kind:  "Pod",
+			want:  providers.ScopeNamespaced,
+		},
+		{
+			name:  "a cluster-scoped kind is reported cluster-scoped",
+			disco: discoServing("v1", metav1.APIResource{Name: "nodes", Kind: "Node", Namespaced: false}),
+			kind:  "Node",
+			want:  providers.ScopeClusterScoped,
+		},
+		{
+			name: "ACK's DBInstance is namespaced — the cloud-kind list would have called it scopeless",
+			disco: discoServing("rds.services.k8s.aws/v1alpha1",
+				metav1.APIResource{Name: "dbinstances", Kind: "DBInstance", Namespaced: true}),
+			kind: "DBInstance",
+			want: providers.ScopeNamespaced,
+		},
+		{
+			name:  "a kind this cluster does not serve is UNKNOWN, not cluster-scoped",
+			disco: discoServing("v1", metav1.APIResource{Name: "pods", Kind: "Pod", Namespaced: true}),
+			kind:  "DBInstance",
+			want:  providers.ScopeUnknown,
+		},
+		{
+			name:  "matching is case-insensitive, like every other kind lookup here",
+			disco: discoServing("v1", metav1.APIResource{Name: "nodes", Kind: "Node", Namespaced: false}),
+			kind:  "node",
+			want:  providers.ScopeClusterScoped,
+		},
+		{
+			name:  "an empty kind asks nothing and answers unknown",
+			disco: discoServing("v1", metav1.APIResource{Name: "pods", Kind: "Pod", Namespaced: true}),
+			kind:  "",
+			want:  providers.ScopeUnknown,
+		},
+		{
+			name: "a subresource is not an object and cannot answer for the kind",
+			disco: discoServing("v1",
+				metav1.APIResource{Name: "pods/log", Kind: "Pod", Namespaced: true}),
+			kind: "Pod",
+			want: providers.ScopeUnknown,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NewSpecReader(nil, tc.disco).KindScope(context.Background(), tc.kind)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("KindScope(%q) = %v, want %v", tc.kind, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestKindScopeRefusesToGuessWhenGroupsDisagree keeps the ambiguity honest.
+//
+// Two API groups can serve one Kind — NetworkPolicy is served by networking.k8s.io and
+// by crd.projectcalico.org on any cluster running Calico — and Workload carries no
+// group, so nothing here can say which one an alert meant. When the two disagree about
+// namespacing, picking either would be the same quiet wrongness ResourceSpec refuses to
+// commit; unknown sends the renderer back to its conservative default instead.
+//
+// Agreement is a different case: both groups saying "namespaced" IS an answer, and
+// withholding it would throw away knowledge for no gain.
+func TestKindScopeRefusesToGuessWhenGroupsDisagree(t *testing.T) {
+	disagree := fakeDiscovery{lists: []*metav1.APIResourceList{
+		{GroupVersion: "hypershift.openshift.io/v1beta1", APIResources: []metav1.APIResource{
+			{Name: "nodepools", Kind: "NodePool", Namespaced: true}}},
+		{GroupVersion: "karpenter.sh/v1", APIResources: []metav1.APIResource{
+			{Name: "nodepools", Kind: "NodePool", Namespaced: false}}},
+	}}
+	got, err := NewSpecReader(nil, disagree).KindScope(context.Background(), "NodePool")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != providers.ScopeUnknown {
+		t.Errorf("KindScope with disagreeing groups = %v, want ScopeUnknown", got)
+	}
+
+	agree := fakeDiscovery{lists: []*metav1.APIResourceList{
+		{GroupVersion: "networking.k8s.io/v1", APIResources: []metav1.APIResource{
+			{Name: "networkpolicies", Kind: "NetworkPolicy", Namespaced: true}}},
+		{GroupVersion: "crd.projectcalico.org/v1", APIResources: []metav1.APIResource{
+			{Name: "networkpolicies", Kind: "NetworkPolicy", Namespaced: true}}},
+	}}
+	got, err = NewSpecReader(nil, agree).KindScope(context.Background(), "NetworkPolicy")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != providers.ScopeNamespaced {
+		t.Errorf("KindScope with agreeing groups = %v, want ScopeNamespaced", got)
+	}
+}
+
+// TestKindScopeSurvivesDiscoveryFailure proves the degrade path is the conservative
+// one at every level: a total discovery failure reports unknown WITH the error (the
+// caller keeps whatever it did before), and a PARTIAL failure — one broken aggregated
+// APIService, which is routine — still answers from the lists that did come back.
+func TestKindScopeSurvivesDiscoveryFailure(t *testing.T) {
+	total := fakeDiscovery{err: errNoGroups}
+	got, err := NewSpecReader(nil, total).KindScope(context.Background(), "Node")
+	if err == nil {
+		t.Fatal("a total discovery failure must be reported, not swallowed")
+	}
+	if got != providers.ScopeUnknown {
+		t.Errorf("scope on discovery failure = %v, want ScopeUnknown", got)
+	}
+
+	partial := fakeDiscovery{
+		lists: []*metav1.APIResourceList{{GroupVersion: "v1", APIResources: []metav1.APIResource{
+			{Name: "nodes", Kind: "Node", Namespaced: false}}}},
+		err: errNoGroups,
+	}
+	got, err = NewSpecReader(nil, partial).KindScope(context.Background(), "Node")
+	if err != nil {
+		t.Fatalf("a partial discovery failure must still answer: %v", err)
+	}
+	if got != providers.ScopeClusterScoped {
+		t.Errorf("scope on partial discovery = %v, want ScopeClusterScoped", got)
+	}
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -48,6 +48,33 @@ const (
 	ChangeCloudAPI  ChangeType = "cloud-api"  // a mutating cloud control-plane call (CloudTrail)
 )
 
+// ResourceScope records whether a resource's KIND is namespaced, as a fact CARRIED
+// with the resource rather than guessed from the kind's name.
+//
+// It is three-valued, and the third value is the load-bearing one. "Namespaced" and
+// "cluster-scoped" are different answers, but "nobody established which" is different
+// again — and a bool conflates it with one of them, silently. A Workload assembled
+// from a cached alert, from a non-Kubernetes cloud event, or on a run with no cluster
+// access has no discovery answer, and reading its zero value as "cluster-scoped" would
+// strip a namespace that was a fact about the object. So the zero value is Unknown,
+// every consumer must fall back to whatever it did before, and no existing
+// construction site changes meaning by not setting the field.
+type ResourceScope uint8
+
+// The scopes a resource can be known to have.
+const (
+	// ScopeUnknown means nothing established this kind's scope: no cluster access, no
+	// discovery answer, or not a Kubernetes object at all. Consumers must degrade to
+	// their prior behaviour rather than assume either answer.
+	ScopeUnknown ResourceScope = iota
+	// ScopeNamespaced means the API server reports this kind as namespaced, so a
+	// namespace qualifier on it is a fact about the object.
+	ScopeNamespaced
+	// ScopeClusterScoped means the API server reports this kind as cluster-scoped, so
+	// the object HAS no namespace and any qualifier on it came from somewhere else.
+	ScopeClusterScoped
+)
+
 // Workload identifies a Kubernetes object, or — when it names a cloud resource —
 // that resource plus the cloud scope it lives in.
 //
@@ -71,6 +98,16 @@ type Workload struct {
 	Namespace string
 	Region    string // AWS region; "" for a Kubernetes object and for an unqualified resource
 	Account   string // AWS account id; "" for a Kubernetes object and for an unqualified resource
+
+	// Scope is what the cluster's own discovery said about Kind, when anything did.
+	// Populated where a discovery answer is reachable (see KindScoper) and left
+	// ScopeUnknown everywhere else, which is every consumer's cue to keep doing what
+	// it did before rather than to assume cluster-scoped.
+	//
+	// Deliberately NOT part of the workload's identity: Ref(), the recall index and
+	// the dedup fingerprint all read Kind/Name/Namespace only, so the same object
+	// scoped and unscoped is still one object.
+	Scope ResourceScope
 }
 
 // Ref renders the workload as "namespace/name", or just "namespace" when the
@@ -494,6 +531,26 @@ type ResourceSpec struct {
 // denials as ResourceForbidden rather than as absence.
 type ResourceSpecReader interface {
 	ResourceSpec(ctx context.Context, q ResourceSpecQuery) (ResourceSpec, error)
+}
+
+// KindScoper answers whether a bare Kubernetes Kind is namespaced ON THIS CLUSTER.
+//
+// It exists so namespaced-ness can be carried as DATA (Workload.Scope) instead of
+// guessed downstream from the kind's name. The guess cannot be made correct: any
+// operator may ship a CRD under any Kind, and several ship namespaced CRDs spelled
+// exactly like cluster-scoped or non-Kubernetes things — ACK's DBInstance, DBCluster,
+// CacheCluster, Nodegroup, TargetGroup, LaunchTemplate and LoadBalancer, Crossplane
+// v2's namespaced managed resources, HyperShift's NodePool against Karpenter's. The
+// API server's own discovery already knows, and the process already reads it.
+//
+// The contract's three-valued answer is the load-bearing part. An implementation MUST
+// return ScopeUnknown — never a guess and never an error — when the cluster serves no
+// such kind, when two API groups serve it and disagree, or when the kind is empty:
+// callers degrade to their prior behaviour on unknown, and any other answer would turn
+// "nobody knows" into a fact. An error is reserved for "discovery itself failed", and
+// carries ScopeUnknown with it.
+type KindScoper interface {
+	KindScope(ctx context.Context, kind string) (ResourceScope, error)
 }
 
 // MetricsProvider abstracts VictoriaMetrics/Prometheus (both speak PromQL).


### PR DESCRIPTION
#536 fixed the card by deciding scope from a **kind list**. This replaces the guess with the cluster's own answer.

`ResourceScope` is three-valued, and the third value is the load-bearing one. "Namespaced" and "cluster-scoped" are different answers, but *"nobody established which"* is different again — and a bool conflates it with one of them, silently. A `Workload` assembled from a cached alert, from a non-Kubernetes cloud event, or on a run with no cluster access has no discovery answer, and reading its zero value as "cluster-scoped" would strip a namespace that was a fact about the object.

So `ScopeUnknown` is the zero value, every consumer falls back to what it did before, and **no existing construction site changes meaning by not setting the field.**

The answer comes from the `resource_spec` tool's own reader, so the process keeps one memoised discovery client rather than opening a second. `nil` when no cluster is reachable, which leaves every workload at `ScopeUnknown`.

Deliberately **not** part of the workload's identity: `Ref()`, the recall index and the dedup fingerprint read Kind/Name/Namespace only, so the same object scoped and unscoped is still one object.

This is also what makes `RunloreResourceScopeDiscoveryFailing` meaningful — the alert rule I'm landing separately reads `resource_scope_lookups_total`, which ships here.

Replanted onto current `main`: its parent was squash-merged as #536, so this carries only its own commit. Two additive conflicts resolved — `main`'s `VerifyTier` fields (#525) kept alongside the new `KindScope`, and `main`'s richer `Workload` doc (#535's Account/Region) kept over the stale one-line version this commit was written against.

Gate: `build` · `vet` · `go test ./... -race` · `gofmt -l .` silent · `golangci-lint run ./...` **0 issues**.
