### PR TITLE
feat(observability): panel the shutdown loss counter, and alert on two silent degradations

### DIFF
--- a/deploy/observability/alerts/prometheusrule.yaml
+++ b/deploy/observability/alerts/prometheusrule.yaml
@@ -246,3 +246,32 @@ spec:
             summary: "RunLore is failing to write curated knowledge to the forge"
             description: "{{ $value | humanize }} curation writes failed in the last 30m — findings were produced but never reached the knowledge base, so the learning loop is not compounding. Check the GitHub App scopes and forge.kb_repo; look for msg=\"curate findings\" with err= in the logs."
             runbook_url: "https://runlore.io/docs/operations/observability/#runlorecurationwriteerrors"
+
+        # 16. The alert_rule tool is systemically unavailable.
+        # class="systemic" means no_capability / backend_error / no_rules: the tool is
+        # dead for EVERY investigation until the backend or config changes, so threshold
+        # levers do not apply. class="routine" (unmatched_alert) is deliberately excluded
+        # — an alert with no matching rule is normal and must never page.
+        - alert: RunloreAlertRuleUnavailable
+          expr: sum(rate(runlore_alert_rule_degraded_total{class="systemic"}[15m])) > 0
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore cannot read alerting rules from its metrics backend"
+            description: "alert_rule has been degrading systemically for 30m — every investigation is judging threshold alerts without the rule's own expression, which is the guessing this tool exists to stop. Check the backend serves /api/v1/rules and that the metrics provider implements it."
+            runbook_url: "https://runlore.io/docs/operations/observability/#runlorealertruleunavailable"
+
+        # 17. Knowledge is being filed that recall can never match.
+        # defect="unrecallable_resource" is the silent-forever case: the PR merges and the
+        # entry is never recalled. defect="merge_gate" is excluded deliberately — it blocks
+        # its own pull request, so a human meets it at review time regardless.
+        - alert: RunloreUnrecallableKBDrafts
+          expr: sum(rate(runlore_kb_draft_defects_total{defect="unrecallable_resource"}[6h])) > 0
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore is drafting knowledge entries recall cannot match"
+            description: "Knowledge PRs are being filed with a resource recall can never agree with — they merge and then never fire. Fix the frontmatter on the open PRs; see the troubleshooting page for the two log lines that name the entry."
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloreunrecallablekbdrafts"

--- a/deploy/observability/alerts/vmrule.yaml
+++ b/deploy/observability/alerts/vmrule.yaml
@@ -242,3 +242,32 @@ spec:
             summary: "RunLore is failing to write curated knowledge to the forge"
             description: "{{ $value | humanize }} curation writes failed in the last 30m — findings were produced but never reached the knowledge base, so the learning loop is not compounding. Check the GitHub App scopes and forge.kb_repo; look for msg=\"curate findings\" with err= in the logs."
             runbook_url: "https://runlore.io/docs/operations/observability/#runlorecurationwriteerrors"
+
+        # 16. The alert_rule tool is systemically unavailable.
+        # class="systemic" means no_capability / backend_error / no_rules: the tool is
+        # dead for EVERY investigation until the backend or config changes, so threshold
+        # levers do not apply. class="routine" (unmatched_alert) is deliberately excluded
+        # — an alert with no matching rule is normal and must never page.
+        - alert: RunloreAlertRuleUnavailable
+          expr: sum(rate(runlore_alert_rule_degraded_total{class="systemic"}[15m])) > 0
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore cannot read alerting rules from its metrics backend"
+            description: "alert_rule has been degrading systemically for 30m — every investigation is judging threshold alerts without the rule's own expression, which is the guessing this tool exists to stop. Check the backend serves /api/v1/rules and that the metrics provider implements it."
+            runbook_url: "https://runlore.io/docs/operations/observability/#runlorealertruleunavailable"
+
+        # 17. Knowledge is being filed that recall can never match.
+        # defect="unrecallable_resource" is the silent-forever case: the PR merges and the
+        # entry is never recalled. defect="merge_gate" is excluded deliberately — it blocks
+        # its own pull request, so a human meets it at review time regardless.
+        - alert: RunloreUnrecallableKBDrafts
+          expr: sum(rate(runlore_kb_draft_defects_total{defect="unrecallable_resource"}[6h])) > 0
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore is drafting knowledge entries recall cannot match"
+            description: "Knowledge PRs are being filed with a resource recall can never agree with — they merge and then never fire. Fix the frontmatter on the open PRs; see the troubleshooting page for the two log lines that name the entry."
+            runbook_url: "https://runlore.io/docs/operations/observability/#runloreunrecallablekbdrafts"

