### PR TITLE
fix(notify): stop the delivery payload naming a namespace the resource is not in

### DIFF
--- a/internal/notify/payload.go
+++ b/internal/notify/payload.go
@@ -13,11 +13,36 @@ import (
 // templated notifier exposes it as the template dot. Field set and json tags
 // are the webhook notifier's original wire format — do not change tags without
 // a compatibility note, external consumers parse them.
+//
+// The three resource fields say three different things, and only one of them is
+// the resource's identity:
+//
+//   - namespace — the namespace this finding is scoped to: the one the resource is
+//     IN, or, for a Namespace object named with no workload inside it, that
+//     namespace itself (the one kind whose own identity arrives in this field).
+//     Absent when the resource is in no namespace at all — a Node, an RDS
+//     instance — where the alert's `namespace` label names whatever exported the
+//     series rather than the object. See scopedNamespace.
+//   - resource — the resource's name, verbatim, never rewritten.
+//   - resource_ref — the whole scoped identity: "namespace/name", or the bare name
+//     when there is no namespace to qualify it. The same string the Slack card
+//     prints, from the same function (resourceRef), so the two cannot disagree.
+//
+// Compatibility note (2026-08-18): `namespace` narrowed to the above and
+// `resource_ref` was added. Nothing was removed or renamed, so every operator
+// template still executes and every JSON consumer still parses — `namespace` is
+// `omitempty` and has always been absent on findings that carry no namespace
+// (PagerDuty incidents carry none at all). What changed is that it is now absent
+// instead of wrong: a template doing "{{.Namespace}}/{{.Resource}}" no longer
+// renders "observability/ip-10-11-132-8.ec2.internal" for a Node. Such a template
+// should move to "{{.ResourceRef}}", which renders the scope correctly for every
+// kind rather than merely stopping short of a false one.
 type Payload struct {
 	Title            string          `json:"title"`
 	Confidence       float64         `json:"confidence"`
 	Namespace        string          `json:"namespace,omitempty"`
 	Resource         string          `json:"resource,omitempty"`
+	ResourceRef      string          `json:"resource_ref,omitempty"`
 	CuratedURL       string          `json:"curated_url,omitempty"`
 	Text             string          `json:"text"`
 	Verdict          string          `json:"verdict,omitempty"`
@@ -73,21 +98,46 @@ func NewPayload(inv providers.Investigation) Payload {
 	}
 	return Payload{
 		Title: inv.Title, Confidence: inv.Confidence,
-		// Namespace is the RAW field, not the card's rendered scope: Payload is a
-		// declared external wire format, so blanking a known-wrong namespace here is
-		// observable to every existing consumer and needs its own change, not a
-		// side effect of a card-rendering fix. Known gap, stated so it is not read as
-		// an oversight: Text above is already the corrected render, and an operator
-		// template (internal/notify/templated) doing "{{.Namespace}}/{{.Resource}}"
-		// still reproduces "observability/ip-10-11-132-8.ec2.internal" for a Node.
-		Namespace: inv.Resource.Namespace, Resource: inv.Resource.Name,
-		CuratedURL: inv.CuratedURL, Text: Format(inv), Verdict: string(inv.Verdict),
+		Namespace: scopedNamespace(inv.Resource), Resource: inv.Resource.Name,
+		ResourceRef: resourceRef(inv.Resource),
+		CuratedURL:  inv.CuratedURL, Text: Format(inv), Verdict: string(inv.Verdict),
 		Severity: inv.Severity, Cluster: inv.Cluster, Environment: inv.Environment,
 		Tenant: inv.Tenant, AlertName: inv.AlertName, StartedAt: startedAt,
 		Occurrences: inv.Occurrences, PrevCuratedURL: inv.PrevCuratedURL,
 		RuledOut: inv.RuledOut, DataGaps: inv.DataGaps,
 		Prior: prior, MatchedKnowledge: matched,
 	}
+}
+
+// scopedNamespace returns the namespace to publish for w: a namespace w is actually
+// scoped to, or nothing. Payload.Namespace used to carry providers.Workload.Namespace
+// raw, and on an alert-driven investigation that field is the namespace of whatever
+// EXPORTED the series — kube-state-metrics, the alerting rule — not the object's. A
+// Node is cluster-scoped and an RDS instance is not a Kubernetes object, so
+// "namespace": "observability" on either is a place the reader can go and not find
+// the resource. Same conflation the Slack card shipped; see resourceRef.
+//
+// It decides by ASKING resourceRef whether the namespace still contributes to the
+// rendered identity — rendering w a second time with the namespace removed and
+// comparing — rather than testing the kind itself. That is the whole point of the
+// shape: the kind decision (which kinds are cluster-scoped, which are cloud, which
+// spellings are not Kubernetes at all, and the one kind whose OWN name arrives in
+// the namespace field) lives in resource_scope.go and exists once. A second copy
+// here would answer differently the day either list moves, and the card and the
+// wire format would disagree about the same investigation.
+//
+// Asking that way is also what keeps a Namespace object's name — which arrives in
+// this very field — from being discarded as a foreign qualifier: resourceRef renders
+// it, so it contributes, so it is published. Nothing here knows that kind by name.
+//
+// Consequently it is fail-safe for exactly the same reason resourceRef is: an
+// unknown, unlisted or empty kind still contributes its namespace, so the field is
+// unchanged for every resource whose namespace is not KNOWN to be foreign.
+func scopedNamespace(w providers.Workload) string {
+	if resourceRef(w) == resourceRef(providers.Workload{Kind: w.Kind, Name: w.Name}) {
+		return "" // the namespace changed nothing about the identity: it is not w's own
+	}
+	return w.Namespace
 }
 
 // kbUpdateEvent is the value KBUpdatePayload.Event always carries. It exists

--- a/internal/notify/payload_test.go
+++ b/internal/notify/payload_test.go
@@ -138,3 +138,134 @@ func TestNewKBUpdatePayloadPopulatesEveryFieldItDeclares(t *testing.T) {
 			"from a producer that never reports provenance: %s", b)
 	}
 }
