### PR TITLE
fix(investigate): stop what_changed reporting a scope limit as an absent change

### DIFF
--- a/examples/eval/poisoned-recall-rejected.yaml
+++ b/examples/eval/poisoned-recall-rejected.yaml
@@ -33,7 +33,13 @@ tools:
   query_logs: no log lines matched — if logs were expected, the collector field names may differ from
     the assumed schema (try discover_log_fields to see the real fields), or narrow/loosen the query; consider
     pod_logs for a specific pod
-  what_changed: no changes found for the given selector
+  what_changed: 'no GitOps object resolved for namespace "eval": this engine reports no diffable
+    object there — nothing managed there, nothing with an applied revision and a resolvable source,
+    or a source read this engine was refused and skipped. A resource on a cluster this engine does
+    not manage reads exactly like this too. No repository was searched, so this says NOTHING about
+    whether the configuration changed — do not cite it as evidence against a config cause. To establish
+    anything about the config, re-call with the namespace alone to list what this engine does manage,
+    or confirm the resource is managed by a GitOps engine this deployment can see at all.'
   workload_ownership: 'Pod/eval-victim-789dff8486-n5wxf → ReplicaSet/eval-victim-789dff8486 → Deployment/eval-victim
     (no GitOps tracking label on the top controller — owner unresolved)
 

--- a/examples/eval/poisoned-recall-rejected.yaml
+++ b/examples/eval/poisoned-recall-rejected.yaml
@@ -33,13 +33,12 @@ tools:
   query_logs: no log lines matched — if logs were expected, the collector field names may differ from
     the assumed schema (try discover_log_fields to see the real fields), or narrow/loosen the query; consider
     pod_logs for a specific pod
-  what_changed: 'no GitOps object resolved for namespace "eval": this engine reports no diffable
-    object there — nothing managed there, nothing with an applied revision and a resolvable source,
-    or a source read this engine was refused and skipped. A resource on a cluster this engine does
-    not manage reads exactly like this too. No repository was searched, so this says NOTHING about
-    whether the configuration changed — do not cite it as evidence against a config cause. To establish
-    anything about the config, re-call with the namespace alone to list what this engine does manage,
-    or confirm the resource is managed by a GitOps engine this deployment can see at all.'
+  what_changed: 'no GitOps object matched namespace "eval": a search of eval returned no object carrying that name/namespace,
+    so nothing resolved to a repository. No repository was searched, so this says NOTHING about whether
+    the configuration changed — do not cite it as evidence against a config cause. A resource on a cluster
+    this engine does not manage reads exactly like this. Re-call with the namespace alone to list what
+    this engine does manage, or confirm the resource is managed by a GitOps engine this deployment can
+    see.'
   workload_ownership: 'Pod/eval-victim-789dff8486-n5wxf → ReplicaSet/eval-victim-789dff8486 → Deployment/eval-victim
     (no GitOps tracking label on the top controller — owner unresolved)
 

--- a/internal/investigate/gitops_kinds.go
+++ b/internal/investigate/gitops_kinds.go
@@ -3,6 +3,7 @@
 package investigate
 
 import (
+	"context"
 	"encoding/json"
 	"slices"
 	"strings"
@@ -138,6 +139,44 @@ func gitopsLookupAnswer(id string, lk providers.Lookup) string {
 	}
 }
 
+// gitopsChangesAnswer renders an EMPTY change enumeration as what the lookup established,
+// the Changes-path sibling of gitopsLookupAnswer above. Same rule: name the scopes that
+// actually completed, give each reason its own answer, and never assert a fact about Git
+// that the enumeration did not establish.
+//
+// It replaces "no changes found for the given selector", which answered all of these
+// identically. An investigation quoted that for a resource on a cluster the engine does not
+// manage, ruled out a config cause on it, and recorded it as the finding's provenance and
+// only citation — #503's mechanism one layer down from where #503 was fixed.
+//
+// Every branch carries notAConfigChange, so the disclaimer cannot drift per reason, and the
+// LookupDenied branch is the reason this function exists at all: only the provider can know
+// a source read was refused, and a refusal reported as an absence is the original bug.
+func gitopsChangesAnswer(sel string, lk providers.Lookup) string {
+	const notAConfigChange = " No repository was searched, so this says NOTHING about whether " +
+		"the configuration changed — do not cite it as evidence against a config cause."
+	const nextStep = " Re-call with the namespace alone to list what this engine does manage, " +
+		"or confirm the resource is managed by a GitOps engine this deployment can see."
+	switch lk.Reason {
+	case providers.LookupDenied:
+		return "no diffable GitOps object for " + sel + ": " + searchedClause(lk.Scopes) +
+			" matched an object whose SOURCE READ WAS DENIED by RBAC, so it never ran and no " +
+			"revision could be resolved." + notAConfigChange + " The change may well exist in a " +
+			"repository this agent was refused; fix the grant rather than concluding anything."
+	case providers.LookupUndiffable:
+		return "no diffable GitOps object for " + sel + ": " + searchedClause(lk.Scopes) +
+			" DID match a GitOps object, but it carries no applied revision and resolvable " +
+			"source, so no repository could be located." + notAConfigChange + " An object that " +
+			"has never reconciled is a strong lead in its own right — inspect it with " +
+			"gitops_resource_status rather than treating it as absent."
+	default:
+		return "no GitOps object matched " + sel + ": " + searchedClause(lk.Scopes) +
+			" returned no object carrying that name/namespace, so nothing resolved to a " +
+			"repository." + notAConfigChange + " A resource on a cluster this engine does not " +
+			"manage reads exactly like this." + nextStep
+	}
+}
+
 // searchedClause names the scopes a provider actually completed. With none recorded it
 // stays silent about scope rather than inventing one — the failure being fixed here is a
 // message that named searches that never happened.
@@ -224,4 +263,18 @@ func engineDisplayName(engine string) string {
 		return "Argo CD"
 	}
 	return "Flux"
+}
+
+// changesWithLookup runs a change enumeration and recovers what it established, via the
+// optional providers.ChangesLookupReporter capability. A provider without it yields a zero
+// Lookup, whose rendering claims no reason — which is correct, because none was established.
+//
+// Both Changes consumers need this (what_changed and incident_timeline), and both used to
+// render an empty list as a statement about Git.
+func changesWithLookup(ctx context.Context, gp providers.GitOpsProvider, w providers.TimeWindow, sel providers.Selector) ([]providers.Change, providers.Lookup, error) {
+	if r, ok := gp.(providers.ChangesLookupReporter); ok {
+		return r.ChangesLookup(ctx, w, sel)
+	}
+	changes, err := gp.Changes(ctx, w, sel)
+	return changes, providers.Lookup{}, err
 }