--- a/deploy/observability/grafana/runlore.json
+++ b/deploy/observability/grafana/runlore.json
@@ -2979,12 +2979,108 @@
       "type": "heatmap"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Alerts that were still inside their debounce window when the process shut down. Alertmanager already got a 200, so it will not resend until its repeat_interval (often hours) — these alerts are simply never investigated. Expected to be rare, but it rises once per held alert on every restart or helm upgrade that lands mid-hold. Any sustained non-zero value is real alert loss: shorten triggers.incidents.debounce or set it to 0s.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 109
+      },
+      "id": 137,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(runlore_incidents_dropped_on_shutdown_total[$__rate_interval]))",
+          "legendFormat": "dropped",
+          "refId": "A",
+          "instant": false
+        }
+      ],
+      "title": "Alerts LOST on shutdown (should be zero)",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 109
+        "y": 117
       },
       "id": 132,
       "panels": [],
@@ -3052,7 +3148,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 110
+        "y": 118
       },
       "id": 133,
       "options": {
@@ -3148,7 +3244,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 110
+        "y": 118
       },
       "id": 134,
       "options": {
@@ -3244,7 +3340,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 118
+        "y": 126
       },
       "id": 135,
       "options": {
@@ -3351,7 +3447,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 118
+        "y": 126
       },
       "id": 136,
       "options": {
@@ -3403,7 +3499,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 126
+        "y": 134
       },
       "id": 122,
       "panels": [],
@@ -3439,7 +3535,7 @@
         "h": 5,
         "w": 8,
         "x": 0,