+
+// TestNewPayloadNamespaceIsTheResourcesOwn pins the templated/webhook half of the
+// resource-scope fix: Payload.Namespace must never carry a namespace that is not the
+// resource's own, and ResourceRef must carry the same scoped identity the Slack card
+// renders — so an operator template has one field to print instead of hand-joining
+// two, and a template that DOES hand-join stops reproducing
+// "observability/ip-10-11-132-8.ec2.internal".
+//
+// The cases mirror resource_scope_test.go's, because the two must agree by
+// construction: the payload asks resourceRef rather than re-deciding the kind.
+func TestNewPayloadNamespaceIsTheResourcesOwn(t *testing.T) {
+	for name, tc := range map[string]struct {
+		w       providers.Workload
+		wantNS  string
+		wantRef string
+	}{
+		"cluster-scoped kind drops the exporter's namespace": {
+			w:       providers.Workload{Kind: "Node", Namespace: "observability", Name: "ip-10-11-132-8.ec2.internal"},
+			wantNS:  "",
+			wantRef: "ip-10-11-132-8.ec2.internal",
+		},
+		"cloud kind drops the exporter's namespace": {
+			w:       providers.Workload{Kind: "DBInstance", Namespace: "observability", Name: "datagrok-aqemia-shared"},
+			wantNS:  "",
+			wantRef: "datagrok-aqemia-shared",
+		},
+		"non-kubernetes spelling drops it too": {
+			w:       providers.Workload{Kind: "AWS::RDS::DBInstance", Namespace: "observability", Name: "datagrok"},
+			wantNS:  "",
+			wantRef: "datagrok",
+		},
+		"namespace object keeps its own name": {
+			w:       providers.Workload{Kind: "Namespace", Namespace: "coder-engineering"},
+			wantNS:  "coder-engineering",
+			wantRef: "coder-engineering",
+		},
+		"namespace object with a name is not in the qualifier": {
+			w:       providers.Workload{Kind: "Namespace", Namespace: "observability", Name: "coder-engineering"},
+			wantNS:  "",
+			wantRef: "coder-engineering",
+		},
+		"namespaced kind is unchanged": {
+			w:       providers.Workload{Kind: "Pod", Namespace: "payments", Name: "api-7f9c"},
+			wantNS:  "payments",
+			wantRef: "payments/api-7f9c",
+		},
+		"unknown kind is unchanged": {
+			w:       providers.Workload{Kind: "HelmRelease", Namespace: "flux-system", Name: "harbor"},
+			wantNS:  "flux-system",
+			wantRef: "flux-system/harbor",
+		},
+		"empty kind is unchanged": {
+			w:       providers.Workload{Namespace: "payments", Name: "api-7f9c"},
+			wantNS:  "payments",
+			wantRef: "payments/api-7f9c",
+		},
+		"cluster-scoped kind with no name names nothing": {
+			w:       providers.Workload{Kind: "Node", Namespace: "observability"},
+			wantNS:  "",
+			wantRef: "",
+		},
+	} {
+		p := NewPayload(providers.Investigation{Resource: tc.w})
+		if p.Namespace != tc.wantNS {
+			t.Errorf("%s: Namespace = %q, want %q", name, p.Namespace, tc.wantNS)
+		}
+		if p.ResourceRef != tc.wantRef {
+			t.Errorf("%s: ResourceRef = %q, want %q", name, p.ResourceRef, tc.wantRef)
+		}
+		// Name is reported verbatim: the payload narrows SCOPE, never identity.
+		if p.Resource != tc.w.Name {
+			t.Errorf("%s: Resource = %q, want %q", name, p.Resource, tc.w.Name)
+		}
+	}
+}
+
+// TestPayloadResourceRefMatchesTheCard pins the no-drift property that made this fix
+// safe to write: the payload's scoped identity is resource_scope.go's answer, not a
+// second copy of the kind decision.
+func TestPayloadResourceRefMatchesTheCard(t *testing.T) {
+	for _, w := range []providers.Workload{
+		{Kind: "Node", Namespace: "observability", Name: "ip-10-11-132-8.ec2.internal"},
+		{Kind: "Namespace", Namespace: "coder-engineering"},
+		{Kind: "Pod", Namespace: "payments", Name: "api-7f9c"},
+		{Kind: "ClusterIssuer", Namespace: "cert-manager", Name: "letsencrypt"},
+	} {
+		if got, want := NewPayload(providers.Investigation{Resource: w}).ResourceRef, resourceRef(w); got != want {
+			t.Errorf("%+v: ResourceRef = %q, card renders %q", w, got, want)
+		}
+	}
+}
+
+// TestPayloadJSONWireKeys pins the JSON half of the contract, which is the part
+// external consumers actually parse: `resource_ref` is the tag the new field ships
+// under, and `namespace` is omitted — not emitted empty — for a resource that has
+// none, so a consumer reading the key gets "absent" (a shape it already had to
+// handle: the field is omitempty, and a PagerDuty incident carries no namespace at
+// all) rather than a namespace the object was never in.
+func TestPayloadJSONWireKeys(t *testing.T) {
+	node := providers.Workload{Kind: "Node", Namespace: "observability", Name: "ip-10-11-132-8.ec2.internal"}
+	b, err := json.Marshal(NewPayload(providers.Investigation{Resource: node}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got["namespace"]; ok {
+		t.Errorf("namespace must be absent for a cluster-scoped resource, got %v", got["namespace"])
+	}
+	if got["resource_ref"] != "ip-10-11-132-8.ec2.internal" {
+		t.Errorf("resource_ref = %v", got["resource_ref"])
+	}
+	if got["resource"] != "ip-10-11-132-8.ec2.internal" {
+		t.Errorf("resource = %v", got["resource"])
+	}
+
+	pod := providers.Workload{Kind: "Pod", Namespace: "payments", Name: "api-7f9c"}
+	b, err = json.Marshal(NewPayload(providers.Investigation{Resource: pod}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got = nil
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["namespace"] != "payments" || got["resource_ref"] != "payments/api-7f9c" {
+		t.Errorf("namespaced resource: namespace=%v resource_ref=%v", got["namespace"], got["resource_ref"])
+	}
+}

--- a/internal/notify/templated/templated_test.go
+++ b/internal/notify/templated/templated_test.go
@@ -180,3 +180,51 @@ func TestTemplatedDeliberatelyDoesNotAnnounceKBUpdates(t *testing.T) {
 			"an instance's template is written against notify.Payload, and a KB update executed through it renders an investigation of zero values")
 	}
 }
+
+// TestDeliverRendersTheResourceScope is the end-to-end half of the resource-scope
+// fix, on the surface that actually shipped the bug: an OPERATOR-written template
+// over notify.Payload. Delivered Slack cards on 2026-08-17/18 read "Node
+// observability/ip-10-11-132-8.ec2.internal"; the card was fixed, and this pins that
+// a template cannot reproduce it from the payload's own fields.
+//
+// Both fields are asserted from ONE rendered body: .ResourceRef must carry the
+// scoped identity, and the hand-join .Namespace/.Resource that a real template
+// writes must no longer name a namespace the Node was never in.
+func TestDeliverRendersTheResourceScope(t *testing.T) {
+	for name, tc := range map[string]struct {
+		w    providers.Workload
+		want string
+	}{
+		"cluster-scoped kind": {
+			w:    providers.Workload{Kind: "Node", Namespace: "observability", Name: "ip-10-11-132-8.ec2.internal"},
+			want: "ref=ip-10-11-132-8.ec2.internal join=/ip-10-11-132-8.ec2.internal",
+		},
+		"cloud kind": {
+			w:    providers.Workload{Kind: "DBInstance", Namespace: "observability", Name: "datagrok-aqemia-shared"},
+			want: "ref=datagrok-aqemia-shared join=/datagrok-aqemia-shared",
+		},
+		"namespace object with no name": {
+			w:    providers.Workload{Kind: "Namespace", Namespace: "coder-engineering"},
+			want: "ref=coder-engineering join=coder-engineering/",
+		},
+		"namespaced kind renders unchanged": {
+			w:    providers.Workload{Kind: "Pod", Namespace: "payments", Name: "api-7f9c"},
+			want: "ref=payments/api-7f9c join=payments/api-7f9c",
+		},
+	} {
+		var gotBody string
+		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			b, _ := io.ReadAll(r.Body)
+			gotBody = string(b)
+		}))
+		n := testNotifier(t, `ref={{ .ResourceRef }} join={{ .Namespace }}/{{ .Resource }}`, srv.URL)
+		err := n.Deliver(context.Background(), providers.Investigation{Resource: tc.w})
+		srv.Close()
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if gotBody != tc.want {
+			t.Errorf("%s: body = %q, want %q", name, gotBody, tc.want)
+		}
+	}
+}