--- a/internal/investigate/timeline_tool.go
+++ b/internal/investigate/timeline_tool.go
@@ -123,16 +123,35 @@ func (t IncidentTimelineTool) Call(ctx context.Context, args string) (string, er
 	// tag (flux/argocd) and, when present, the from→to revision so a row reads like a
 	// deploy. A change with no When is dropped — a timeline needs a wall-clock anchor.
 	if t.GitOps != nil {
-		changes, err := t.GitOps.Changes(ctx, window, providers.Selector{Namespace: in.Namespace})
-		if err != nil {
+		sel := providers.Selector{Namespace: in.Namespace}
+		changes, lk, err := changesWithLookup(ctx, t.GitOps, window, sel)
+		switch {
+		case err != nil:
 			notes = append(notes, fmt.Sprintf("(gitops changes error: %v)", err))
-		} else {
+		case len(changes) == 0:
+			// The empty message below says "no dated GitOps changes", which is a claim about
+			// the world. It is only true if the enumeration actually resolved something; when
+			// it did not — nothing managed here, an undiffable object, a REFUSED source read —
+			// say what was established instead. Same defect what_changed carried, and this is
+			// the other Changes consumer.
+			notes = append(notes, "("+gitopsChangesAnswer(fmt.Sprintf("namespace %q", in.Namespace), lk)+")")
+		default:
+			undated := 0
 			for _, c := range changes {
 				if c.When.IsZero() {
+					undated++
 					continue
 				}
 				recordObserved(ctx, c.Workload)
 				rows = append(rows, timelineRow{when: c.When, tag: changeTag(c.Engine), text: renderChangeRow(c)})
+			}
+			// Dropping these silently is how "no dated GitOps changes" can be printed while
+			// the provider returned changes: the timeline needs a wall-clock anchor, but their
+			// absence is a gap in THIS tool, not evidence that nothing was deployed.
+			if undated > 0 {
+				notes = append(notes, fmt.Sprintf("(%d GitOps change(s) matched but carry no "+
+					"timestamp, so they are not on the timeline — this tool needs a wall-clock "+
+					"anchor; query what_changed for them)", undated))
 			}
 		}
 	}

--- a/internal/investigate/whatchanged_scope_test.go
+++ b/internal/investigate/whatchanged_scope_test.go
@@ -11,38 +11,40 @@ import (
 	"github.com/Smana/runlore/internal/providers"
 )
 
-// scopedGitOps answers Changes() per selector, so a test can model the shape that
-// caused the incident: a name that resolves to no GitOps object in a namespace that
-// may or may not be managed at all. It records every selector it was asked for,
-// because the number of provider calls is part of the contract here — the probe must
-// not fire when there is nothing to probe.
-type scopedGitOps struct {
-	fakeGitOps                     // Diff + WatchFailures; its `changes` is the by-name answer
-	byNamespace []providers.Change // returned when sel.Name == ""
-	nsErr       error              // returned instead of byNamespace
-	seen        []providers.Selector
+// lookupGitOps is a provider that implements the optional ChangesLookupReporter, so a test
+// can drive each reason the real providers can report.
+type lookupGitOps struct {
+	fakeGitOps // Diff + WatchFailures; its `changes` is the answer for both entry points
+	lk         providers.Lookup
+	// errOnCall fails the Nth ChangesLookup only (1-based, 0 = never). The reason read is
+	// a SECOND call after Call's own enumeration came back empty, so failing every call
+	// would test the pre-existing "Changes errored" path instead of this one.
+	errOnCall int
+	err       error
+	calls     int
 }
 
-func (f *scopedGitOps) Changes(_ context.Context, _ providers.TimeWindow, sel providers.Selector) ([]providers.Change, error) {
-	f.seen = append(f.seen, sel)
-	if sel.Name != "" {
-		return f.changes, nil
+func (f *lookupGitOps) ChangesLookup(context.Context, providers.TimeWindow, providers.Selector) ([]providers.Change, providers.Lookup, error) {
+	f.calls++
+	if f.err != nil && f.calls == f.errOnCall {
+		return nil, providers.Lookup{Reason: providers.LookupFailed}, f.err
 	}
-	if f.nsErr != nil {
-		return nil, f.nsErr
-	}
-	return f.byNamespace, nil
+	return f.changes, f.lk, nil
+}
+
+func (f *lookupGitOps) Changes(ctx context.Context, w providers.TimeWindow, sel providers.Selector) ([]providers.Change, error) {
+	c, _, err := f.ChangesLookup(ctx, w, sel)
+	return c, err
 }
 
 // assertRefusesAbsence checks the SHAPE of the claim rather than blocklisting phrasings.
-// gitops_kinds.go records why: a forbidden-word list shipped here once and "no such object
-// exists" slipped straight past it, so the package standardised on asserting that the
-// disclaimer marker is PRESENT. Every unresolved answer must carry notAConfigStatement, and
-// none may still carry the exact sentence that caused the incident.
+// gitops_kinds.go records why: a forbidden-word list shipped there once and "no such object
+// exists" slipped straight past it, so the package standardised on asserting the disclaimer
+// marker is PRESENT.
 func assertRefusesAbsence(t *testing.T, out string) {
 	t.Helper()
-	if !strings.Contains(out, notAConfigStatement) {
-		t.Errorf("output does not carry the not-a-config-statement disclaimer:\n%s", out)
+	if !strings.Contains(out, "says NOTHING about whether the configuration changed") {
+		t.Errorf("output does not carry the not-a-config-change disclaimer:\n%s", out)
 	}
 	// The one literal worth pinning: this exact string is what the model quoted as evidence.
 	if strings.Contains(out, "no changes found") {
@@ -50,131 +52,141 @@ func assertRefusesAbsence(t *testing.T, out string) {
 	}
 }
 
-// TestWhatChangedUnresolvedSelectorDoesNotClaimAbsence is the regression pin. The
-// selector resolves to no GitOps object AND the namespace holds none either, so no
-// repository was searched — the tool must say that rather than answer a question
-// about Git history it never asked.
-func TestWhatChangedUnresolvedSelectorDoesNotClaimAbsence(t *testing.T) {
-	gp := &scopedGitOps{}
-	out, err := WhatChangedTool{GitOps: gp}.Call(context.Background(),
-		`{"namespace":"observability","name":"vmagent-vmagent-0"}`)
+func callUnresolved(t *testing.T, gp providers.GitOpsProvider, args string) string {
+	t.Helper()
+	out, err := WhatChangedTool{GitOps: gp}.Call(context.Background(), args)
 	if err != nil {
-		t.Fatalf("Call: %v", err)
+		t.Fatalf("Call(%s): %v", args, err)
 	}
+	return out
+}
+
+const unresolvedArgs = `{"namespace":"observability","name":"vmagent-vmagent-0"}`
+
+// TestWhatChangedEmptyIsReportedPerReason is the regression pin: each reason the provider
+// can establish gets its own answer, none of them claims the config is unchanged, and the
+// two that matter most are distinguishable from a plain absence.
+func TestWhatChangedEmptyIsReportedPerReason(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		lk     providers.Lookup
+		want   []string
+		reject []string
+	}{{
+		name: "absent — nothing matched the selector",
+		lk:   providers.Lookup{Reason: providers.LookupAbsent, Scopes: []string{"observability", providers.AllNamespaces}},
+		// Names the scopes actually completed, and says an unmanaged cluster looks like this.
+		want: []string{"no GitOps object matched", "observability", "all namespaces", "does not manage"},
+	}, {
+		name: "denied — a source read was refused and never ran",
+		lk:   providers.Lookup{Reason: providers.LookupDenied, Scopes: []string{"observability"}},
+		want: []string{"DENIED by RBAC", "never ran", "fix the grant"},
+		// A denial must never read as an absence: that is #503's exact mechanism.
+		reject: []string{"no GitOps object matched"},
+	}, {
+		name: "undiffable — the object EXISTS but has no resolvable source",
+		lk:   providers.Lookup{Reason: providers.LookupUndiffable, Scopes: []string{"observability"}},
+		// The object is a lead, not an absence — it must point at inspecting it.
+		want:   []string{"DID match a GitOps object", "never reconciled", "gitops_resource_status"},
+		reject: []string{"no GitOps object matched"},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := callUnresolved(t, &lookupGitOps{lk: tc.lk}, unresolvedArgs)
+			assertRefusesAbsence(t, out)
+			for _, w := range tc.want {
+				if !strings.Contains(out, w) {
+					t.Errorf("output missing %q:\n%s", w, out)
+				}
+			}
+			for _, r := range tc.reject {
+				if strings.Contains(out, r) {
+					t.Errorf("output wrongly reads as a plain absence (%q):\n%s", r, out)
+				}
+			}
+			// Always attributable to what was asked.
+			if !strings.Contains(out, "vmagent-vmagent-0") {
+				t.Errorf("output does not name the selector it answered for:\n%s", out)
+			}
+		})
+	}
+}
+
+// TestWhatChangedScopesAreNotInvented pins the half of #503 that shipped a false message:
+// with no scopes recorded, the answer must stay silent about scope rather than name a
+// search that never happened.
+func TestWhatChangedScopesAreNotInvented(t *testing.T) {
+	out := callUnresolved(t, &lookupGitOps{lk: providers.Lookup{Reason: providers.LookupAbsent}}, unresolvedArgs)
 	assertRefusesAbsence(t, out)
-	// It must state the scope outcome: nothing resolved, so nothing was searched.
-	// "repository was searched" without the leading article: notAConfigStatement opens a
-	// sentence with it, so pinning the lowercase form would break on capitalisation alone.
-	for _, want := range []string{"no GitOps object", "repository was searched"} {
-		if !strings.Contains(out, want) {
-			t.Errorf("output missing %q:\n%s", want, out)
+	for _, invented := range []string{"all namespaces", "flux-system"} {
+		if strings.Contains(out, invented) {
+			t.Errorf("output names scope %q the provider never recorded:\n%s", invented, out)
 		}
 	}
-	// And it must name what it was asked about, so the answer is attributable.
-	if !strings.Contains(out, "vmagent-vmagent-0") || !strings.Contains(out, "observability") {
-		t.Errorf("output does not name the selector it answered for:\n%s", out)
-	}
 }
 
-// TestWhatChangedUnresolvedNameListsWhatTheNamespaceDoesHave is the recover-don't-guess
-// half: when the namespace IS managed, the name simply was not a GitOps object name
-// (a pod name never is), so the reply lists the objects that do exist there rather
-// than dead-ending. Mirrors alert_rule's unmatched-alertname list.
-func TestWhatChangedUnresolvedNameListsWhatTheNamespaceDoesHave(t *testing.T) {
-	gp := &scopedGitOps{byNamespace: []providers.Change{
-		{Workload: providers.Workload{Kind: "Application", Name: "monitoring", Namespace: "argocd"}, Engine: providers.EngineArgoCD},
-		{Workload: providers.Workload{Kind: "Application", Name: "essentials", Namespace: "argocd"}, Engine: providers.EngineArgoCD},
-	}}
-	out, err := WhatChangedTool{GitOps: gp}.Call(context.Background(),
-		`{"namespace":"observability","name":"vmagent-vmagent-0"}`)
-	if err != nil {
-		t.Fatalf("Call: %v", err)
-	}
+// TestWhatChangedWithoutTheCapabilityClaimsNoReason: a provider that does not implement
+// ChangesLookupReporter established nothing, so the answer must not pick a reason for it.
+func TestWhatChangedWithoutTheCapabilityClaimsNoReason(t *testing.T) {
+	out := callUnresolved(t, fakeGitOps{}, `{"namespace":"observability"}`)
 	assertRefusesAbsence(t, out)
-	for _, want := range []string{"monitoring", "essentials", "vmagent-vmagent-0"} {
-		if !strings.Contains(out, want) {
-			t.Errorf("output missing %q:\n%s", want, out)
+	for _, r := range []string{"DENIED by RBAC", "DID match a GitOps object"} {
+		if strings.Contains(out, r) {
+			t.Errorf("output claims reason %q with no provider support:\n%s", r, out)
 		}
 	}
-	// The distinction that matters: the namespace resolved, the NAME did not.
-	if !strings.Contains(out, "did not resolve") {
-		t.Errorf("output does not say the name failed to resolve:\n%s", out)
-	}
 }
 
-// TestWhatChangedNamespaceOnlySelectorDoesNotReprobe pins the call count. With no
-// name there is nothing to narrow, so the namespace-only probe would re-ask the
-// identical question — a wasted provider round-trip on every empty namespace lookup.
-func TestWhatChangedNamespaceOnlySelectorDoesNotReprobe(t *testing.T) {
-	gp := &scopedGitOps{}
-	out, err := WhatChangedTool{GitOps: gp}.Call(context.Background(), `{"namespace":"observability"}`)
-	if err != nil {
-		t.Fatalf("Call: %v", err)
-	}
+// TestWhatChangedLookupErrorDoesNotFailTheInvestigation: recovering the reason is an aid,
+// never a gate. Its failure must neither fail the tool nor fall back to the absence claim.
+func TestWhatChangedLookupErrorDoesNotFailTheInvestigation(t *testing.T) {
+	gp := &lookupGitOps{errOnCall: 2, err: errors.New("argocd api unreachable")}
+	out := callUnresolved(t, gp, unresolvedArgs)
 	assertRefusesAbsence(t, out)
-	if len(gp.seen) != 1 {
-		t.Errorf("namespace-only selector made %d provider calls, want 1: %+v", len(gp.seen), gp.seen)
+	if gp.calls != 2 {
+		t.Fatalf("want the reason read to have been attempted (2 calls), got %d", gp.calls)
+	}
+	// No reason may be claimed: the read that would have established one failed.
+	for _, r := range []string{"DENIED by RBAC", "DID match a GitOps object"} {
+		if strings.Contains(out, r) {
+			t.Errorf("output claims reason %q after the reason read failed:\n%s", r, out)
+		}
 	}
 }
 
-// TestWhatChangedProbeFailureStillRefusesAbsence: the probe is a best-effort aid, so
-// its failure must degrade to the scope statement rather than either erroring the
-// investigation or falling back to the absence claim it exists to remove.
-func TestWhatChangedProbeFailureStillRefusesAbsence(t *testing.T) {
-	gp := &scopedGitOps{nsErr: errors.New("argocd api unreachable")}
-	out, err := WhatChangedTool{GitOps: gp}.Call(context.Background(),
-		`{"namespace":"observability","name":"vmagent-vmagent-0"}`)
-	if err != nil {
-		t.Fatalf("Call must not fail the investigation on a probe error: %v", err)
-	}
-	assertRefusesAbsence(t, out)
-	if !strings.Contains(out, "no GitOps object") {
-		t.Errorf("output missing the scope statement:\n%s", out)
-	}
-	// The probe-error branch alone must NOT assert a cause: whether the namespace is
-	// managed is exactly what the failed probe left unestablished.
-	if strings.Contains(out, unresolvedCauses) {
-		t.Errorf("probe-error branch names causes it did not establish:\n%s", out)
-	}
-}
-
-// TestWhatChangedResolvedSelectorIsUnaffected guards the happy path: when the
-// selector does resolve, none of the above wording appears and no probe is issued.
+// TestWhatChangedResolvedSelectorIsUnaffected guards the happy path.
+//
+// It does NOT assert the absence of "no GitOps object": the pre-existing B2 note prints
+// exactly that ("note: no GitOps object in namespace %q; matched by name across
+// namespaces") whenever a name resolves in another namespace, which is the standard Flux
+// bootstrap shape. Pin the sentences this change introduced instead.
 func TestWhatChangedResolvedSelectorIsUnaffected(t *testing.T) {
-	gp := &scopedGitOps{fakeGitOps: fakeGitOps{changes: []providers.Change{{
+	gp := &lookupGitOps{fakeGitOps: fakeGitOps{changes: []providers.Change{{
 		Workload: providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"},
 		Engine:   providers.EngineFlux, Type: providers.ChangeSync, FromRev: "aaa", ToRev: "bbb",
 	}}}}
-	out, err := WhatChangedTool{GitOps: gp}.Call(context.Background(),
-		`{"namespace":"flux-system","name":"apps"}`)
-	if err != nil {
-		t.Fatalf("Call: %v", err)
+	out := callUnresolved(t, gp, `{"namespace":"flux-system","name":"apps"}`)
+	for _, r := range []string{"says NOTHING about whether", "No repository was searched"} {
+		if strings.Contains(out, r) {
+			t.Errorf("resolved selector must not carry the unresolved answer (%q):\n%s", r, out)
+		}
 	}
-	// NOT "must not contain 'no GitOps object'" — the pre-existing B2 note prints exactly
-	// that ("note: no GitOps object in namespace %q; matched by name across namespaces")
-	// whenever a name resolves in another namespace, which is the standard Flux bootstrap
-	// shape. Pin the sentences this change introduced instead.
-	if strings.Contains(out, notAConfigStatement) || strings.Contains(out, "repository was searched") {
-		t.Errorf("resolved selector must not carry the unresolved-selector answer:\n%s", out)
-	}
-	if len(gp.seen) != 1 {
-		t.Errorf("resolved selector made %d provider calls, want 1", len(gp.seen))
+	// One enumeration, not two: the reason is only read when the list came back empty.
+	if gp.calls != 1 {
+		t.Errorf("resolved selector made %d enumerations, want 1", gp.calls)
 	}
 }
 
-// TestWhatChangedDescriptionDoesNotInviteAWorkloadName pins the other half of the
-// defect. The shipped description said "optionally a named workload", but `name` is
-// matched against the GitOps OBJECT — an Application or a Kustomization — which is
-// never named after the pod it renders. A model that believes it may pass a workload
-// name will, and the empty result it gets back is what the absence claim was built on.
-func TestWhatChangedDescriptionDoesNotInviteAWorkloadName(t *testing.T) {
+// TestWhatChangedDescriptionNamesTheArgumentAccurately pins the other half of the defect.
+// The shipped description said "optionally a named workload", but `name` matches the GitOps
+// OBJECT, so a pod name carrying a hash or ordinal cannot match. It must also not
+// over-correct: a BARE workload name frequently DOES match, and both providers retry a name
+// across namespaces for exactly that case, so claiming workload names never match would
+// lose that narrowing.
+func TestWhatChangedDescriptionNamesTheArgumentAccurately(t *testing.T) {
 	d := WhatChangedTool{}.Description()
 	if strings.Contains(strings.ToLower(d), "named workload") {
 		t.Errorf("description invites a workload name for `name`, which cannot match:\n%s", d)
 	}
-	// It must say what the argument IS, and that a pod name is not it.
-	// And it must not over-correct the other way: a BARE workload name often does match,
-	// so the claim has to be about the suffix, not about workload names.
 	if strings.Contains(d, "never match") && !strings.Contains(d, "suffix") {
 		t.Errorf("description claims workload names never match, losing the bare-name retry:\n%s", d)
 	}
@@ -185,29 +197,35 @@ func TestWhatChangedDescriptionDoesNotInviteAWorkloadName(t *testing.T) {
 	}
 }
 
-// TestWhatChangedPeerListIsStableAndDeduped: several in-window revisions of one object
-// arrive as several Changes, and the model is being handed names to re-call with — not
-// a change count. Duplicates would read as several distinct objects.
-func TestWhatChangedPeerListIsStableAndDeduped(t *testing.T) {
-	rev := func(name, to string) providers.Change {
-		return providers.Change{
-			Workload: providers.Workload{Kind: "Application", Name: name, Namespace: "argocd"},
-			Engine:   providers.EngineArgoCD, ToRev: to,
-		}
-	}
-	gp := &scopedGitOps{byNamespace: []providers.Change{
-		rev("monitoring", "c"), rev("monitoring", "b"), rev("essentials", "a"), rev("monitoring", "a"),
-	}}
-	out, err := WhatChangedTool{GitOps: gp}.Call(context.Background(),
-		`{"namespace":"observability","name":"vmagent-vmagent-0"}`)
+// TestTimelineEmptyDoesNotClaimNoGitOpsChanges: incident_timeline is the OTHER Changes
+// consumer, and it printed "(no dated GitOps/cloud changes and no Warning events)" — the
+// same claim about the world for a namespace the engine may not manage. The what_changed
+// guard is file-local and would never have caught it.
+func TestTimelineEmptyDoesNotClaimNoGitOpsChanges(t *testing.T) {
+	gp := &lookupGitOps{lk: providers.Lookup{Reason: providers.LookupDenied, Scopes: []string{"observability"}}}
+	out, err := IncidentTimelineTool{GitOps: gp}.Call(context.Background(), `{"namespace":"observability"}`)
 	if err != nil {
 		t.Fatalf("Call: %v", err)
 	}
-	if n := strings.Count(out, "Application argocd/monitoring"); n != 1 {
-		t.Errorf("monitoring listed %d times, want 1 (three revisions are one object):\n%s", n, out)
+	if !strings.Contains(out, "DENIED by RBAC") {
+		t.Errorf("timeline did not report what the gitops enumeration established:\n%s", out)
 	}
-	// Sorted, so the rendering does not change between identical calls.
-	if strings.Index(out, "argocd/essentials") > strings.Index(out, "argocd/monitoring") {
-		t.Errorf("peer list is not sorted:\n%s", out)
+	assertRefusesAbsence(t, out)
+}
+
+// TestTimelineUndatedChangesAreNotSilentlyDropped: the timeline needs a wall-clock anchor,
+// so a change with no When cannot be a row — but dropping it silently is how "no dated
+// GitOps changes" gets printed while the provider DID return changes.
+func TestTimelineUndatedChangesAreNotSilentlyDropped(t *testing.T) {
+	gp := &lookupGitOps{fakeGitOps: fakeGitOps{changes: []providers.Change{{
+		Workload: providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"},
+		Engine:   providers.EngineFlux, ToRev: "bbb", // When deliberately zero
+	}}}}
+	out, err := IncidentTimelineTool{GitOps: gp}.Call(context.Background(), `{"namespace":"flux-system"}`)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if !strings.Contains(out, "carry no timestamp") {
+		t.Errorf("timeline dropped an undated change without saying so:\n%s", out)
 	}
 }

--- a/internal/investigate/whatchanged_scope_test.go
+++ b/internal/investigate/whatchanged_scope_test.go
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// scopedGitOps answers Changes() per selector, so a test can model the shape that
+// caused the incident: a name that resolves to no GitOps object in a namespace that
+// may or may not be managed at all. It records every selector it was asked for,
+// because the number of provider calls is part of the contract here — the probe must
+// not fire when there is nothing to probe.
+type scopedGitOps struct {
+	byName      []providers.Change // returned when sel.Name != ""
+	byNamespace []providers.Change // returned when sel.Name == ""
+	nsErr       error              // returned instead of byNamespace
+	seen        []providers.Selector
+}
+
+func (f *scopedGitOps) Changes(_ context.Context, _ providers.TimeWindow, sel providers.Selector) ([]providers.Change, error) {
+	f.seen = append(f.seen, sel)
+	if sel.Name != "" {
+		return f.byName, nil
+	}
+	if f.nsErr != nil {
+		return nil, f.nsErr
+	}
+	return f.byNamespace, nil
+}
+
+func (f *scopedGitOps) Diff(context.Context, providers.Change) (providers.Diff, error) {
+	return providers.Diff{}, nil
+}
+
+func (f *scopedGitOps) WatchFailures(context.Context) (<-chan providers.FailureEvent, error) {
+	ch := make(chan providers.FailureEvent)
+	close(ch)
+	return ch, nil
+}
+
+// absenceClaims are phrasings a model can quote as "Git shows no change". The first
+// is the exact string that shipped: an investigation into a pod on a cluster this
+// Argo CD does not manage read it as evidence, put it in the finding's provenance and
+// its only citation, and ruled out a config change on it.
+var absenceClaims = []string{
+	"no changes found",
+	"no Git changes",
+	"the config did not change",
+}
+
+func assertNoAbsenceClaim(t *testing.T, out string) {
+	t.Helper()
+	for _, c := range absenceClaims {
+		if strings.Contains(strings.ToLower(out), strings.ToLower(c)) {
+			t.Errorf("output claims absence with %q; an unresolved selector establishes nothing about Git history:\n%s", c, out)
+		}
+	}
+}
+
+// TestWhatChangedUnresolvedSelectorDoesNotClaimAbsence is the regression pin. The
+// selector resolves to no GitOps object AND the namespace holds none either, so no
+// repository was searched — the tool must say that rather than answer a question
+// about Git history it never asked.
+func TestWhatChangedUnresolvedSelectorDoesNotClaimAbsence(t *testing.T) {
+	gp := &scopedGitOps{}
+	out, err := WhatChangedTool{GitOps: gp}.Call(context.Background(),
+		`{"namespace":"observability","name":"vmagent-vmagent-0"}`)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	assertNoAbsenceClaim(t, out)
+	// It must state the scope outcome: nothing resolved, so nothing was searched.
+	for _, want := range []string{"no GitOps object", "no repository was searched"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	// And it must name what it was asked about, so the answer is attributable.
+	if !strings.Contains(out, "vmagent-vmagent-0") || !strings.Contains(out, "observability") {
+		t.Errorf("output does not name the selector it answered for:\n%s", out)
+	}
+}
+
+// TestWhatChangedUnresolvedNameListsWhatTheNamespaceDoesHave is the recover-don't-guess
+// half: when the namespace IS managed, the name simply was not a GitOps object name
+// (a pod name never is), so the reply lists the objects that do exist there rather
+// than dead-ending. Mirrors alert_rule's unmatched-alertname list.
+func TestWhatChangedUnresolvedNameListsWhatTheNamespaceDoesHave(t *testing.T) {
+	gp := &scopedGitOps{byNamespace: []providers.Change{
+		{Workload: providers.Workload{Kind: "Application", Name: "monitoring", Namespace: "argocd"}, Engine: providers.EngineArgoCD},
+		{Workload: providers.Workload{Kind: "Application", Name: "essentials", Namespace: "argocd"}, Engine: providers.EngineArgoCD},
+	}}
+	out, err := WhatChangedTool{GitOps: gp}.Call(context.Background(),
+		`{"namespace":"observability","name":"vmagent-vmagent-0"}`)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	assertNoAbsenceClaim(t, out)
+	for _, want := range []string{"monitoring", "essentials", "vmagent-vmagent-0"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	// The distinction that matters: the namespace resolved, the NAME did not.
+	if !strings.Contains(out, "did not resolve") {
+		t.Errorf("output does not say the name failed to resolve:\n%s", out)
+	}
+}
+
+// TestWhatChangedNamespaceOnlySelectorDoesNotReprobe pins the call count. With no
+// name there is nothing to narrow, so the namespace-only probe would re-ask the
+// identical question — a wasted provider round-trip on every empty namespace lookup.
+func TestWhatChangedNamespaceOnlySelectorDoesNotReprobe(t *testing.T) {
+	gp := &scopedGitOps{}
+	out, err := WhatChangedTool{GitOps: gp}.Call(context.Background(), `{"namespace":"observability"}`)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	assertNoAbsenceClaim(t, out)
+	if len(gp.seen) != 1 {
+		t.Errorf("namespace-only selector made %d provider calls, want 1: %+v", len(gp.seen), gp.seen)
+	}
+}
+
+// TestWhatChangedProbeFailureStillRefusesAbsence: the probe is a best-effort aid, so
+// its failure must degrade to the scope statement rather than either erroring the
+// investigation or falling back to the absence claim it exists to remove.
+func TestWhatChangedProbeFailureStillRefusesAbsence(t *testing.T) {
+	gp := &scopedGitOps{nsErr: errors.New("argocd api unreachable")}
+	out, err := WhatChangedTool{GitOps: gp}.Call(context.Background(),
+		`{"namespace":"observability","name":"vmagent-vmagent-0"}`)
+	if err != nil {
+		t.Fatalf("Call must not fail the investigation on a probe error: %v", err)
+	}
+	assertNoAbsenceClaim(t, out)
+	if !strings.Contains(out, "no GitOps object") {
+		t.Errorf("output missing the scope statement:\n%s", out)
+	}
+}
+
+// TestWhatChangedResolvedSelectorIsUnaffected guards the happy path: when the
+// selector does resolve, none of the above wording appears and no probe is issued.
+func TestWhatChangedResolvedSelectorIsUnaffected(t *testing.T) {
+	gp := &scopedGitOps{byName: []providers.Change{{
+		Workload: providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"},
+		Engine:   providers.EngineFlux, Type: providers.ChangeSync, FromRev: "aaa", ToRev: "bbb",
+	}}}
+	out, err := WhatChangedTool{GitOps: gp}.Call(context.Background(),
+		`{"namespace":"flux-system","name":"apps"}`)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if strings.Contains(out, "no GitOps object") || strings.Contains(out, "no repository was searched") {
+		t.Errorf("resolved selector must not carry the scope statement:\n%s", out)
+	}
+	if len(gp.seen) != 1 {
+		t.Errorf("resolved selector made %d provider calls, want 1", len(gp.seen))
+	}
+}
+
+// TestWhatChangedDescriptionDoesNotInviteAWorkloadName pins the other half of the
+// defect. The shipped description said "optionally a named workload", but `name` is
+// matched against the GitOps OBJECT — an Application or a Kustomization — which is
+// never named after the pod it renders. A model that believes it may pass a workload
+// name will, and the empty result it gets back is what the absence claim was built on.
+func TestWhatChangedDescriptionDoesNotInviteAWorkloadName(t *testing.T) {
+	d := WhatChangedTool{}.Description()
+	if strings.Contains(strings.ToLower(d), "named workload") {
+		t.Errorf("description invites a workload name for `name`, which cannot match:\n%s", d)
+	}
+	// It must say what the argument IS, and that a pod name is not it.
+	for _, want := range []string{"Application", "Kustomization", "NOT a pod"} {
+		if !strings.Contains(d, want) {
+			t.Errorf("description missing %q:\n%s", want, d)
+		}
+	}
+}
+
+// TestWhatChangedPeerListIsStableAndDeduped: several in-window revisions of one object
+// arrive as several Changes, and the model is being handed names to re-call with — not
+// a change count. Duplicates would read as several distinct objects.
+func TestWhatChangedPeerListIsStableAndDeduped(t *testing.T) {
+	rev := func(name, to string) providers.Change {
+		return providers.Change{
+			Workload: providers.Workload{Kind: "Application", Name: name, Namespace: "argocd"},
+			Engine:   providers.EngineArgoCD, ToRev: to,
+		}
+	}
+	gp := &scopedGitOps{byNamespace: []providers.Change{
+		rev("monitoring", "c"), rev("monitoring", "b"), rev("essentials", "a"), rev("monitoring", "a"),
+	}}
+	out, err := WhatChangedTool{GitOps: gp}.Call(context.Background(),
+		`{"namespace":"observability","name":"vmagent-vmagent-0"}`)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if n := strings.Count(out, "Application argocd/monitoring"); n != 1 {
+		t.Errorf("monitoring listed %d times, want 1 (three revisions are one object):\n%s", n, out)
+	}
+	// Sorted, so the rendering does not change between identical calls.
+	if strings.Index(out, "argocd/essentials") > strings.Index(out, "argocd/monitoring") {
+		t.Errorf("peer list is not sorted:\n%s", out)
+	}
+}

--- a/internal/investigate/whatchanged_scope_test.go
+++ b/internal/investigate/whatchanged_scope_test.go
@@ -17,7 +17,7 @@ import (
 // because the number of provider calls is part of the contract here — the probe must
 // not fire when there is nothing to probe.
 type scopedGitOps struct {
-	byName      []providers.Change // returned when sel.Name != ""
+	fakeGitOps                     // Diff + WatchFailures; its `changes` is the by-name answer
 	byNamespace []providers.Change // returned when sel.Name == ""
 	nsErr       error              // returned instead of byNamespace
 	seen        []providers.Selector
@@ -26,7 +26,7 @@ type scopedGitOps struct {
 func (f *scopedGitOps) Changes(_ context.Context, _ providers.TimeWindow, sel providers.Selector) ([]providers.Change, error) {
 	f.seen = append(f.seen, sel)
 	if sel.Name != "" {
-		return f.byName, nil
+		return f.changes, nil
 	}
 	if f.nsErr != nil {
 		return nil, f.nsErr
@@ -34,32 +34,19 @@ func (f *scopedGitOps) Changes(_ context.Context, _ providers.TimeWindow, sel pr
 	return f.byNamespace, nil
 }
 
-func (f *scopedGitOps) Diff(context.Context, providers.Change) (providers.Diff, error) {
-	return providers.Diff{}, nil
-}
-
-func (f *scopedGitOps) WatchFailures(context.Context) (<-chan providers.FailureEvent, error) {
-	ch := make(chan providers.FailureEvent)
-	close(ch)
-	return ch, nil
-}
-
-// absenceClaims are phrasings a model can quote as "Git shows no change". The first
-// is the exact string that shipped: an investigation into a pod on a cluster this
-// Argo CD does not manage read it as evidence, put it in the finding's provenance and
-// its only citation, and ruled out a config change on it.
-var absenceClaims = []string{
-	"no changes found",
-	"no Git changes",
-	"the config did not change",
-}
-
-func assertNoAbsenceClaim(t *testing.T, out string) {
+// assertRefusesAbsence checks the SHAPE of the claim rather than blocklisting phrasings.
+// gitops_kinds.go records why: a forbidden-word list shipped here once and "no such object
+// exists" slipped straight past it, so the package standardised on asserting that the
+// disclaimer marker is PRESENT. Every unresolved answer must carry notAConfigStatement, and
+// none may still carry the exact sentence that caused the incident.
+func assertRefusesAbsence(t *testing.T, out string) {
 	t.Helper()
-	for _, c := range absenceClaims {
-		if strings.Contains(strings.ToLower(out), strings.ToLower(c)) {
-			t.Errorf("output claims absence with %q; an unresolved selector establishes nothing about Git history:\n%s", c, out)
-		}
+	if !strings.Contains(out, notAConfigStatement) {
+		t.Errorf("output does not carry the not-a-config-statement disclaimer:\n%s", out)
+	}
+	// The one literal worth pinning: this exact string is what the model quoted as evidence.
+	if strings.Contains(out, "no changes found") {
+		t.Errorf("output still carries the shipped absence claim:\n%s", out)
 	}
 }
 
@@ -74,9 +61,11 @@ func TestWhatChangedUnresolvedSelectorDoesNotClaimAbsence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Call: %v", err)
 	}
-	assertNoAbsenceClaim(t, out)
+	assertRefusesAbsence(t, out)
 	// It must state the scope outcome: nothing resolved, so nothing was searched.
-	for _, want := range []string{"no GitOps object", "no repository was searched"} {
+	// "repository was searched" without the leading article: notAConfigStatement opens a
+	// sentence with it, so pinning the lowercase form would break on capitalisation alone.
+	for _, want := range []string{"no GitOps object", "repository was searched"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q:\n%s", want, out)
 		}
@@ -101,7 +90,7 @@ func TestWhatChangedUnresolvedNameListsWhatTheNamespaceDoesHave(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Call: %v", err)
 	}
-	assertNoAbsenceClaim(t, out)
+	assertRefusesAbsence(t, out)
 	for _, want := range []string{"monitoring", "essentials", "vmagent-vmagent-0"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q:\n%s", want, out)
@@ -122,7 +111,7 @@ func TestWhatChangedNamespaceOnlySelectorDoesNotReprobe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Call: %v", err)
 	}
-	assertNoAbsenceClaim(t, out)
+	assertRefusesAbsence(t, out)
 	if len(gp.seen) != 1 {
 		t.Errorf("namespace-only selector made %d provider calls, want 1: %+v", len(gp.seen), gp.seen)
 	}
@@ -138,26 +127,35 @@ func TestWhatChangedProbeFailureStillRefusesAbsence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Call must not fail the investigation on a probe error: %v", err)
 	}
-	assertNoAbsenceClaim(t, out)
+	assertRefusesAbsence(t, out)
 	if !strings.Contains(out, "no GitOps object") {
 		t.Errorf("output missing the scope statement:\n%s", out)
+	}
+	// The probe-error branch alone must NOT assert a cause: whether the namespace is
+	// managed is exactly what the failed probe left unestablished.
+	if strings.Contains(out, unresolvedCauses) {
+		t.Errorf("probe-error branch names causes it did not establish:\n%s", out)
 	}
 }
 
 // TestWhatChangedResolvedSelectorIsUnaffected guards the happy path: when the
 // selector does resolve, none of the above wording appears and no probe is issued.
 func TestWhatChangedResolvedSelectorIsUnaffected(t *testing.T) {
-	gp := &scopedGitOps{byName: []providers.Change{{
+	gp := &scopedGitOps{fakeGitOps: fakeGitOps{changes: []providers.Change{{
 		Workload: providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"},
 		Engine:   providers.EngineFlux, Type: providers.ChangeSync, FromRev: "aaa", ToRev: "bbb",
-	}}}
+	}}}}
 	out, err := WhatChangedTool{GitOps: gp}.Call(context.Background(),
 		`{"namespace":"flux-system","name":"apps"}`)
 	if err != nil {
 		t.Fatalf("Call: %v", err)
 	}
-	if strings.Contains(out, "no GitOps object") || strings.Contains(out, "no repository was searched") {
-		t.Errorf("resolved selector must not carry the scope statement:\n%s", out)
+	// NOT "must not contain 'no GitOps object'" — the pre-existing B2 note prints exactly
+	// that ("note: no GitOps object in namespace %q; matched by name across namespaces")
+	// whenever a name resolves in another namespace, which is the standard Flux bootstrap
+	// shape. Pin the sentences this change introduced instead.
+	if strings.Contains(out, notAConfigStatement) || strings.Contains(out, "repository was searched") {
+		t.Errorf("resolved selector must not carry the unresolved-selector answer:\n%s", out)
 	}
 	if len(gp.seen) != 1 {
 		t.Errorf("resolved selector made %d provider calls, want 1", len(gp.seen))
@@ -175,7 +173,12 @@ func TestWhatChangedDescriptionDoesNotInviteAWorkloadName(t *testing.T) {
 		t.Errorf("description invites a workload name for `name`, which cannot match:\n%s", d)
 	}
 	// It must say what the argument IS, and that a pod name is not it.
-	for _, want := range []string{"Application", "Kustomization", "NOT a pod"} {
+	// And it must not over-correct the other way: a BARE workload name often does match,
+	// so the claim has to be about the suffix, not about workload names.
+	if strings.Contains(d, "never match") && !strings.Contains(d, "suffix") {
+		t.Errorf("description claims workload names never match, losing the bare-name retry:\n%s", d)
+	}
+	for _, want := range []string{"Application", "Kustomization", "NEVER a pod", "suffix"} {
 		if !strings.Contains(d, want) {
 			t.Errorf("description missing %q:\n%s", want, d)
 		}

--- a/internal/investigate/whatchanged_tool.go
+++ b/internal/investigate/whatchanged_tool.go
@@ -6,7 +6,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"strings"
 	"time"
 
@@ -26,16 +27,23 @@ func (t WhatChangedTool) Name() string { return "what_changed" }
 // Description returns the human-readable tool description advertised to the model.
 //
 // "optionally a named workload" is what shipped, and it invited the call that cannot
-// work: `name` is matched against the GitOps OBJECT's name — an Argo CD Application or
-// a Flux Kustomization — and those are named after apps, never after the pod or
-// Deployment they render. A model reading "named workload" passes the failing pod's
-// name, gets an empty result, and the empty result used to read as "Git shows no
-// change". Naming the argument correctly removes the first half of that.
+// work: `name` is matched against the GitOps OBJECT's name, so the failing pod's name —
+// which carries a ReplicaSet hash or a StatefulSet ordinal — can never match. A model
+// reading "named workload" passes exactly that, gets an empty result, and the empty
+// result used to read as "Git shows no change".
+//
+// The correction has a floor, though: a BARE workload name frequently DOES match, because
+// Kustomizations and Applications are routinely named after the app they render, and both
+// providers deliberately retry a name across all namespaces for that case. Telling the
+// model a Deployment name never matches would lose that narrowing — the accurate claim is
+// about the suffix, not about workload names.
 func (t WhatChangedTool) Description() string {
 	return "List what changed (GitOps revision history + the actual Git diff) for a namespace, " +
-		"optionally narrowed to one GitOps object by name. name is the Argo CD Application or " +
-		"Flux Kustomization name, NOT a pod, Deployment or container name — those never match. " +
-		"Prefer the namespace alone; an unmatched name lists the objects that do exist there."
+		"optionally narrowed to one GitOps object by name. name is matched against the Argo CD " +
+		"Application / Flux Kustomization name — often the bare app name (e.g. \"vmagent\"), but " +
+		"NEVER a pod or replicaset name carrying a hash or ordinal suffix (e.g. " +
+		"\"vmagent-vmagent-0\"), which cannot match. Prefer the namespace alone; an unmatched " +
+		"name lists the objects that do exist there."
 }
 
 // Schema returns the JSON Schema for the tool's arguments.
@@ -70,7 +78,8 @@ func (t WhatChangedTool) Call(ctx context.Context, args string) (string, error) 
 	// B2: the provider resolves a workload namespace to its OWNING GitOps object,
 	// which commonly lives elsewhere (Flux Kustomizations in flux-system, Argo
 	// Applications in argocd). Flag that so a match in another namespace is never
-	// misread as "the tool ignored my namespace" — and "no changes" stays honest.
+	// misread as "the tool ignored my namespace". (This used to end "and 'no changes' stays
+	// honest", naming a return string unresolvedSelector below has since replaced.)
 	if in.Namespace != "" && !anyInNamespace(changes, in.Namespace) {
 		fmt.Fprintf(&b, "note: no GitOps object in namespace %q; matched by name across namespaces (the owning object lives elsewhere, e.g. flux-system/argocd)\n", in.Namespace)
 	}
@@ -134,78 +143,96 @@ func (t WhatChangedTool) Call(ctx context.Context, args string) (string, error) 
 // When a name narrowed the lookup, one namespace-only probe separates "this engine
 // manages nothing in that namespace" from "it does, and your name is not one of its
 // objects" — and the second can then list the names that do exist, the same
-// recover-don't-guess shape alert_rule uses for an unmatched alertname. The probe runs
-// only on this path and only when a name was given; the clone cache the caller opened
-// is still active, so any source resolution it triggers is shared rather than repeated.
+// recover-don't-guess shape alert_rule uses for an unmatched alertname.
+//
+// THE PROBE IS NOT FREE, and an earlier version of this comment claimed the opposite. It
+// said the caller's clone cache made any source resolution shared — but flux's changesFor
+// sets `c.When = changeTime(...)` immediately before appending, with no `continue` between
+// them, so an empty result PROVES changeTime never ran and the cache is cold. Every clone
+// the probe triggers is therefore a fresh one, against the 60s ToolTimeout, and on flux it
+// costs a cluster-wide List plus a GetGitRepository and a CommitTime clone per source repo
+// — to render names only. On Argo CD it is a duplicate List and no git I/O at all, so the
+// cost is asymmetric between the two engines. The durable fix is for the provider to report
+// what it established, which removes this call entirely.
 func (t WhatChangedTool) unresolvedSelector(ctx context.Context, namespace, name string) string {
-	sel := fmt.Sprintf("namespace %q", namespace)
-	if name != "" {
-		sel += fmt.Sprintf(", name %q", name)
-	}
-	// No name means the original lookup was ALREADY namespace-only, so the probe would
-	// re-ask the identical question for nothing.
+	// Hoisted before sel is built: with no name the original lookup was ALREADY
+	// namespace-only, so the probe would re-ask the identical question for nothing, and
+	// sel's name half can never apply.
 	if name == "" {
-		return fmt.Sprintf("no GitOps object resolved for %s: this engine reports no diffable "+
-			"object there (nothing managed in that namespace, or nothing with an applied "+
-			"revision and a resolvable source), so no repository was searched. That is a scope "+
-			"result about this tool, NOT a statement that the configuration is unchanged — do "+
-			"not cite it as evidence against a config cause. To establish that, name a GitOps "+
-			"object with gitops_resource_status, or check whether the resource is managed by a "+
-			"GitOps engine this deployment can see at all.", sel)
+		return fmt.Sprintf("no GitOps object resolved for namespace %q: this engine reports no "+
+			"diffable object there%s", namespace, unresolvedCauses+notAConfigStatement+gitopsNextStep)
 	}
+	sel := fmt.Sprintf("namespace %q, name %q", namespace, name)
 	peers, err := t.GitOps.Changes(ctx, providers.TimeWindow{}, providers.Selector{Namespace: namespace})
-	if err != nil {
+	switch {
+	case err != nil:
 		// The probe is an aid, never a gate: its failure must not fail the investigation,
 		// and must not fall back to the absence claim this function exists to remove. Say
-		// which half is unestablished instead of guessing at it.
+		// which half is unestablished instead of guessing at it — so this branch alone does
+		// NOT carry unresolvedCauses, because whether the namespace is managed is unknown.
 		return fmt.Sprintf("no GitOps object resolved for %s, and no repository was searched. "+
 			"The follow-up namespace-only probe FAILED (%v), so whether this engine manages "+
-			"anything in %q is unestablished. Nothing here bears on whether the configuration "+
-			"changed — do not cite it as evidence against a config cause.", sel, err, namespace)
-	}
-	if len(peers) == 0 {
+			"anything there is unestablished.%s%s", sel, err, notAConfigStatement, gitopsNextStep)
+	case len(peers) == 0:
 		return fmt.Sprintf("no GitOps object resolved for %s, and a namespace-only retry found "+
-			"none either: this engine reports no diffable object in %q, so no repository was "+
-			"searched. Either nothing there is managed by this engine — a resource on another "+
-			"cluster reads exactly like this — or what is managed has no applied revision and "+
-			"resolvable source. That is a scope result about this tool, NOT a statement that "+
-			"the configuration is unchanged; do not cite it as evidence against a config cause.",
-			sel, namespace)
+			"none either: this engine reports no diffable object there%s", sel,
+			unresolvedCauses+notAConfigStatement+gitopsNextStep)
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "the name %q did not resolve to a GitOps object, so no repository was "+
-		"searched for it — but %q IS managed by this engine. A workload or pod name is not a "+
-		"GitOps object name; re-call with the namespace alone, or with one of the objects below. "+
-		"Nothing here bears on whether the configuration changed.\n", name, namespace)
-	fmt.Fprintf(&b, "GitOps objects resolving for namespace %q:\n", namespace)
+		"searched for it — but namespace %q IS managed by this engine, so re-call with the "+
+		"namespace alone, or with one of the bare object names below.%s\n",
+		name, namespace, notAConfigStatement)
 	names := peerNames(peers)
-	for i, n := range names {
-		if i >= maxToolRows {
-			fmt.Fprintf(&b, "  … (%d more)\n", len(names)-i)
-			break
-		}
-		fmt.Fprintf(&b, "  %s\n", n)
-	}
+	renderRows(&b, len(names), "more", func(i int) { fmt.Fprintf(&b, "  %s\n", names[i]) })
 	return b.String()
 }
 
-// peerNames renders each change's owning object as "engine Kind namespace/name",
-// deduplicated and sorted so the list is stable across calls: several in-window
-// revisions of one object arrive as several Changes, and the model is being offered
-// names to re-call with, not a change count.
+// The three fragments every unresolved-selector answer is composed from. They were four
+// hand-written variants of the same sentences, which had already drifted before review —
+// one pair differed only in "unchanged — do not cite" versus "unchanged; do not cite", and
+// two of the four silently dropped the recovery advice entirely, on exactly the branches
+// reached when a name was given and the model most needs a next step.
+const (
+	// unresolvedCauses names the causes an empty result CAN have, as possibilities. It is
+	// omitted on the probe-error branch, where the namespace question is unestablished.
+	//
+	// It is deliberately not exhaustive in one respect worth knowing: flux's changesFor
+	// swallows a GetGitRepository error with a bare `continue`, so an RBAC Forbidden on the
+	// source reaches here indistinguishable from a benign skip and is filed under "no
+	// applied revision or resolvable source". That is #503's mechanism — a denial collapsed
+	// into an absence — surviving one layer down, and it cannot be fixed from the tool:
+	// providers.LookupDenied exists for it and only the provider can set it.
+	unresolvedCauses = " — nothing managed there, nothing with an applied revision and a " +
+		"resolvable source, or a source read this engine was refused and skipped. A resource " +
+		"on a cluster this engine does not manage reads exactly like this too."
+
+	// notAConfigStatement is the load-bearing caveat, in the package's established shape:
+	// "says NOTHING about whether X" (gitops_kinds.go, resource_spec_tool.go), which the
+	// guard tests assert the PRESENCE of. A blocklist of forbidden phrasings is the retired
+	// style — gitops_kinds.go records that "no such object exists" slipped straight past one.
+	notAConfigStatement = " No repository was searched, so this says NOTHING about whether " +
+		"the configuration changed — do not cite it as evidence against a config cause."
+
+	// gitopsNextStep is the recovery half. It names a LISTING call rather than asking the
+	// model to invent an object name: gitops_resource_status needs kind+name+namespace, so
+	// pointing at it here would invite a guess, and a guessed resource that later shows up
+	// as an action target is what observedresources.go flags as possibly hallucinated.
+	gitopsNextStep = " To establish anything about the config, re-call with the namespace " +
+		"alone to list what this engine does manage, or confirm the resource is managed by a " +
+		"GitOps engine this deployment can see at all."
+)
+
+// peerNames renders each change's owning object as "engine Kind namespace/name" via
+// Workload.Ref, the canonical identity form, deduplicated and sorted so the list is stable
+// across calls: several in-window revisions of one object arrive as several Changes, and
+// the model is being offered names to re-call with, not a change count.
 func peerNames(changes []providers.Change) []string {
 	seen := make(map[string]struct{}, len(changes))
-	out := make([]string, 0, len(changes))
 	for _, c := range changes {
-		n := fmt.Sprintf("%s %s %s/%s", c.Engine, c.Workload.Kind, c.Workload.Namespace, c.Workload.Name)
-		if _, dup := seen[n]; dup {
-			continue
-		}
-		seen[n] = struct{}{}
-		out = append(out, n)
+		seen[fmt.Sprintf("%s %s %s", c.Engine, c.Workload.Kind, c.Workload.Ref())] = struct{}{}
 	}
-	sort.Strings(out)
-	return out
+	return slices.Sorted(maps.Keys(seen))
 }
 
 const (

--- a/internal/investigate/whatchanged_tool.go
+++ b/internal/investigate/whatchanged_tool.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -23,8 +24,18 @@ type WhatChangedTool struct {
 func (t WhatChangedTool) Name() string { return "what_changed" }
 
 // Description returns the human-readable tool description advertised to the model.
+//
+// "optionally a named workload" is what shipped, and it invited the call that cannot
+// work: `name` is matched against the GitOps OBJECT's name — an Argo CD Application or
+// a Flux Kustomization — and those are named after apps, never after the pod or
+// Deployment they render. A model reading "named workload" passes the failing pod's
+// name, gets an empty result, and the empty result used to read as "Git shows no
+// change". Naming the argument correctly removes the first half of that.
 func (t WhatChangedTool) Description() string {
-	return "List what changed (GitOps revision history + the actual Git diff) for a namespace, optionally a named workload."
+	return "List what changed (GitOps revision history + the actual Git diff) for a namespace, " +
+		"optionally narrowed to one GitOps object by name. name is the Argo CD Application or " +
+		"Flux Kustomization name, NOT a pod, Deployment or container name — those never match. " +
+		"Prefer the namespace alone; an unmatched name lists the objects that do exist there."
 }
 
 // Schema returns the JSON Schema for the tool's arguments.
@@ -53,7 +64,7 @@ func (t WhatChangedTool) Call(ctx context.Context, args string) (string, error) 
 		return "", err
 	}
 	if len(changes) == 0 {
-		return "no changes found for the given selector", nil
+		return t.unresolvedSelector(ctx, in.Namespace, in.Name), nil
 	}
 	var b strings.Builder
 	// B2: the provider resolves a workload namespace to its OWNING GitOps object,
@@ -91,6 +102,110 @@ func (t WhatChangedTool) Call(ctx context.Context, args string) (string, error) 
 		renderDiff(&b, d)
 	}
 	return b.String(), nil
+}
+
+// unresolvedSelector reports what the lookup ESTABLISHED when the engine yielded no
+// change, rather than asserting what Git does or does not contain.
+//
+// The shipped wording was "no changes found for the given selector" — a claim about
+// Git history in answer to a question this tool may never have asked. Observed live:
+// asked about a pod running on a cluster this Argo CD does not manage, the tool
+// returned that string, and the model put it in the finding's `provenance`, made it
+// the entry's ONLY citation, and ruled out a config change on it. The same finding's
+// data-gaps section stated correctly that the cluster was invisible to the cluster
+// tools — the investigation contradicted itself, and this sentence is what let it.
+//
+// An empty result has three causes and none of them is "the repository shows no change":
+//
+//  1. Nothing matched the selector. No GitOps object carries that name/namespace, so no
+//     repoURL was ever resolved and no clone happened. This is the ORDINARY case for a
+//     workload-level name: Applications and Kustomizations are named after apps, not
+//     after pods, so `name: vmagent-vmagent-0` cannot match one.
+//  2. Objects matched but none was diffable — no applied revision, no sourceRef, or an
+//     unresolvable source. Both providers `continue` past those.
+//  3. Matched, diffable, and genuinely nothing in the window. Unreachable from here: a
+//     zero TimeWindow makes both providers fall back to emitting the current revision
+//     for every object they keep, so a match always produces at least one Change.
+//
+// Cases 1 and 2 are not separable from outside the provider, and picking one would be
+// the same over-claim in a new direction. What IS establishable is that the engine
+// produced no diffable object, so no repository was searched for that selector.
+//
+// When a name narrowed the lookup, one namespace-only probe separates "this engine
+// manages nothing in that namespace" from "it does, and your name is not one of its
+// objects" — and the second can then list the names that do exist, the same
+// recover-don't-guess shape alert_rule uses for an unmatched alertname. The probe runs
+// only on this path and only when a name was given; the clone cache the caller opened
+// is still active, so any source resolution it triggers is shared rather than repeated.
+func (t WhatChangedTool) unresolvedSelector(ctx context.Context, namespace, name string) string {
+	sel := fmt.Sprintf("namespace %q", namespace)
+	if name != "" {
+		sel += fmt.Sprintf(", name %q", name)
+	}
+	// No name means the original lookup was ALREADY namespace-only, so the probe would
+	// re-ask the identical question for nothing.
+	if name == "" {
+		return fmt.Sprintf("no GitOps object resolved for %s: this engine reports no diffable "+
+			"object there (nothing managed in that namespace, or nothing with an applied "+
+			"revision and a resolvable source), so no repository was searched. That is a scope "+
+			"result about this tool, NOT a statement that the configuration is unchanged — do "+
+			"not cite it as evidence against a config cause. To establish that, name a GitOps "+
+			"object with gitops_resource_status, or check whether the resource is managed by a "+
+			"GitOps engine this deployment can see at all.", sel)
+	}
+	peers, err := t.GitOps.Changes(ctx, providers.TimeWindow{}, providers.Selector{Namespace: namespace})
+	if err != nil {
+		// The probe is an aid, never a gate: its failure must not fail the investigation,
+		// and must not fall back to the absence claim this function exists to remove. Say
+		// which half is unestablished instead of guessing at it.
+		return fmt.Sprintf("no GitOps object resolved for %s, and no repository was searched. "+
+			"The follow-up namespace-only probe FAILED (%v), so whether this engine manages "+
+			"anything in %q is unestablished. Nothing here bears on whether the configuration "+
+			"changed — do not cite it as evidence against a config cause.", sel, err, namespace)
+	}
+	if len(peers) == 0 {
+		return fmt.Sprintf("no GitOps object resolved for %s, and a namespace-only retry found "+
+			"none either: this engine reports no diffable object in %q, so no repository was "+
+			"searched. Either nothing there is managed by this engine — a resource on another "+
+			"cluster reads exactly like this — or what is managed has no applied revision and "+
+			"resolvable source. That is a scope result about this tool, NOT a statement that "+
+			"the configuration is unchanged; do not cite it as evidence against a config cause.",
+			sel, namespace)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "the name %q did not resolve to a GitOps object, so no repository was "+
+		"searched for it — but %q IS managed by this engine. A workload or pod name is not a "+
+		"GitOps object name; re-call with the namespace alone, or with one of the objects below. "+
+		"Nothing here bears on whether the configuration changed.\n", name, namespace)
+	fmt.Fprintf(&b, "GitOps objects resolving for namespace %q:\n", namespace)
+	names := peerNames(peers)
+	for i, n := range names {
+		if i >= maxToolRows {
+			fmt.Fprintf(&b, "  … (%d more)\n", len(names)-i)
+			break
+		}
+		fmt.Fprintf(&b, "  %s\n", n)
+	}
+	return b.String()
+}
+
+// peerNames renders each change's owning object as "engine Kind namespace/name",
+// deduplicated and sorted so the list is stable across calls: several in-window
+// revisions of one object arrive as several Changes, and the model is being offered
+// names to re-call with, not a change count.
+func peerNames(changes []providers.Change) []string {
+	seen := make(map[string]struct{}, len(changes))
+	out := make([]string, 0, len(changes))
+	for _, c := range changes {
+		n := fmt.Sprintf("%s %s %s/%s", c.Engine, c.Workload.Kind, c.Workload.Namespace, c.Workload.Name)
+		if _, dup := seen[n]; dup {
+			continue
+		}
+		seen[n] = struct{}{}
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
 }
 
 const (

--- a/internal/investigate/whatchanged_tool.go
+++ b/internal/investigate/whatchanged_tool.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"maps"
-	"slices"
 	"strings"
 	"time"
 
@@ -67,12 +65,13 @@ func (t WhatChangedTool) Call(ctx context.Context, args string) (string, error) 
 	// removes them when the call returns.
 	ctx, done := whatchanged.WithCloneCache(ctx)
 	defer done()
-	changes, err := t.GitOps.Changes(ctx, providers.TimeWindow{}, providers.Selector{Namespace: in.Namespace, Name: in.Name})
+	sel := providers.Selector{Namespace: in.Namespace, Name: in.Name}
+	changes, err := t.GitOps.Changes(ctx, providers.TimeWindow{}, sel)
 	if err != nil {
 		return "", err
 	}
 	if len(changes) == 0 {
-		return t.unresolvedSelector(ctx, in.Namespace, in.Name), nil
+		return t.unresolvedSelector(ctx, providers.TimeWindow{}, sel), nil
 	}
 	var b strings.Builder
 	// B2: the provider resolves a workload namespace to its OWNING GitOps object,
@@ -113,126 +112,46 @@ func (t WhatChangedTool) Call(ctx context.Context, args string) (string, error) 
 	return b.String(), nil
 }
 
-// unresolvedSelector reports what the lookup ESTABLISHED when the engine yielded no
-// change, rather than asserting what Git does or does not contain.
+// unresolvedSelector reports what the enumeration ESTABLISHED when it yielded no change,
+// rather than asserting what Git does or does not contain.
 //
-// The shipped wording was "no changes found for the given selector" — a claim about
-// Git history in answer to a question this tool may never have asked. Observed live:
-// asked about a pod running on a cluster this Argo CD does not manage, the tool
-// returned that string, and the model put it in the finding's `provenance`, made it
-// the entry's ONLY citation, and ruled out a config change on it. The same finding's
-// data-gaps section stated correctly that the cluster was invisible to the cluster
-// tools — the investigation contradicted itself, and this sentence is what let it.
+// The shipped wording was "no changes found for the given selector" — a claim about Git
+// history in reply to a question the tool may never have asked. Observed live: asked about a
+// pod running on a cluster this Argo CD does not manage, the tool returned that string, and
+// the model used it to rule out a GitOps cause, then recorded it as the finding's provenance
+// and the entry's ONLY citation. The same finding's data-gaps section said the cluster was
+// invisible — the investigation contradicted itself, and this sentence is what let it.
 //
-// An empty result has three causes and none of them is "the repository shows no change":
+// THE ANSWER COMES FROM THE PROVIDER, the only place that can give it. An empty list means
+// nothing matched, or something matched but was undiffable, or a source read was REFUSED —
+// the first is about the request, the second about an object that exists, the third not about
+// the cluster at all. providers.ChangesLookupReporter exists for exactly this.
 //
-//  1. Nothing matched the selector. No GitOps object carries that name/namespace, so no
-//     repoURL was ever resolved and no clone happened. This is the ORDINARY case for a
-//     workload-level name: Applications and Kustomizations are named after apps, not
-//     after pods, so `name: vmagent-vmagent-0` cannot match one.
-//  2. Objects matched but none was diffable — no applied revision, no sourceRef, or an
-//     unresolvable source. Both providers `continue` past those.
-//  3. Matched, diffable, and genuinely nothing in the window. Unreachable from here: a
-//     zero TimeWindow makes both providers fall back to emitting the current revision
-//     for every object they keep, so a match always produces at least one Change.
+// An earlier version of this fix guessed instead: it re-called Changes with a namespace-only
+// selector and inferred from whether THAT was empty. Recording why, because the shape is
+// tempting — it could not see a denial at all (so it filed one under "no resolvable source",
+// reintroducing #503 inside the fix for #503), it asserted "this namespace IS managed" from a
+// namespace match that ignores the destination CLUSTER, and it cost a second cluster-wide
+// List plus a cold clone per source repo against the 60s tool timeout, to render names only.
 //
-// Cases 1 and 2 are not separable from outside the provider, and picking one would be
-// the same over-claim in a new direction. What IS establishable is that the engine
-// produced no diffable object, so no repository was searched for that selector.
-//
-// When a name narrowed the lookup, one namespace-only probe separates "this engine
-// manages nothing in that namespace" from "it does, and your name is not one of its
-// objects" — and the second can then list the names that do exist, the same
-// recover-don't-guess shape alert_rule uses for an unmatched alertname.
-//
-// THE PROBE IS NOT FREE, and an earlier version of this comment claimed the opposite. It
-// said the caller's clone cache made any source resolution shared — but flux's changesFor
-// sets `c.When = changeTime(...)` immediately before appending, with no `continue` between
-// them, so an empty result PROVES changeTime never ran and the cache is cold. Every clone
-// the probe triggers is therefore a fresh one, against the 60s ToolTimeout, and on flux it
-// costs a cluster-wide List plus a GetGitRepository and a CommitTime clone per source repo
-// — to render names only. On Argo CD it is a duplicate List and no git I/O at all, so the
-// cost is asymmetric between the two engines. The durable fix is for the provider to report
-// what it established, which removes this call entirely.
-func (t WhatChangedTool) unresolvedSelector(ctx context.Context, namespace, name string) string {
-	// Hoisted before sel is built: with no name the original lookup was ALREADY
-	// namespace-only, so the probe would re-ask the identical question for nothing, and
-	// sel's name half can never apply.
-	if name == "" {
-		return fmt.Sprintf("no GitOps object resolved for namespace %q: this engine reports no "+
-			"diffable object there%s", namespace, unresolvedCauses+notAConfigStatement+gitopsNextStep)
+// A provider without the capability gets the neutral answer, claiming no reason because none
+// was established. Both real providers implement it.
+func (t WhatChangedTool) unresolvedSelector(ctx context.Context, w providers.TimeWindow, sel providers.Selector) string {
+	id := fmt.Sprintf("namespace %q", sel.Namespace)
+	if sel.Name != "" {
+		id += fmt.Sprintf(", name %q", sel.Name)
 	}
-	sel := fmt.Sprintf("namespace %q, name %q", namespace, name)
-	peers, err := t.GitOps.Changes(ctx, providers.TimeWindow{}, providers.Selector{Namespace: namespace})
-	switch {
-	case err != nil:
-		// The probe is an aid, never a gate: its failure must not fail the investigation,
-		// and must not fall back to the absence claim this function exists to remove. Say
-		// which half is unestablished instead of guessing at it — so this branch alone does
-		// NOT carry unresolvedCauses, because whether the namespace is managed is unknown.
-		return fmt.Sprintf("no GitOps object resolved for %s, and no repository was searched. "+
-			"The follow-up namespace-only probe FAILED (%v), so whether this engine manages "+
-			"anything there is unestablished.%s%s", sel, err, notAConfigStatement, gitopsNextStep)
-	case len(peers) == 0:
-		return fmt.Sprintf("no GitOps object resolved for %s, and a namespace-only retry found "+
-			"none either: this engine reports no diffable object there%s", sel,
-			unresolvedCauses+notAConfigStatement+gitopsNextStep)
+	// changesWithLookup is shared with incident_timeline, the other Changes consumer that
+	// rendered an empty list as a statement about Git. The enumeration already ran in Call;
+	// this re-reads it to recover the reason rather than threading a second return value
+	// through every GitOpsProvider caller. It repeats the List, not the resolution work: an
+	// empty result means no object reached the revision/clone path, so there is nothing for
+	// the repeat to redo.
+	_, lk, err := changesWithLookup(ctx, t.GitOps, w, sel)
+	if err != nil {
+		return gitopsChangesAnswer(id, providers.Lookup{Reason: providers.LookupFailed})
 	}
-	var b strings.Builder
-	fmt.Fprintf(&b, "the name %q did not resolve to a GitOps object, so no repository was "+
-		"searched for it — but namespace %q IS managed by this engine, so re-call with the "+
-		"namespace alone, or with one of the bare object names below.%s\n",
-		name, namespace, notAConfigStatement)
-	names := peerNames(peers)
-	renderRows(&b, len(names), "more", func(i int) { fmt.Fprintf(&b, "  %s\n", names[i]) })
-	return b.String()
-}
-
-// The three fragments every unresolved-selector answer is composed from. They were four
-// hand-written variants of the same sentences, which had already drifted before review —
-// one pair differed only in "unchanged — do not cite" versus "unchanged; do not cite", and
-// two of the four silently dropped the recovery advice entirely, on exactly the branches
-// reached when a name was given and the model most needs a next step.
-const (
-	// unresolvedCauses names the causes an empty result CAN have, as possibilities. It is
-	// omitted on the probe-error branch, where the namespace question is unestablished.
-	//
-	// It is deliberately not exhaustive in one respect worth knowing: flux's changesFor
-	// swallows a GetGitRepository error with a bare `continue`, so an RBAC Forbidden on the
-	// source reaches here indistinguishable from a benign skip and is filed under "no
-	// applied revision or resolvable source". That is #503's mechanism — a denial collapsed
-	// into an absence — surviving one layer down, and it cannot be fixed from the tool:
-	// providers.LookupDenied exists for it and only the provider can set it.
-	unresolvedCauses = " — nothing managed there, nothing with an applied revision and a " +
-		"resolvable source, or a source read this engine was refused and skipped. A resource " +
-		"on a cluster this engine does not manage reads exactly like this too."
-
-	// notAConfigStatement is the load-bearing caveat, in the package's established shape:
-	// "says NOTHING about whether X" (gitops_kinds.go, resource_spec_tool.go), which the
-	// guard tests assert the PRESENCE of. A blocklist of forbidden phrasings is the retired
-	// style — gitops_kinds.go records that "no such object exists" slipped straight past one.
-	notAConfigStatement = " No repository was searched, so this says NOTHING about whether " +
-		"the configuration changed — do not cite it as evidence against a config cause."
-
-	// gitopsNextStep is the recovery half. It names a LISTING call rather than asking the
-	// model to invent an object name: gitops_resource_status needs kind+name+namespace, so
-	// pointing at it here would invite a guess, and a guessed resource that later shows up
-	// as an action target is what observedresources.go flags as possibly hallucinated.
-	gitopsNextStep = " To establish anything about the config, re-call with the namespace " +
-		"alone to list what this engine does manage, or confirm the resource is managed by a " +
-		"GitOps engine this deployment can see at all."
-)
-
-// peerNames renders each change's owning object as "engine Kind namespace/name" via
-// Workload.Ref, the canonical identity form, deduplicated and sorted so the list is stable
-// across calls: several in-window revisions of one object arrive as several Changes, and
-// the model is being offered names to re-call with, not a change count.
-func peerNames(changes []providers.Change) []string {
-	seen := make(map[string]struct{}, len(changes))
-	for _, c := range changes {
-		seen[fmt.Sprintf("%s %s %s", c.Engine, c.Workload.Kind, c.Workload.Ref())] = struct{}{}
-	}
-	return slices.Sorted(maps.Keys(seen))
+	return gitopsChangesAnswer(id, lk)
 }
 
 const (

--- a/internal/providers/gitops/argocd/argocd.go
+++ b/internal/providers/gitops/argocd/argocd.go
@@ -85,24 +85,50 @@ func New(reader Reader, differ *whatchanged.Differ) *Provider {
 // zero/unset window falls back to the single current-revision behavior. The
 // enumeration is bounded so a wide window can't explode the output.
 func (p *Provider) Changes(ctx context.Context, w providers.TimeWindow, sel providers.Selector) ([]providers.Change, error) {
+	changes, _, err := p.ChangesLookup(ctx, w, sel)
+	return changes, err
+}
+
+// ChangesLookup implements providers.ChangesLookupReporter: the same enumeration as
+// Changes, plus what an empty result established. The distinction is free here — the
+// skip that produces an empty list is right below, and it used to be dropped into a
+// slog.Debug.
+func (p *Provider) ChangesLookup(ctx context.Context, w providers.TimeWindow, sel providers.Selector) ([]providers.Change, providers.Lookup, error) {
 	apps, err := p.reader.ListApplications(ctx)
 	if err != nil {
-		return nil, err
+		return nil, providers.Lookup{Reason: providers.LookupFailed}, err
 	}
-	changes := p.changesFor(ctx, w, apps, func(a application) bool {
+	scope := sel.Namespace
+	if scope == "" {
+		scope = providers.AllNamespaces
+	}
+	changes, lk := p.changesFor(ctx, w, apps, func(a application) bool {
 		return matchesNamespace(a, sel.Namespace) && (sel.Name == "" || a.Name == sel.Name)
 	})
+	lk.Scopes = []string{scope}
 	if len(changes) == 0 && sel.Name != "" {
-		changes = p.changesFor(ctx, w, apps, func(a application) bool { return a.Name == sel.Name })
+		// B2 fallback: the named object may live in another namespace. The second pass
+		// genuinely searches cluster-wide, so record that scope — and take its reason,
+		// which is the more informed one for the object actually found by name.
+		changes, lk = p.changesFor(ctx, w, apps, func(a application) bool { return a.Name == sel.Name })
+		lk.Scopes = []string{scope, providers.AllNamespaces}
+		if scope == providers.AllNamespaces {
+			lk.Scopes = []string{providers.AllNamespaces}
+		}
 	}
-	return changes, nil
+	return changes, lk, nil
 }
 
 // changesFor maps the Applications accepted by keep into engine-agnostic Changes.
 // With a non-zero window it expands each app into one Change per in-window source
 // revision (G3); otherwise it emits the single current-revision Change.
-func (p *Provider) changesFor(ctx context.Context, w providers.TimeWindow, apps []application, keep func(application) bool) []providers.Change {
+func (p *Provider) changesFor(ctx context.Context, w providers.TimeWindow, apps []application, keep func(application) bool) ([]providers.Change, providers.Lookup) {
 	var changes []providers.Change
+	// LookupAbsent until an Application actually matches: the list WAS searched and
+	// nothing carried that name/namespace. A match that is then skipped for having no
+	// diffable source escalates to LookupUndiffable, because that object EXISTS and is
+	// often the answer (an Application that has never synced has no revision).
+	lk := providers.Lookup{Reason: providers.LookupAbsent}
 	for _, a := range apps {
 		if !keep(a) {
 			continue
@@ -111,6 +137,7 @@ func (p *Provider) changesFor(ctx context.Context, w providers.TimeWindow, apps 
 			slog.Debug("argocd: skipping application with no diffable source",
 				"application", a.Namespace+"/"+a.Name,
 				"hasRepoURL", a.RepoURL != "", "hasRevision", a.Revision != "")
+			lk.Reason = providers.LookupUndiffable
 			continue // not enough to locate a source diff
 		}
 		if wchanges := p.windowChanges(ctx, w, a); len(wchanges) > 0 {
@@ -119,7 +146,7 @@ func (p *Provider) changesFor(ctx context.Context, w providers.TimeWindow, apps 
 		}
 		changes = append(changes, mapApplication(a))
 	}
-	return changes
+	return changes, lk
 }
 
 // windowChanges expands an Application into one Change per source revision that landed

--- a/internal/providers/gitops/argocd/changeslookup_test.go
+++ b/internal/providers/gitops/argocd/changeslookup_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package argocd
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/whatchanged"
+)
+
+// TestChangesLookupReportsWhatItEstablished pins the reason at the point it is DETERMINED.
+// An empty change list used to be indistinguishable from any other empty change list, and
+// what_changed rendered all of them as "no changes found" — a claim about Git in answer to
+// a question about the tool's scope (runlore#503, one layer down).
+func TestChangesLookupReportsWhatItEstablished(t *testing.T) {
+	diffable := application{
+		Name: "monitoring", Namespace: "argocd", RepoURL: "https://github.com/org/repo",
+		Path: "apps/monitoring", Revision: "newsha", PrevRevision: "oldsha",
+	}
+	// Matches the selector but carries nothing to locate a source with — the Application
+	// EXISTS, which is why this must not read as absence.
+	undiffable := application{Name: "monitoring", Namespace: "argocd", RepoURL: "", Revision: ""}
+
+	for _, tc := range []struct {
+		name       string
+		apps       []application
+		sel        providers.Selector
+		wantReason providers.LookupReason
+		wantScopes []string
+	}{{
+		name:       "nothing matched the namespace",
+		apps:       []application{diffable},
+		sel:        providers.Selector{Namespace: "observability"},
+		wantReason: providers.LookupAbsent,
+		wantScopes: []string{"observability"},
+	}, {
+		name: "nothing matched the name, and the cluster-wide retry ran",
+		apps: []application{diffable},
+		// A pod name can never match an Application name; this is the incident's shape.
+		sel:        providers.Selector{Namespace: "observability", Name: "vmagent-vmagent-0"},
+		wantReason: providers.LookupAbsent,
+		wantScopes: []string{"observability", providers.AllNamespaces},
+	}, {
+		name:       "matched, but no diffable source",
+		apps:       []application{undiffable},
+		sel:        providers.Selector{Namespace: "argocd"},
+		wantReason: providers.LookupUndiffable,
+		wantScopes: []string{"argocd"},
+	}, {
+		name:       "an empty selector searches all namespaces, and says so once",
+		apps:       []application{undiffable},
+		sel:        providers.Selector{},
+		wantReason: providers.LookupUndiffable,
+		wantScopes: []string{providers.AllNamespaces},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := New(fakeReader{apps: tc.apps}, &whatchanged.Differ{})
+			changes, lk, err := p.ChangesLookup(context.Background(), providers.TimeWindow{}, tc.sel)
+			if err != nil {
+				t.Fatalf("ChangesLookup: %v", err)
+			}
+			if len(changes) != 0 {
+				t.Fatalf("want an empty change list to exercise the Lookup, got %d", len(changes))
+			}
+			if lk.Reason != tc.wantReason {
+				t.Errorf("Reason = %q, want %q", lk.Reason, tc.wantReason)
+			}
+			if !slices.Equal(lk.Scopes, tc.wantScopes) {
+				t.Errorf("Scopes = %v, want %v", lk.Scopes, tc.wantScopes)
+			}
+		})
+	}
+}
+
+// TestChangesDelegatesToChangesLookup: Changes must stay a thin wrapper, so the two can
+// never disagree about what the enumeration found.
+func TestChangesDelegatesToChangesLookup(t *testing.T) {
+	r := fakeReader{apps: []application{{
+		Name: "harbor", Namespace: "argocd", RepoURL: "https://github.com/org/repo",
+		Path: "apps/harbor", Revision: "newsha", PrevRevision: "oldsha",
+	}}}
+	p := New(r, &whatchanged.Differ{})
+	viaChanges, err := p.Changes(context.Background(), providers.TimeWindow{}, providers.Selector{})
+	if err != nil {
+		t.Fatalf("Changes: %v", err)
+	}
+	viaLookup, _, err := p.ChangesLookup(context.Background(), providers.TimeWindow{}, providers.Selector{})
+	if err != nil {
+		t.Fatalf("ChangesLookup: %v", err)
+	}
+	if len(viaChanges) != len(viaLookup) || len(viaChanges) != 1 {
+		t.Fatalf("Changes returned %d, ChangesLookup %d, want 1 each", len(viaChanges), len(viaLookup))
+	}
+}
+
+// TestProviderImplementsChangesLookupReporter pins the optional capability, since consumers
+// type-assert for it and a silent loss degrades what_changed to the neutral answer.
+// Compile-time assertion, not a test: consumers type-assert for this optional capability,
+// so losing it would silently degrade what_changed and incident_timeline to the neutral
+// answer rather than fail anything.
+var _ providers.ChangesLookupReporter = (*Provider)(nil)

--- a/internal/providers/gitops/flux/changeslookup_test.go
+++ b/internal/providers/gitops/flux/changeslookup_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package flux
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/whatchanged"
+)
+
+// forbiddenReader answers GetGitRepository with a real RBAC Forbidden, which is the case
+// this whole restructure exists for: changesFor used to `continue` past it with a bare
+// error check, so a refused read arrived at the tool indistinguishable from a benign skip
+// and was reported as "nothing with a resolvable source" — a denial rendered as an absence,
+// which is precisely runlore#503's mechanism.
+type forbiddenReader struct{ fakeReader }
+
+func (f forbiddenReader) GetGitRepository(_ context.Context, _, name string) (gitRepository, error) {
+	return gitRepository{}, apierrors.NewForbidden(
+		schema.GroupResource{Group: "source.toolkit.fluxcd.io", Resource: "gitrepositories"},
+		name, nil)
+}
+
+func TestChangesLookupReportsWhatItEstablished(t *testing.T) {
+	diffable := kustomization{
+		Name: "apps", Namespace: "flux-system", Path: "./apps",
+		SourceName: "flux-system", SourceNamespace: "flux-system", Revision: "main@sha1:abc123",
+	}
+	grs := map[string]gitRepository{"flux-system/flux-system": {URL: "https://github.com/org/repo"}}
+
+	for _, tc := range []struct {
+		name       string
+		reader     Reader
+		sel        providers.Selector
+		wantReason providers.LookupReason
+		wantScopes []string
+	}{{
+		name:       "nothing matched the namespace",
+		reader:     fakeReader{ks: []kustomization{diffable}, grs: grs},
+		sel:        providers.Selector{Namespace: "observability"},
+		wantReason: providers.LookupAbsent,
+		wantScopes: []string{"observability"},
+	}, {
+		name: "matched but never reconciled — the object EXISTS",
+		reader: fakeReader{ks: []kustomization{{
+			Name: "vmagent", Namespace: "observability", Path: "./vmagent",
+			SourceName: "flux-system", SourceNamespace: "flux-system", Revision: "", // never applied
+		}}, grs: grs},
+		sel:        providers.Selector{Namespace: "observability"},
+		wantReason: providers.LookupUndiffable,
+		wantScopes: []string{"observability"},
+	}, {
+		name: "matched but the source read was REFUSED — never an absence",
+		reader: forbiddenReader{fakeReader{ks: []kustomization{{
+			Name: "vmagent", Namespace: "observability", Path: "./vmagent",
+			SourceName: "flux-system", SourceNamespace: "flux-system", Revision: "main@sha1:abc",
+		}}}},
+		sel:        providers.Selector{Namespace: "observability"},
+		wantReason: providers.LookupDenied,
+		wantScopes: []string{"observability"},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := New(tc.reader, &whatchanged.Differ{})
+			changes, lk, err := p.ChangesLookup(context.Background(), providers.TimeWindow{}, tc.sel)
+			if err != nil {
+				t.Fatalf("ChangesLookup: %v", err)
+			}
+			if len(changes) != 0 {
+				t.Fatalf("want an empty change list to exercise the Lookup, got %d", len(changes))
+			}
+			if lk.Reason != tc.wantReason {
+				t.Errorf("Reason = %q, want %q", lk.Reason, tc.wantReason)
+			}
+			if !slices.Equal(lk.Scopes, tc.wantScopes) {
+				t.Errorf("Scopes = %v, want %v", lk.Scopes, tc.wantScopes)
+			}
+		})
+	}
+}
+
+// TestDeniedIsNeverDowngraded pins the precedence. A namespace holding BOTH a refused
+// source and a merely-undiffable object must report the denial: a search that never ran
+// cannot be reported as one that came back empty, whatever else the loop saw afterwards.
+func TestDeniedIsNeverDowngraded(t *testing.T) {
+	r := forbiddenReader{fakeReader{ks: []kustomization{
+		{Name: "refused", Namespace: "observability", Path: "./a", SourceName: "src", SourceNamespace: "observability", Revision: "main@sha1:abc"},
+		{Name: "never-applied", Namespace: "observability", Path: "./b", SourceName: "src", SourceNamespace: "observability", Revision: ""},
+	}}}
+	p := New(r, &whatchanged.Differ{})
+	_, lk, err := p.ChangesLookup(context.Background(), providers.TimeWindow{}, providers.Selector{Namespace: "observability"})
+	if err != nil {
+		t.Fatalf("ChangesLookup: %v", err)
+	}
+	if lk.Reason != providers.LookupDenied {
+		t.Errorf("Reason = %q, want %q — a denial must outrank an undiffable skip", lk.Reason, providers.LookupDenied)
+	}
+}
+
+// Compile-time assertion, not a test: consumers type-assert for this optional capability,
+// so losing it would silently degrade what_changed and incident_timeline to the neutral
+// answer rather than fail anything.
+var _ providers.ChangesLookupReporter = (*Provider)(nil)

--- a/internal/providers/gitops/flux/flux.go
+++ b/internal/providers/gitops/flux/flux.go
@@ -116,34 +116,64 @@ func New(reader Reader, differ *whatchanged.Differ) *Provider {
 // window falls back to the single-latest-revision behavior. The enumeration is bounded
 // (cap + committer-time short-circuit) so a wide window can't explode the output.
 func (p *Provider) Changes(ctx context.Context, w providers.TimeWindow, sel providers.Selector) ([]providers.Change, error) {
+	changes, _, err := p.ChangesLookup(ctx, w, sel)
+	return changes, err
+}
+
+// ChangesLookup implements providers.ChangesLookupReporter: the same enumeration as
+// Changes, plus what an empty result established. Four of the five `continue`s in
+// changesFor below already know which case they hit; this stops throwing that away.
+func (p *Provider) ChangesLookup(ctx context.Context, w providers.TimeWindow, sel providers.Selector) ([]providers.Change, providers.Lookup, error) {
 	ks, err := p.reader.ListKustomizations(ctx)
 	if err != nil {
-		return nil, err
+		return nil, providers.Lookup{Reason: providers.LookupFailed}, err
 	}
-	changes := p.changesFor(ctx, w, ks, func(k kustomization) bool {
+	scope := sel.Namespace
+	if scope == "" {
+		scope = providers.AllNamespaces
+	}
+	changes, lk := p.changesFor(ctx, w, ks, func(k kustomization) bool {
 		return matchesNamespace(k, sel.Namespace) && (sel.Name == "" || k.Name == sel.Name)
 	})
+	lk.Scopes = []string{scope}
 	// B2 fallback: the namespace filter found nothing, but a named object might live
 	// in another namespace (the flux-system bootstrap layout). Retry by name across
 	// every namespace rather than returning a false-negative "no changes".
 	if len(changes) == 0 && sel.Name != "" {
-		changes = p.changesFor(ctx, w, ks, func(k kustomization) bool { return k.Name == sel.Name })
+		changes, lk = p.changesFor(ctx, w, ks, func(k kustomization) bool { return k.Name == sel.Name })
+		lk.Scopes = []string{scope, providers.AllNamespaces}
+		if scope == providers.AllNamespaces {
+			lk.Scopes = []string{providers.AllNamespaces}
+		}
 	}
-	return changes, nil
+	return changes, lk, nil
 }
 
 // changesFor maps the Kustomizations accepted by keep into engine-agnostic Changes,
 // resolving each source URL (cached per source) and populating When. With a non-zero
 // window it expands each diffable-Git Kustomization into one Change per in-window
 // source revision (G3); otherwise it emits the single current-revision Change.
-func (p *Provider) changesFor(ctx context.Context, w providers.TimeWindow, ks []kustomization, keep func(kustomization) bool) []providers.Change {
+func (p *Provider) changesFor(ctx context.Context, w providers.TimeWindow, ks []kustomization, keep func(kustomization) bool) ([]providers.Change, providers.Lookup) {
 	urlCache := map[string]string{}
 	var changes []providers.Change
+	// LookupAbsent until a Kustomization matches; a match then skipped for being
+	// undiffable escalates to LookupUndiffable (the object exists — a Kustomization with
+	// no applied revision is often the answer); a source read REFUSED by RBAC escalates
+	// further to LookupDenied and is never downgraded, because a search that never ran
+	// must not be reported as one that came back empty. That precedence is the whole
+	// point: #503 was a denial rendered as an absence.
+	lk := providers.Lookup{Reason: providers.LookupAbsent}
+	undiffable := func() {
+		if lk.Reason != providers.LookupDenied {
+			lk.Reason = providers.LookupUndiffable
+		}
+	}
 	for _, k := range ks {
 		if !keep(k) {
 			continue
 		}
 		if k.Revision == "" || k.SourceName == "" {
+			undiffable()
 			continue // nothing applied yet / no source to attribute the change to
 		}
 		isGit := k.SourceKind == "" || k.SourceKind == "GitRepository"
@@ -155,6 +185,7 @@ func (p *Provider) changesFor(ctx context.Context, w providers.TimeWindow, ks []
 		url := ""
 		if isGit {
 			if k.Path == "" {
+				undiffable()
 				continue // a GitRepository change with no path can't be located for a diff
 			}
 			key := k.SourceNamespace + "/" + k.SourceName
@@ -162,12 +193,22 @@ func (p *Provider) changesFor(ctx context.Context, w providers.TimeWindow, ks []
 			if !ok {
 				gr, err := p.reader.GetGitRepository(ctx, k.SourceNamespace, k.SourceName)
 				if err != nil {
-					continue // source not resolvable (missing/transient) — skip, don't abort
+					// A Forbidden here is NOT a missing source: the read never happened, so
+					// reporting it as "nothing with a resolvable source" is #503's mechanism
+					// (a denial collapsed into an absence) reappearing on this path. It was a
+					// bare `continue` before, which is exactly how that bug shipped last time.
+					if apierrors.IsForbidden(err) {
+						lk.Reason = providers.LookupDenied
+					} else {
+						undiffable()
+					}
+					continue // source not resolvable (missing/transient/refused) — skip, don't abort
 				}
 				cached = gr.URL
 				urlCache[key] = cached
 			}
 			if cached == "" {
+				undiffable()
 				continue
 			}
 			url = cached
@@ -185,7 +226,7 @@ func (p *Provider) changesFor(ctx context.Context, w providers.TimeWindow, ks []
 		c.When = p.changeTime(ctx, url, toRev, k.ReadyTime)
 		changes = append(changes, c)
 	}
-	return changes
+	return changes, lk
 }
 
 // windowChanges expands a diffable-Git Kustomization into one Change per source

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -364,6 +364,12 @@ const (
 	LookupUnresolvable LookupReason = "unresolvable"
 	// LookupFailed — the read errored for some other reason, so nothing was established.
 	LookupFailed LookupReason = "failed"
+	// LookupUndiffable — objects matching the request WERE found, but none carries enough
+	// to locate a source (no applied revision, no sourceRef, or a source that did not
+	// resolve), so no repository could be searched. Distinct from LookupAbsent because the
+	// object exists: a Kustomization that has never reconciled is a prime suspect, and
+	// reporting it as absent hides the very thing the caller is looking for.
+	LookupUndiffable LookupReason = "undiffable"
 )
 
 // AllNamespaces is the Lookup scope name for a completed cluster-wide search by name.
@@ -436,6 +442,27 @@ type DepNode struct {
 	Ready    string // Ready condition status
 	Reason   string
 	Children []DepNode
+}
+
+// ChangesLookupReporter is an optional capability: a GitOps provider that says what an
+// EMPTY Changes result established. Consumers type-assert for it exactly like
+// GitOpsInspector.
+//
+// It exists because an empty change list has several causes and only the provider can tell
+// them apart — it is the code doing the skipping. Nothing matched the selector, objects
+// matched but none was diffable, or a source read was refused by RBAC and never ran: the
+// first is about the request, the second is about an object that EXISTS, and the third is
+// not about the cluster at all. Collapsing them is how runlore#503 turned a limit of a tool
+// into a claim about the world, and what_changed reproduced it one layer down by answering
+// "no changes found for the given selector" to all of them.
+//
+// Changes() stays on the interface and delegates here, so a provider that does not
+// implement this keeps working and every existing caller and test double is unaffected.
+type ChangesLookupReporter interface {
+	// ChangesLookup returns the same changes as Changes plus, when that list is EMPTY, a
+	// Lookup recording what the enumeration established. The Lookup is meaningless when
+	// changes is non-empty — the caller has data and needs no explanation of it.
+	ChangesLookup(ctx context.Context, w TimeWindow, sel Selector) ([]Change, Lookup, error)
 }
 
 // GitOpsEngineReporter is an optional capability: a GitOps provider naming the engine it


### PR DESCRIPTION
`what_changed` answered **"no changes found for the given selector"** whenever the GitOps provider returned an empty slice. That is a claim about Git history in reply to a question the tool may never have asked — the same defect #508 removed from `gitops_resource_status`, in a tool #508 did not touch.

## Observed live

A `TooHighMemoryUsage` investigation into a pod running on a cluster this Argo CD does **not** manage called `what_changed(observability, vmagent-vmagent-0)`, got that string, and:

- used it to **rule out** a GitOps/config cause,
- recorded it as the finding's `provenance`,
- and made it the entry's **only citation**.

The same finding's data-gaps section stated correctly that the cluster was invisible to the cluster tools — so the investigation contradicted itself, and this sentence is what let it. It also happened to be **right** (the real limit had been set four weeks earlier), which is precisely why nobody would have caught it.

## The provider reports what it established

`providers.Lookup` / `LookupReason` exist because *"a provider knows which case it hit, so it says so"* — added by #508. An empty change list is that sentence exactly, so the discrimination belongs there, not in prose above it.

New optional capability **`ChangesLookupReporter`**, following the `GitOpsEngineReporter` precedent. `Changes()` stays on the interface and delegates, so **no existing caller and no test double changes**. Both providers set a reason at the `continue` that already knew it — Argo CD was even logging the distinction to `slog.Debug` and discarding it:

| reason | means |
|---|---|
| `LookupAbsent` | nothing carried that name/namespace — the list *was* searched |
| `LookupUndiffable` | an object **matched** but has no applied revision and resolvable source |
| `LookupDenied` | a source read was **refused** by RBAC, so it never ran |

`LookupUndiffable` is new and earns its place: a Kustomization that has never reconciled is a prime suspect, and reporting it as absent hides the very thing the caller is hunting.

### `LookupDenied` is why this lives in the provider

Flux's `changesFor` swallowed a `Forbidden` from `GetGitRepository` with a bare `continue`, so an RBAC refusal arrived at the tool indistinguishable from a benign skip — and an earlier revision of this PR filed it under *"nothing with a resolvable source"*. That is a denial rendered as an absence: **#503's exact mechanism, reintroduced inside the fix for #503**, in the one case the mechanism exists to surface. `flux/dynamic.go` had the discriminator all along.

Denial now outranks undiffable and is never downgraded — a search that never ran must not be reported as one that came back empty. Pinned by a test on a namespace holding both.

## The description is the other half of the defect

It said **"optionally a named workload"**. But `name` is matched against the GitOps **object's** name, so the failing pod's name — carrying a ReplicaSet hash or StatefulSet ordinal — can never match. The description invited exactly the call that cannot work, which is how the empty result got produced in the first place.

It now names what the argument is, and the correction has a floor: a **bare** workload name frequently *does* match (Kustomizations and Applications are routinely named after the app they render, and both providers deliberately retry a name across namespaces for that case), so the claim is about the **suffix**, not about workload names. Both directions are guarded.

## What the model gets now

```
no diffable GitOps object for namespace "observability": a search of observability matched an
object whose SOURCE READ WAS DENIED by RBAC, so it never ran and no revision could be
resolved. No repository was searched, so this says NOTHING about whether the configuration
changed — do not cite it as evidence against a config cause. The change may well exist in a
repository this agent was refused; fix the grant rather than concluding anything.
```

```
no GitOps object matched namespace "observability", name "vmagent-vmagent-0": a search of
observability, all namespaces returned no object carrying that name/namespace, so nothing
resolved to a repository. No repository was searched, so this says NOTHING about whether the
configuration changed — do not cite it as evidence against a config cause. A resource on a
cluster this engine does not manage reads exactly like this. Re-call with the namespace alone
to list what this engine does manage, or confirm the resource is managed by a GitOps engine
this deployment can see.
```

## `incident_timeline` is fixed too

It is the other `Changes` consumer and had the same defect, which a tool-layer fix could not reach. It printed *"(no dated GitOps/cloud changes and no Warning events)"* — the same claim about the world — and worse, it dropped changes with a zero `When` **after** the provider returned them, so it could hold a non-empty list and still report none.

Both consumers now share one `changesWithLookup` + `gitopsChangesAnswer`, mirroring the `gitopsLookupAnswer` / `gitopsLookupNote` pairing `gitops_kinds.go` already uses. Undated changes are reported as a gap in *this tool* rather than dropped in silence.

## An intermediate approach that does not work

The middle commit tried it at the tool layer: on an empty result, re-call `Changes` namespace-only and infer from whether *that* was empty. It is kept in history because the shape is tempting and every one of its failures is instructive:

- it **cannot see a denial at all**, so it files one under "no resolvable source" — the bug above;
- it asserts *"this namespace IS managed"* from a namespace match that ignores `spec.destination.server` (Argo CD parses only `destination.namespace`), which on a multi-cluster Argo CD is false — and the motivating incident was a pod on an unmanaged cluster;
- it costs a second cluster-wide List plus a **cold** clone per source repo against the 60 s `ToolTimeout`, to render names only. Flux sets `c.When = changeTime(...)` immediately before appending, so an empty list *proves* `changeTime` never ran and the cache is empty — the comment claiming the cache made it cheap argued the exact inverse.

## Test plan

- [x] Reason determination pinned in **both providers, where it is decided** — not only where it is rendered — including the `Forbidden` and the never-downgrade precedence.
- [x] The renderer driven per reason; scopes never invented when the provider recorded none (#503's other half); a provider **without** the capability claims no reason; a failed reason read degrades without failing the tool.
- [x] Two `incident_timeline` guards: the enumeration reason reaches the output, and undated changes are not silently dropped.
- [x] Description guarded in **both** directions — no "named workload", and no over-correction to "workload names never match".
- [x] **Mutation-verified:** restoring Flux's bare `continue` fails 3 guards, collapsing `LookupUndiffable` fails 3, dropping the disclaimer fails 8, restoring the shipped sentence fails 5. Each on the rule it breaks.
- [x] `go build ./...`, `go vet ./...`, `go test ./...` pass; `gofmt -l .` silent; `golangci-lint run ./...` reports **0 issues**.
- [x] `examples/eval/poisoned-recall-rejected.yaml` carried the deleted string as canned replay evidence, so the offline eval named for rejecting poisoned recall kept feeding the model the exact defect. Regenerated **from the real renderer output** rather than typed by hand, so it cannot drift.

## Note for review

Three commits, and the third touches the `GitOpsProvider` contract (additively, via an optional capability). Squashing is fine — though the middle commit is the record of why the tool-layer shape does not work, which is worth keeping somewhere.