-        "y": 127
+        "y": 135
       },
       "id": 111,
       "options": {
@@ -3510,7 +3606,7 @@
         "h": 5,
         "w": 8,
         "x": 8,
-        "y": 127
+        "y": 135
       },
       "id": 112,
       "options": {
@@ -3577,7 +3673,7 @@
         "h": 5,
         "w": 8,
         "x": 16,
-        "y": 127
+        "y": 135
       },
       "id": 113,
       "options": {

--- a/internal/docsguard/metric_names_test.go
+++ b/internal/docsguard/metric_names_test.go
@@ -23,13 +23,24 @@ import (
 	"github.com/Smana/runlore/internal/telemetry"
 )
 
-// dashboardPath and observabilityDoc are the two published surfaces that quote
-// RunLore metric names back at operators. Both are hand-maintained; neither is
-// compiled, imported, or executed by anything, so a rename in internal/telemetry
+// dashboardPath, observabilityDoc and the two alert manifests are the published
+// surfaces that quote RunLore metric names back at operators. All are hand-maintained;
+// none is compiled, imported, or executed by anything, so a rename in internal/telemetry
 // leaves them silently pointing at series the agent no longer emits.
+//
+// The alert manifests were added to this list last, and they are the surface where a
+// dead series costs most. A panel querying a retired name renders empty, which at least
+// looks wrong. An ALERT on one is indistinguishable from an alert that is simply not
+// firing — the failure mode is silence, which is exactly what a healthy system looks
+// like. A rule for runlore_resource_scope_lookups_total was proposed on the strength of
+// a commit message saying the counter shipped on another branch; that branch merged
+// carrying the ResourceScope type and no counter at all, and nothing here would have
+// noticed.
 const (
 	dashboardPath      = "deploy/observability/grafana/runlore.json"
 	observabilityDoc   = "website/content/docs/operations/observability.md"
+	prometheusRulePath = "deploy/observability/alerts/prometheusrule.yaml"
+	vmRulePath         = "deploy/observability/alerts/vmrule.yaml"
 	metricNamePattern  = `runlore_[a-z0-9_]+`
 	histogramSuffixBkt = "_bucket"
 )
@@ -68,6 +79,8 @@ func TestPublishedMetricNamesExist(t *testing.T) {
 	}{
 		{name: "grafana_dashboard", path: dashboardPath, found: dashboardMetricRefs},
 		{name: "observability_docs", path: observabilityDoc, found: markdownMetricRefs},
+		{name: "prometheus_rules", path: prometheusRulePath, found: alertRuleMetricRefs},
+		{name: "victoriametrics_rules", path: vmRulePath, found: alertRuleMetricRefs},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			body, err := os.ReadFile(filepath.Join(repoRoot(t), tc.path))
@@ -328,4 +341,33 @@ func TestEveryInstrumentIsDocumented(t *testing.T) {
 			"on an operator scraping /metrics and noticing a name they have never seen.",
 			observabilityDoc, name)
 	}
+}
+
+// alertRuleMetricRefs returns every runlore_* series named in an alert manifest's
+// PromQL, mapped to the alert names that reference it.
+//
+// Keyed by ALERT NAME rather than by line, because that is what the failure needs to
+// say: "RunloreResourceScopeDiscoveryFailing queries a series nothing emits" names the
+// rule to delete, where a line number only names where to look. Only `expr:` is read —
+// a metric named in a description or a runbook_url is prose about the alert, not a
+// query that has to resolve.
+func alertRuleMetricRefs(t *testing.T, body []byte) map[string][]string {
+	t.Helper()
+	refs := map[string][]string{}
+	alert := ""
+	for _, line := range strings.Split(string(body), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if name, ok := strings.CutPrefix(trimmed, "- alert:"); ok {
+			alert = strings.TrimSpace(name)
+			continue
+		}
+		expr, ok := strings.CutPrefix(trimmed, "expr:")
+		if !ok {
+			continue
+		}
+		for _, m := range metricNameRE.FindAllString(expr, -1) {
+			refs[m] = append(refs[m], alert)
+		}
+	}
+	return refs
 }

--- a/website/content/docs/operations/observability.md
+++ b/website/content/docs/operations/observability.md
@@ -480,6 +480,39 @@ that `result="error"` counts only genuine write failures — a finding that was 
 (below `forge.min_confidence`) or deduplicated against an existing entry is a different
 `result` and is not an error.
 
+### RunloreAlertRuleUnavailable
+
+`runlore_alert_rule_degraded_total{class="systemic"}` is non-zero: the `alert_rule` tool
+cannot read the firing alert's own rule definition, for every investigation, until the
+backend or the config changes.
+
+This is the one alert on this page for a tool that is *working as designed* when it
+fails. `alert_rule` degrades to a plain string rather than an error, because a rule
+definition is corroborating context and must never fail an investigation — which means
+`runlore_tool_calls_total` records every degradation as `result="ok"`. A deployment whose
+backend serves no rules endpoint is therefore metrically identical to one where the tool
+works, and this counter is the only series that separates them.
+
+`class="routine"` (`unmatched_alert`) is excluded on purpose: an alert with no matching
+rule is normal and must never page. Check the backend serves `/api/v1/rules` and that
+your metrics provider implements it.
+
+### RunloreUnrecallableKBDrafts
+
+`runlore_kb_draft_defects_total{defect="unrecallable_resource"}` is non-zero: entries are
+being filed with a `resource` recall's structural match can never agree with.
+
+These merge cleanly and then never fire — worse than an entry with no `resource` at all,
+because a non-empty one also disables the scopeless fallback. Every such entry is
+permanent catalog weight that never repays its cost, and nothing else surfaces it:
+`runlore_curations_total{kind="pr",result="opened"}` scores the pull request a success
+either way.
+
+`defect="merge_gate"` is excluded deliberately — that draft fails `lore validate-kb`, so
+its pull request cannot merge and a human meets it at review time regardless. Fix the
+frontmatter on the open PRs; the two log lines that name the entry are on the
+[troubleshooting page]({{< relref "troubleshooting.md#the-pr-opened-but-the-entry-will-never-be-recalled" >}}).
+
 ### RunloreInvestigationCostHigh
 
 p95 of `runlore_investigation_tokens_estimated` above 100000 over 30m. Read the metric