--- a/website/content/docs/configuration/configuration.md
+++ b/website/content/docs/configuration/configuration.md
@@ -520,6 +520,17 @@ limitations, kept distinct from human-only open questions):
 and `data_gaps` alongside the existing `title`/`confidence`/`curated_url`/`text` fields (all
 `omitempty`).
 
+**Resource scope in the payload** (`notify.webhook` JSON and `notify.templated` templates alike).
+`resource` is the object's name, verbatim. `namespace` is the namespace the finding is **scoped to** —
+the one the object is in, or the namespace itself when the finding is *about* a namespace — and is
+**omitted when the object is in no namespace at all**: a `Node` is cluster-scoped and an RDS instance
+is not a Kubernetes object, so the alert's `namespace` label on either names whatever exported the
+series (kube-state-metrics, the alerting rule), not the resource. `resource_ref` (template
+`.ResourceRef`) is the whole scoped identity — `namespace/name`, or the bare name when there is
+nothing to qualify it — and is the same string the Slack card prints. A template that joined
+`.Namespace` and `.Resource` by hand keeps working, but should render `.ResourceRef` instead: it is
+correct for every kind, where the hand-join is merely no longer wrong.
+
 **👍/👎 feedback buttons — `feedback_buttons` (opt-in, default `false`).** When enabled, Slack
 investigation messages carry two buttons ("👍 Accurate" / "👎 Off-base") so the on-call can rate the
 diagnosis in one click. Ratings land in the **outcome ledger** and weigh the recalled entry's trust

--- a/website/content/docs/integrations/notifications/templated.md
+++ b/website/content/docs/integrations/notifications/templated.md
@@ -41,6 +41,11 @@ locally]({{< relref "webhook.md#verify-it-locally" >}})) and inspect the rendere
 
 - Each instance renders a Go `text/template` over the delivery payload — the same fields the
   `notify.webhook` JSON carries — and POSTs the result.
+- **Render the affected resource with `{{ .ResourceRef }}`**, not `{{ .Namespace }}/{{ .Resource }}`:
+  it is the whole scoped identity (`namespace/name`, or the bare name for a `Node`, an RDS instance
+  or any other object that has no namespace), and it is the same string the Slack card prints.
+  `.Namespace` is empty for an object that is in no namespace, so a hand-join renders a stray leading
+  slash there instead of the namespace it used to invent.
 - **Two template functions**: `toJSON` (escaping-correct JSON splicing — always use it for values
   inside JSON bodies) and `mulPct` (×100 for percent display).
 - Findings are secret-redacted **before** any notifier runs, so templates only ever see redacted data.

--- a/website/content/docs/integrations/notifications/webhook.md
+++ b/website/content/docs/integrations/notifications/webhook.md
@@ -37,6 +37,14 @@ watch the echoed JSON body land in terminal 1.
 - The JSON payload carries `verdict`, `severity`, `environment`, `cluster`, `tenant`, `alert_name`,
   `started_at` (RFC3339, empty when unknown), `occurrences`, `prev_curated_url`, `ruled_out` and
   `data_gaps`, alongside `title`/`confidence`/`curated_url`/`text` (all `omitempty`).