### PR DESCRIPTION
Extracted from `feat/observability-panels` rather than merging it. That branch predates 16 commits, and merging it as-is would **regress `main` twice**.

### Why not merge the branch

| Its commit | State on `main` |
|---|---|
| Document 15 metrics | `TestEveryInstrumentIsDocumented` passes — every emitted instrument is already documented (#527) |
| Budget-trips panel | "Spend-ceiling trips by stage" and "Which ceiling is binding" already exist |
| Mentions-dropped alert | `RunloreThreadMentionsDropped` already exists |
| **Repoint 24 runbook_urls at `#alerting`** | **Regression** — `main` has zero dead links and 15 real per-alert sections |
| **Budget panel description** | **Regression** — repeats *"the default is unchanged at 100000"*, the claim #524 corrected |

### What was genuinely missing, and is here

**Alerts LOST on shutdown.** `incidents_dropped_on_shutdown_total` was documented and had **no panel**, so the only way to see it was to know it existed and query it by hand. It rises once per held alert on every restart or `helm upgrade` landing mid-debounce — and Alertmanager has already returned 200, so it will not resend until its `repeat_interval`, often hours. The alert is simply never investigated. That makes it the counter most likely to be non-zero with nobody looking.

**`RunloreAlertRuleUnavailable`** and **`RunloreUnrecallableKBDrafts`.** Both subsystems fail soft — right for availability, invisible to operations. `alert_rule` answers with a *string*, so `tool_calls_total` records every degradation as `result="ok"`; an unrecallable KB draft merges cleanly and never fires again while `curations_total{result="opened"}` scores it a success.

Each rule reads only the **systemic** half of its counter. `class="routine"` is excluded because an alert with no matching rule is normal; `defect="merge_gate"` is excluded because that draft blocks its own PR and a human meets it at review time regardless.

Both keep `main`'s per-alert runbook anchors and get the doc sections those anchors point at, so the links resolve. 17 rules in both manifests, 17 doc sections, 445 in-page anchors resolving.

### The third rule is deliberately absent

`RunloreResourceScopeDiscoveryFailing` queries `runlore_resource_scope_lookups_total`, on the strength of a commit message saying the counter *"ships with feat/workload-namespaced-from-discovery"*. **That branch merged as #540 carrying the `ResourceScope` type and no counter at all.** The rule would never fire.

### And the reason nobody would have noticed

`TestPublishedMetricNamesExist` covered the Grafana dashboard and the observability doc — **not the alert manifests**. A rule naming a dead series passed CI silently.

It now covers both manifests, keyed by **alert name** so the failure names the rule to delete rather than a line to look at. This is the surface where a dead series costs most: an empty panel at least looks wrong, while an alert that can never fire is indistinguishable from one that is simply not firing — the failure mode is silence, which is what a healthy system looks like.

Mutation-tested both ways:

```
M1  add the branch's third rule
    → deploy/observability/alerts/prometheusrule.yaml references
      "runlore_resource_scope_lookups_total", which no instrument emits.
        seen in: RunloreResourceScopeDiscoveryFailing

M2  manifest yields no expressions
    → no runlore_* metric names found in vmrule.yaml — the file moved or its
      shape changed, and this guard is inert
```

Gate: `build` · `vet` · `go test ./... -race` · `gofmt -l .` silent · `golangci-lint run ./...` **0 issues** · `hugo` exit 0 · `check-anchors.sh` 445/72 · `helm lint` 0 · both manifests parse as YAML and carry identical rule sets.