+- **The three resource fields say three different things.** `resource` is the object's name,
+  verbatim. `namespace` is the namespace the finding is **scoped to** — the one the object is in, or
+  the namespace itself when the finding is *about* a namespace — and is **omitted when the object is
+  in no namespace at all**: a `Node` is cluster-scoped and an RDS instance is not a Kubernetes object,
+  so an alert's `namespace` label on either names whatever exported the series (kube-state-metrics,
+  the alerting rule), not the resource. `resource_ref` is the whole scoped identity —
+  `namespace/name`, or the bare name when there is nothing to qualify it — and is the field to read
+  when you want one string: it is the same one the Slack card prints.
 - Findings are secret-redacted **before** any notifier runs, so the webhook only ever sees redacted
   data.
 - This notifier exists as much to prove RunLore's notifier extensibility (drop one self-registering


### PR DESCRIPTION
#536 stopped the **card** naming a namespace the resource is not in. The webhook payload still did.

`NewPayload` built its namespace from `Workload.Namespace` unconditionally, so a receiver storing the record — or routing on it — got `observability` for a cluster-scoped Node or an RDS instance, the same conflation the card had. The payload now carries `resource_ref` from the same `resource_scope.go` answer the card renders, so the two cannot drift into disagreeing about the same object.

On the wire, `namespace` is **omitted rather than emitted empty** for a resource that has none, so a consumer reading the key gets "absent" — a shape it already had to handle, since the field is `omitempty` and a PagerDuty incident carries no namespace at all — rather than a namespace the object was never in.

`TestPayloadResourceRefMatchesTheCard` pins the no-drift property directly: the payload's scoped identity is `resource_scope.go`'s answer, not a second copy of the kind decision.

Replanted onto current `main`: its parent was squash-merged as #536, so this carries only its own commit. `payload_test.go` was reconstructed from both real versions rather than machine-merged — `main` had gained the KB-update field guards (#528) and a naive line merge dropped brace lines common to both.

Gate: `build` · `vet` · `go test ./... -race` · `gofmt -l .` silent · `golangci-lint run ./...` **0 issues**.
