### PR TITLE
feat(investigate): add list_resources so the model stops guessing object names

### DIFF
--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -269,8 +269,14 @@ func BuildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 	// cannot read a CRD), and it is absent rather than broken when either is unavailable —
 	// a tool that cannot answer must not exist, per the same reasoning that gates
 	// controller_logs on the engine.
+	// list_resources rides the SAME reader: enumerating a kind needs exactly the dynamic
+	// client and discovery that resource_spec needs, and pairing them is deliberate —
+	// registering the by-name reader without the lister is what forces a model to guess
+	// names, which it does badly and expensively (32 wasted calls in one real
+	// investigation, and a card that could not name the policy it had proven was denying
+	// traffic).
 	if sr := BuildResourceSpecReader(log); sr != nil {
-		tools = append(tools, investigate.ResourceSpecTool{Reader: sr})
+		tools = append(tools, investigate.ResourceSpecTool{Reader: sr}, investigate.ResourceListTool{Lister: sr})
 	}
 	// Cloud context (AWS): CloudTrail "what changed" + EC2/ASG/EKS health. Opt-in.
 	var cloudProvider providers.CloudProvider

--- a/internal/app/kube.go
+++ b/internal/app/kube.go
@@ -57,19 +57,19 @@ func RestConfig() (*rest.Config, error) {
 //
 // Discovery is memoised and lazy: the round trip happens on first use rather than at
 // startup, so an unreachable API server delays a tool call instead of blocking boot.
-func BuildResourceSpecReader(log *slog.Logger) providers.ResourceSpecReader {
+func BuildResourceSpecReader(log *slog.Logger) providers.ResourceReader {
 	restCfg, err := RestConfig()
 	if err != nil {
 		return nil
 	}
 	dc, err := dynamic.NewForConfig(restCfg)
 	if err != nil {
-		log.Warn("dynamic client unavailable; resource_spec disabled", "err", err)
+		log.Warn("dynamic client unavailable; resource_spec and list_resources disabled", "err", err)
 		return nil
 	}
 	disco, err := discovery.NewDiscoveryClientForConfig(restCfg)
 	if err != nil {
-		log.Warn("discovery client unavailable; resource_spec disabled", "err", err)
+		log.Warn("discovery client unavailable; resource_spec and list_resources disabled", "err", err)
 		return nil
 	}
 	// Memoised discovery: resolving a Kind costs one round trip the first time and nothing

--- a/internal/investigate/resource_list_tool.go
+++ b/internal/investigate/resource_list_tool.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/redact"
+)
+
+// ResourceListTool enumerates the objects of one kind in one namespace.
+//
+// It is the complement resource_spec structurally cannot be. That tool reads a NAMED
+// object, which presumes the name is already known; a large class of incidents is instead
+// "which object is doing this to me" — which NetworkPolicy denies this flow, which
+// ValidatingWebhookConfiguration rejects this apply, which ScaledObject governs this
+// Deployment. With only a by-name reader, a model can do nothing but guess names.
+//
+// It guesses badly, and expensively. A real investigation into a denied readiness probe
+// spent 32 of its 58 tool calls trying CiliumNetworkPolicy names (checkout-ui, orders-api,
+// default-deny, runlore-demo, …), got ABSENT for every one, and shipped a card whose own
+// Data gaps section read: "resource_spec reads named objects only (not lists), so I could
+// not enumerate all NetworkPolicy/CiliumNetworkPolicy objects". It had PROVEN the denial
+// from flow logs and still could not name the policy, so it published at 55% confidence
+// with the object identification left as an open question for a human.
+type ResourceListTool struct {
+	Lister providers.ResourceLister
+}
+
+// Name returns the tool name.
+func (t ResourceListTool) Name() string { return "list_resources" }
+
+// Description returns the tool description.
+//
+// It leads with the distinction from resource_spec because the two are otherwise easy to
+// confuse, and states the empty-result semantics up front: an empty listing is the one
+// answer here that IS evidence of absence, and it is the answer guessing names can never
+// produce.
+func (t ResourceListTool) Description() string {
+	return "List the NAMES of every object of one Kubernetes kind in a namespace, for any kind " +
+		"the cluster serves, including CRDs. Use it whenever you need to find WHICH object is " +
+		"responsible and do not already know its name — which NetworkPolicy or " +
+		"CiliumNetworkPolicy denies a flow, which webhook rejects an apply, which ScaledObject " +
+		"governs a Deployment. Do NOT guess names with resource_spec: that only answers about " +
+		"the name you guessed, and a wrong guess returns ABSENT, which proves nothing. " +
+		"A successful EMPTY listing IS evidence that no such object exists there. Returns " +
+		"identities only — read one with resource_spec once you know its name. Secret is " +
+		"refused. Namespaced kinds take a namespace; cluster-scoped kinds take none. When a " +
+		"kind is served by several API groups the listing is refused as ambiguous — call again " +
+		"with group set. A denial or an unknown kind is reported as such and is NOT evidence " +
+		"that no objects exist."
+}
+
+// Schema returns the JSON schema for the arguments.
+func (t ResourceListTool) Schema() string {
+	return `{"type":"object","properties":{"kind":{"type":"string"},` +
+		`"namespace":{"type":"string","description":"namespace to list in; omit for a cluster-scoped kind"},` +
+		`"group":{"type":"string","description":"optional API group, e.g. cilium.io (\"core\" for the core group) — only needed when a kind is served by more than one group"},` +
+		`"labelSelector":{"type":"string","description":"optional label selector, e.g. app=orders-api"}},` +
+		`"required":["kind"]}`
+}
+
+// Call lists the objects and renders them.
+//
+// The outcome taxonomy is ResourceSpec's, and for the same reason: collapsing "you may not
+// read this" into "there are none" is exactly the fabrication this family of tools exists
+// to prevent. The one addition is that here a successful empty result is POSITIVE evidence
+// and says so, because that is the whole point of being able to enumerate.
+func (t ResourceListTool) Call(ctx context.Context, args string) (string, error) {
+	var in struct {
+		Kind, Namespace, Group, LabelSelector string
+	}
+	if err := json.Unmarshal([]byte(args), &in); err != nil {
+		return "", fmt.Errorf("parse args: %w", err)
+	}
+	if t.Lister == nil {
+		return "list_resources is not configured (no cluster access).", nil
+	}
+	q := providers.ResourceListQuery{
+		Kind:          in.Kind,
+		Namespace:     in.Namespace,
+		Group:         in.Group,
+		LabelSelector: in.LabelSelector,
+	}
+	rl, err := t.Lister.ResourceList(ctx, q)
+	if err != nil {
+		return "", err
+	}
+	// Identify by what the lister RESOLVED, falling back to the request when it resolved
+	// nothing — same reasoning as resource_spec: echoing a caller's mistake back as fact
+	// ("StorageClass made-up-ns") states the mistake as cluster truth.
+	id := listID(rl.Query)
+	if rl.Query.Kind == "" {
+		id = listID(q)
+	}
+	switch rl.Outcome {
+	case providers.ResourceRefused:
+		return id + ": REFUSED — " + redact.Secrets(rl.Detail) + "\nThis is a policy of this " +
+			"agent, NOT an RBAC denial: widening the ClusterRole will not change it, and it says " +
+			"NOTHING about whether any such objects exist.", nil
+	case providers.ResourceForbidden:
+		return id + ": FORBIDDEN — " + redact.Secrets(rl.Detail) + "\nThis says NOTHING about " +
+			"whether any such objects exist; it says this agent may not list them. Do NOT treat " +
+			"it as evidence that there are none.", nil
+	case providers.ResourceKindAmbiguous:
+		return id + ": AMBIGUOUS KIND — " + redact.Secrets(rl.Detail) + "\nNothing was listed, " +
+			"because listing the wrong group's objects and naming them confidently is worse " +
+			"than answering nothing. This says NOTHING about whether any objects exist.", nil
+	case providers.ResourceKindUnknown:
+		return id + ": UNKNOWN KIND — " + redact.Secrets(rl.Detail) + "\nThis says NOTHING about " +
+			"whether any objects exist. Re-check the kind's spelling, or use a tool suited to it.", nil
+	case providers.ResourceAbsent:
+		// The namespace itself is gone. Distinct from an empty listing: "no namespace" and
+		// "a namespace with no such objects" are different facts about the cluster.
+		return id + ": ABSENT — " + redact.Secrets(rl.Detail) + "\nThe place asked about does " +
+			"not exist, so nothing could be listed in it.", nil
+	}
+	if len(rl.Items) == 0 && !rl.Truncated {
+		return id + ": NONE — the cluster serves this kind and this agent may list it, and " +
+			"there are no such objects here. This IS evidence that no object of this kind " +
+			"exists in this scope.", nil
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (%s) — %d object(s)\n", id, rl.APIVersion, len(rl.Items))
+	for _, it := range rl.Items {
+		ref := it.Name
+		if it.Namespace != "" {
+			ref = it.Namespace + "/" + it.Name
+		}
+		fmt.Fprintf(&b, "  %s\n", redact.Secrets(ref))
+	}
+	if rl.Truncated {
+		// Without this, a name missing from a capped page reads as proof of absence — the
+		// exact wrong inference this tool was built to remove.
+		b.WriteString("TRUNCATED — the server had more objects than are listed above. A name " +
+			"NOT shown here is NOT evidence that it does not exist; narrow with labelSelector.\n")
+	}
+	b.WriteString("Read any one of them with resource_spec, using its name.\n")
+	return b.String(), nil
+}
+
+// listID renders the scope being listed, "Kind in namespace" — or "Kind (cluster-scoped)"
+// when there is no namespace to render.
+func listID(q providers.ResourceListQuery) string {
+	kind := strings.TrimSpace(q.Kind)
+	if q.Namespace == "" {
+		return kind + " (cluster-scoped)"
+	}
+	return kind + " in " + q.Namespace
+}

--- a/internal/investigate/resource_list_tool_test.go
+++ b/internal/investigate/resource_list_tool_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+type fakeLister struct {
+	out providers.ResourceList
+	err error
+	got providers.ResourceListQuery
+}
+
+func (f *fakeLister) ResourceList(_ context.Context, q providers.ResourceListQuery) (providers.ResourceList, error) {
+	f.got = q
+	return f.out, f.err
+}
+
+func callList(t *testing.T, r providers.ResourceLister, args string) string {
+	t.Helper()
+	out, err := ResourceListTool{Lister: r}.Call(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	return out
+}
+
+// TestEmptyListingIsEvidenceButDenialIsNot is the reason this tool exists alongside
+// resource_spec, and the distinction it must never blur.
+//
+// A successful listing that returns nothing IS evidence that no such object is there —
+// that is precisely the answer resource_spec cannot give, because it can only ask about
+// names somebody already guessed. A FORBIDDEN or UNKNOWN KIND listing is NOT evidence of
+// anything about the objects, and must say so, exactly as resource_spec does.
+func TestEmptyListingIsEvidenceButDenialIsNot(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		outcome    providers.ResourceSpecOutcome
+		detail     string
+		wantMarker string
+		// mustDisclaim: the output must state that it says nothing about existence.
+		mustDisclaim bool
+		// mustAssert: the output must state that this IS evidence of absence.
+		mustAssert bool
+	}{
+		{"found but empty", providers.ResourceFound, "", "NONE", false, true},
+		{"forbidden", providers.ResourceForbidden, `ciliumnetworkpolicies.cilium.io is forbidden`, "FORBIDDEN", true, false},
+		{"unknown kind", providers.ResourceKindUnknown, `this cluster serves no kind "Widget"`, "UNKNOWN KIND", true, false},
+		{"ambiguous kind", providers.ResourceKindAmbiguous, "served by 2 groups", "AMBIGUOUS KIND", true, false},
+		{"refused", providers.ResourceRefused, "Secret objects are never listable", "REFUSED", true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			l := &fakeLister{out: providers.ResourceList{Outcome: tc.outcome, Detail: tc.detail}}
+			out := callList(t, l, `{"kind":"CiliumNetworkPolicy","namespace":"demo"}`)
+			if !strings.Contains(out, tc.wantMarker) {
+				t.Fatalf("outcome %s not distinguishable in output:\n%s", tc.outcome, out)
+			}
+			if tc.mustDisclaim && !strings.Contains(out, "NOTHING about whether") {
+				t.Fatalf("outcome %s must disclaim evidence of absence, got:\n%s", tc.outcome, out)
+			}
+			if tc.mustAssert && !strings.Contains(out, "IS evidence") {
+				t.Fatalf("an empty successful listing must be stated as evidence, got:\n%s", out)
+			}
+			// A denial must never be renderable as an empty namespace.
+			if !tc.mustAssert && strings.Contains(out, "IS evidence") {
+				t.Fatalf("outcome %s must not claim evidence of absence:\n%s", tc.outcome, out)
+			}
+		})
+	}
+}
+
+// TestListingNamesTheObjects covers the case the tool was built for: the model has a Kind
+// and a namespace and needs the NAMES, which is what it could not obtain by guessing.
+func TestListingNamesTheObjects(t *testing.T) {
+	l := &fakeLister{out: providers.ResourceList{
+		Outcome:    providers.ResourceFound,
+		APIVersion: "cilium.io/v2",
+		Query:      providers.ResourceListQuery{Kind: "CiliumNetworkPolicy", Namespace: "demo"},
+		Items: []providers.ResourceListItem{
+			{Name: "orders-api-allow-payments-only", Namespace: "demo"},
+			{Name: "default-deny", Namespace: "demo"},
+		},
+	}}
+	out := callList(t, l, `{"kind":"CiliumNetworkPolicy","namespace":"demo"}`)
+	for _, want := range []string{"orders-api-allow-payments-only", "default-deny", "cilium.io/v2", "2"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("listing must contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+// TestTruncationIsDisclosed matters because a truncated listing silently reintroduces the
+// bug this tool removes: a name missing from a capped page would otherwise read as proof
+// the object does not exist.
+func TestTruncationIsDisclosed(t *testing.T) {
+	l := &fakeLister{out: providers.ResourceList{
+		Outcome:   providers.ResourceFound,
+		Items:     []providers.ResourceListItem{{Name: "a", Namespace: "demo"}},
+		Truncated: true,
+	}}
+	out := callList(t, l, `{"kind":"ConfigMap","namespace":"demo"}`)
+	if !strings.Contains(out, "TRUNCATED") {
+		t.Fatalf("a truncated listing must say so, got:\n%s", out)
+	}
+	if strings.Contains(out, "IS evidence") {
+		t.Fatalf("a truncated listing must not be rendered as evidence of absence:\n%s", out)
+	}
+}
+
+// TestArgsReachTheLister keeps the schema and the query in step — a namespace or selector
+// dropped on the floor would silently widen or narrow what the model believes it asked.
+func TestArgsReachTheLister(t *testing.T) {
+	l := &fakeLister{out: providers.ResourceList{Outcome: providers.ResourceFound}}
+	callList(t, l, `{"kind":"NetworkPolicy","namespace":"demo","group":"networking.k8s.io","labelSelector":"app=x"}`)
+	want := providers.ResourceListQuery{Kind: "NetworkPolicy", Namespace: "demo", Group: "networking.k8s.io", LabelSelector: "app=x"}
+	if l.got != want {
+		t.Fatalf("query not forwarded intact:\ngot  %+v\nwant %+v", l.got, want)
+	}
+}
+
+// TestUnconfiguredListerSaysSo mirrors resource_spec: no cluster access is a statement
+// about the agent, not about the cluster.
+func TestUnconfiguredListerSaysSo(t *testing.T) {
+	out, err := ResourceListTool{}.Call(context.Background(), `{"kind":"Pod","namespace":"demo"}`)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if !strings.Contains(out, "not configured") {
+		t.Fatalf("unconfigured lister must say so, got: %s", out)
+	}
+}
+
+// TestSchemaIsValidJSONAndRequiresKind guards the contract the model is handed.
+func TestSchemaIsValidJSONAndRequiresKind(t *testing.T) {
+	var schema struct {
+		Properties map[string]any `json:"properties"`
+		Required   []string       `json:"required"`
+	}
+	if err := json.Unmarshal([]byte(ResourceListTool{}.Schema()), &schema); err != nil {
+		t.Fatalf("schema is not valid JSON: %v", err)
+	}
+	if len(schema.Required) != 1 || schema.Required[0] != "kind" {
+		t.Fatalf("kind must be the only required arg, got %v", schema.Required)
+	}
+	for _, p := range []string{"kind", "namespace", "group", "labelSelector"} {
+		if _, ok := schema.Properties[p]; !ok {
+			t.Fatalf("schema is missing property %q", p)
+		}
+	}
+}

--- a/internal/providers/cluster/resolvekind.go
+++ b/internal/providers/cluster/resolvekind.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// resolution is the outcome of turning a bare Kind (plus an optional API group) into the
+// one served resource to act on.
+//
+// It is shared by the by-name reader and the lister so the two cannot drift: a Kind that
+// is ambiguous for resource_spec must be ambiguous for list_resources, and a refusal that
+// fails closed for one must fail closed for the other. Duplicating this logic would let
+// them disagree, and the disagreement would be a security-relevant one — the second
+// refusal check below is what catches a `secrets` resource served under some other Kind.
+type resolution struct {
+	match resolved
+	// outcome is empty when resolution succeeded; otherwise it is the terminal outcome to
+	// report, with detail carrying the server-facing explanation.
+	outcome providers.ResourceSpecOutcome
+	detail  string
+}
+
+// resolveOne resolves a bare Kind to exactly one served resource, or explains why it could
+// not. group narrows to a single API group ("" means no preference).
+func (r *SpecReader) resolveOne(kind, group string) (resolution, error) {
+	if why, refused := refusalFor(kind); refused {
+		return resolution{outcome: providers.ResourceRefused, detail: why}, nil
+	}
+	matches, err := r.resolveKind(kind)
+	if err != nil {
+		return resolution{}, err
+	}
+	if group != "" {
+		kept := matches[:0]
+		for _, m := range matches {
+			if matchGroup(m, group) {
+				kept = append(kept, m)
+			}
+		}
+		matches = kept
+	}
+	switch len(matches) {
+	case 0:
+		detail := fmt.Sprintf("this cluster serves no kind %q", kind)
+		if group != "" {
+			detail += fmt.Sprintf(" in API group %q", group)
+		}
+		return resolution{outcome: providers.ResourceKindUnknown, detail: detail}, nil
+	case 1:
+	default:
+		// Ambiguous: several API groups serve this Kind. Reporting it beats guessing —
+		// acting on the wrong group's objects and naming them confidently is the failure
+		// this family of tools exists to prevent. The candidates are named, and so is the
+		// argument that resolves it, so the ambiguity is not a dead end.
+		groups := make([]string, 0, len(matches))
+		for _, m := range matches {
+			groups = append(groups, m.gvr.GroupVersion().String())
+		}
+		return resolution{
+			outcome: providers.ResourceKindAmbiguous,
+			detail: fmt.Sprintf("kind %q is served by more than one API group (%s); "+
+				"nothing was read. Call again with the group argument set to the one you mean",
+				kind, strings.Join(groups, ", ")),
+		}, nil
+	}
+	match := matches[0]
+	// Refuse AGAIN, on what resolution actually produced. The pre-check only ever sees the
+	// caller's spelling of the KIND, so it cannot refuse a Secret reached under a Kind of
+	// somebody else's choosing — which is what an aggregated API server or a CRD serving a
+	// `secrets` resource does.
+	if why, refused := refusedResources[match.gvr.Resource]; refused {
+		return resolution{outcome: providers.ResourceRefused, detail: why}, nil
+	}
+	return resolution{match: match}, nil
+}

--- a/internal/providers/cluster/resourcelist.go
+++ b/internal/providers/cluster/resourcelist.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// maxListItems bounds one listing. Identities are small (a name and a namespace), but a
+// busy namespace has thousands of ConfigMaps or Secrets-adjacent objects, and the
+// investigation loop's global tool-output cap would then be spent enumerating one kind.
+//
+// The cap is disclosed rather than silent: a truncated listing says so, because a name
+// missing from a capped page would otherwise be read as proof the object does not exist —
+// reintroducing the exact wrong inference this lister removes.
+const maxListItems = 200
+
+var _ providers.ResourceLister = (*SpecReader)(nil)
+
+// ResourceList enumerates the objects of q.Kind in q.Namespace.
+//
+// It shares SpecReader's resolution and refusals deliberately (see resolveOne): a kind
+// that is ambiguous or refused for a by-name read must be ambiguous or refused here too.
+//
+// The outcome taxonomy is the by-name reader's, with one meaningful difference. For
+// ResourceSpec only ABSENT is evidence about an object; here a successful listing with
+// ZERO items is itself evidence — the cluster serves the kind, this agent may list it, and
+// there are none. That is the answer a by-name reader structurally cannot produce, because
+// it can only answer about names that were already guessed.
+func (r *SpecReader) ResourceList(ctx context.Context, q providers.ResourceListQuery) (providers.ResourceList, error) {
+	out := providers.ResourceList{Query: q}
+	if q.Kind == "" {
+		return out, fmt.Errorf("kind is required")
+	}
+	res, err := r.resolveOne(q.Kind, q.Group)
+	if err != nil {
+		return out, err
+	}
+	if res.outcome != "" {
+		out.Outcome, out.Detail = res.outcome, res.detail
+		return out, nil
+	}
+	match := res.match
+	// Echo the identity that was actually resolved, not the caller's spelling — and drop
+	// the namespace for a cluster-scoped kind, so the answer never states a caller's
+	// mistake ("StorageClass in made-up-ns") as a fact about the cluster.
+	out.Query.Kind, out.Query.Group = match.kind, match.gvr.Group
+	var ri dynamic.ResourceInterface = r.client.Resource(match.gvr)
+	if match.namespaced {
+		if q.Namespace == "" {
+			return out, fmt.Errorf("kind %q is namespaced: namespace is required", match.kind)
+		}
+		ri = r.client.Resource(match.gvr).Namespace(q.Namespace)
+	} else {
+		out.Query.Namespace = ""
+	}
+	list, err := ri.List(ctx, metav1.ListOptions{
+		LabelSelector: q.LabelSelector,
+		Limit:         maxListItems,
+	})
+	switch {
+	case err == nil:
+	case apierrors.IsForbidden(err), apierrors.IsUnauthorized(err):
+		// RBAC is the boundary. A denial must never be rendered as an empty namespace:
+		// "may not list" and "there are none" are different facts, and only the second is
+		// evidence about the cluster's contents.
+		out.Outcome = providers.ResourceForbidden
+		out.Detail = err.Error()
+		return out, nil
+	case apierrors.IsNotFound(err):
+		// For a LIST there is no object to be absent, so a 404 is always about the path:
+		// a CRD deleted since discovery ran, or an aggregated APIService that stopped
+		// serving. Reporting that as "no objects" would be the #503 conflation again.
+		out.Outcome = providers.ResourceKindUnknown
+		out.Detail = fmt.Sprintf("the API server no longer serves %s (discovery may be stale); "+
+			"nothing was listed", match.gvr.GroupResource().String())
+		return out, nil
+	default:
+		return out, fmt.Errorf("list %s: %w", match.gvr.GroupResource().String(), err)
+	}
+	out.Outcome = providers.ResourceFound
+	out.APIVersion = match.gvr.GroupVersion().String()
+	items := list.Items
+	// A continue token means the server had more than the page asked for. Trust it over
+	// len(items): a server may return a short page for its own reasons.
+	out.Truncated = list.GetContinue() != ""
+	if len(items) > maxListItems {
+		items = items[:maxListItems]
+		out.Truncated = true
+	}
+	out.Items = make([]providers.ResourceListItem, 0, len(items))
+	for i := range items {
+		out.Items = append(out.Items, providers.ResourceListItem{
+			Name:      items[i].GetName(),
+			Namespace: items[i].GetNamespace(),
+		})
+	}
+	return out, nil
+}

--- a/internal/providers/cluster/resourcelist_test.go
+++ b/internal/providers/cluster/resourcelist_test.go
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+var cnpGVR = schema.GroupVersionResource{Group: "cilium.io", Version: "v2", Resource: "ciliumnetworkpolicies"}
+
+func cnp(name, ns string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "cilium.io/v2",
+		"kind":       "CiliumNetworkPolicy",
+		"metadata":   map[string]any{"name": name, "namespace": ns},
+	}}
+}
+
+func cnpReader(t *testing.T, objs ...runtime.Object) *SpecReader {
+	t.Helper()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{cnpGVR: "CiliumNetworkPolicyList"}, objs...)
+	disco := discoServing("cilium.io/v2",
+		metav1.APIResource{Name: cnpGVR.Resource, Kind: "CiliumNetworkPolicy", Namespaced: true})
+	return NewSpecReader(client, disco)
+}
+
+// TestResourceListNamesObjectsThatCannotBeGuessed is the whole reason the lister exists.
+// The by-name reader can only answer about a name somebody already produced; a policy
+// called "orders-api-allow-payments-only" is not a name a model guesses, and a real
+// investigation burned 32 tool calls proving that.
+func TestResourceListNamesObjectsThatCannotBeGuessed(t *testing.T) {
+	r := cnpReader(t, cnp("orders-api-allow-payments-only", "demo"), cnp("default-deny", "demo"))
+	got, err := r.ResourceList(context.Background(), providers.ResourceListQuery{
+		Kind: "CiliumNetworkPolicy", Namespace: "demo",
+	})
+	if err != nil {
+		t.Fatalf("ResourceList: %v", err)
+	}
+	if got.Outcome != providers.ResourceFound {
+		t.Fatalf("outcome = %s, want found", got.Outcome)
+	}
+	if len(got.Items) != 2 {
+		t.Fatalf("got %d items, want 2: %+v", len(got.Items), got.Items)
+	}
+	found := false
+	for _, it := range got.Items {
+		if it.Name == "orders-api-allow-payments-only" && it.Namespace == "demo" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("the unguessable name was not listed: %+v", got.Items)
+	}
+	if got.APIVersion != "cilium.io/v2" {
+		t.Fatalf("APIVersion = %q, want cilium.io/v2", got.APIVersion)
+	}
+}
+
+// TestEmptyListingIsFoundNotAbsent pins the distinction the tool's rendering depends on:
+// zero objects is a SUCCESSFUL listing, and it is evidence. If this returned absent or
+// forbidden, the tool would disclaim the one answer that is actually informative.
+func TestEmptyListingIsFoundNotAbsent(t *testing.T) {
+	r := cnpReader(t)
+	got, err := r.ResourceList(context.Background(), providers.ResourceListQuery{
+		Kind: "CiliumNetworkPolicy", Namespace: "demo",
+	})
+	if err != nil {
+		t.Fatalf("ResourceList: %v", err)
+	}
+	if got.Outcome != providers.ResourceFound {
+		t.Fatalf("an empty listing must be found (it is evidence), got %s", got.Outcome)
+	}
+	if len(got.Items) != 0 {
+		t.Fatalf("want no items, got %+v", got.Items)
+	}
+}
+
+// TestForbiddenListingIsNotAnEmptyNamespace is the security-relevant one: an RBAC denial
+// rendered as "there are none" invents a fact about the cluster.
+func TestForbiddenListingIsNotAnEmptyNamespace(t *testing.T) {
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{cnpGVR: "CiliumNetworkPolicyList"})
+	client.PrependReactor("list", "ciliumnetworkpolicies", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(cnpGVR.GroupResource(), "", fmt.Errorf("no permission"))
+	})
+	disco := discoServing("cilium.io/v2",
+		metav1.APIResource{Name: cnpGVR.Resource, Kind: "CiliumNetworkPolicy", Namespaced: true})
+	r := NewSpecReader(client, disco)
+
+	got, err := r.ResourceList(context.Background(), providers.ResourceListQuery{
+		Kind: "CiliumNetworkPolicy", Namespace: "demo",
+	})
+	if err != nil {
+		t.Fatalf("ResourceList: %v", err)
+	}
+	if got.Outcome != providers.ResourceForbidden {
+		t.Fatalf("an RBAC denial must be forbidden, not %s — otherwise it reads as an empty namespace", got.Outcome)
+	}
+}
+
+// TestListRefusesSecretByKindAndByResource keeps the lister failing closed exactly where
+// the by-name reader does. Listing Secret NAMES is still listing secrets, and the second
+// arm covers a `secrets` resource served under some other Kind.
+func TestListRefusesSecretByKindAndByResource(t *testing.T) {
+	secretGVR := schema.GroupVersionResource{Version: "v1", Resource: "secrets"}
+	for _, tc := range []struct{ name, kind string }{
+		{"by kind", "Secret"},
+		{"by resolved resource", "Sealed"}, // a Kind of somebody else's choosing over `secrets`
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+				map[schema.GroupVersionResource]string{secretGVR: "SecretList"})
+			disco := discoServing("v1",
+				metav1.APIResource{Name: "secrets", Kind: tc.kind, Namespaced: true})
+			r := NewSpecReader(client, disco)
+			got, err := r.ResourceList(context.Background(), providers.ResourceListQuery{
+				Kind: tc.kind, Namespace: "demo",
+			})
+			if err != nil {
+				t.Fatalf("ResourceList: %v", err)
+			}
+			if got.Outcome != providers.ResourceRefused {
+				t.Fatalf("listing %s must be refused, got %s", tc.kind, got.Outcome)
+			}
+		})
+	}
+}
+
+// TestListAmbiguousKindListsNothing mirrors the by-name reader: acting on the wrong
+// group's objects and naming them confidently is worse than answering nothing.
+func TestListAmbiguousKindListsNothing(t *testing.T) {
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"}: "NetworkPolicyList",
+		})
+	disco := fakeDiscovery{lists: []*metav1.APIResourceList{
+		{GroupVersion: "networking.k8s.io/v1", APIResources: []metav1.APIResource{
+			{Name: "networkpolicies", Kind: "NetworkPolicy", Namespaced: true}}},
+		{GroupVersion: "crd.projectcalico.org/v1", APIResources: []metav1.APIResource{
+			{Name: "networkpolicies", Kind: "NetworkPolicy", Namespaced: true}}},
+	}}
+	r := NewSpecReader(client, disco)
+	got, err := r.ResourceList(context.Background(), providers.ResourceListQuery{
+		Kind: "NetworkPolicy", Namespace: "demo",
+	})
+	if err != nil {
+		t.Fatalf("ResourceList: %v", err)
+	}
+	if got.Outcome != providers.ResourceKindAmbiguous {
+		t.Fatalf("outcome = %s, want kind_ambiguous", got.Outcome)
+	}
+	if len(got.Items) != 0 {
+		t.Fatalf("an ambiguous kind must list nothing, got %+v", got.Items)
+	}
+}
+
+// TestNamespacedKindRequiresNamespace stops a namespaced listing silently becoming a
+// cluster-wide one, which would both widen the read and misreport its scope.
+func TestNamespacedKindRequiresNamespace(t *testing.T) {
+	r := cnpReader(t)
+	_, err := r.ResourceList(context.Background(), providers.ResourceListQuery{Kind: "CiliumNetworkPolicy"})
+	if err == nil {
+		t.Fatal("a namespaced kind listed without a namespace must error")
+	}
+}
+
+// TestUnknownKindIsNotAnEmptyListing keeps "this cluster has no such kind" out of the
+// answer "there are none of them here".
+func TestUnknownKindIsNotAnEmptyListing(t *testing.T) {
+	r := cnpReader(t)
+	got, err := r.ResourceList(context.Background(), providers.ResourceListQuery{
+		Kind: "Widget", Namespace: "demo",
+	})
+	if err != nil {
+		t.Fatalf("ResourceList: %v", err)
+	}
+	if got.Outcome != providers.ResourceKindUnknown {
+		t.Fatalf("outcome = %s, want kind_unknown", got.Outcome)
+	}
+}

--- a/internal/providers/cluster/resourcespec.go
+++ b/internal/providers/cluster/resourcespec.go
@@ -206,63 +206,15 @@ func (r *SpecReader) ResourceSpec(ctx context.Context, q providers.ResourceSpecQ
 	if q.Kind == "" || q.Name == "" {
 		return out, fmt.Errorf("kind and name are required")
 	}
-	if why, refused := refusalFor(q.Kind); refused {
-		out.Outcome = providers.ResourceRefused
-		out.Detail = why
-		return out, nil
-	}
-	matches, err := r.resolveKind(q.Kind)
+	res, err := r.resolveOne(q.Kind, q.Group)
 	if err != nil {
 		return out, err
 	}
-	if q.Group != "" {
-		kept := matches[:0]
-		for _, m := range matches {
-			if matchGroup(m, q.Group) {
-				kept = append(kept, m)
-			}
-		}
-		matches = kept
-	}
-	switch len(matches) {
-	case 0:
-		out.Outcome = providers.ResourceKindUnknown
-		out.Detail = fmt.Sprintf("this cluster serves no kind %q", q.Kind)
-		if q.Group != "" {
-			out.Detail += fmt.Sprintf(" in API group %q", q.Group)
-		}
-		return out, nil
-	case 1:
-	default:
-		// Ambiguous: several API groups serve this Kind. Reporting it beats guessing —
-		// reading the wrong object and describing it confidently is the failure this tool
-		// exists to prevent, so the ambiguity is handed back with the candidates named
-		// AND with the argument that resolves it, so it is not a dead end.
-		groups := make([]string, 0, len(matches))
-		for _, m := range matches {
-			groups = append(groups, m.gvr.GroupVersion().String())
-		}
-		out.Outcome = providers.ResourceKindAmbiguous
-		out.Detail = fmt.Sprintf("kind %q is served by more than one API group (%s); "+
-			"nothing was read. Call again with the group argument set to the one you mean",
-			q.Kind, strings.Join(groups, ", "))
+	if res.outcome != "" {
+		out.Outcome, out.Detail = res.outcome, res.detail
 		return out, nil
 	}
-	match := matches[0]
-	// Refuse AGAIN, on what resolution actually produced. The pre-check only ever sees the
-	// caller's spelling of the KIND, so it cannot refuse a Secret reached under a Kind of
-	// somebody else's choosing — which is what an aggregated API server or a CRD serving a
-	// `secrets` resource does.
-	//
-	// Re-checking the resolved KIND as well would be a no-op: resolution matches Kind with
-	// the same EqualFold the refusal uses, so the two cover exactly the same spellings.
-	// TestRefusalAndResolutionAgreeOnFolding pins that equivalence, so a change to either
-	// matcher fails loudly instead of quietly opening a bypass.
-	if why, refused := refusedResources[match.gvr.Resource]; refused {
-		out.Outcome = providers.ResourceRefused
-		out.Detail = why
-		return out, nil
-	}
+	match := res.match
 	// Echo the identity that was actually resolved: the server's spelling of the Kind,
 	// the group that answered, and NO namespace for a cluster-scoped kind. Repeating the
 	// request verbatim would render a caller's mistake as fact — "StorageClass

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -560,6 +560,84 @@ type ResourceSpecReader interface {
 	ResourceSpec(ctx context.Context, q ResourceSpecQuery) (ResourceSpec, error)
 }
 
+// ResourceListQuery identifies the objects to enumerate.
+//
+// It is deliberately the same shape as ResourceSpecQuery minus Name: the caller knows a
+// Kind and a place to look, and that is exactly the situation Name cannot be supplied in.
+type ResourceListQuery struct {
+	Kind      string
+	Namespace string
+	// Group narrows resolution to one API group ("" means "no preference", and "core"
+	// is accepted as a spelling of the core group's empty name).
+	Group string
+	// LabelSelector optionally narrows the listing, in the standard
+	// "key=value,key2=value2" form. Empty lists everything of the kind.
+	LabelSelector string
+}
+
+// ResourceListItem is one object's identity in a listing.
+//
+// Identity ONLY — no spec, no status. The listing answers "what exists here"; reading any
+// one of them is resource_spec's job, and returning specs here would blow the tool-output
+// budget on objects the caller has not asked about yet.
+type ResourceListItem struct {
+	Name      string
+	Namespace string // empty for a cluster-scoped kind
+}
+
+// ResourceList is the set of objects of one kind in one place.
+//
+// Outcome reuses ResourceSpecOutcome because the taxonomy is the same and the distinctions
+// are the same ones that matter: a FORBIDDEN listing is not an empty namespace, and an
+// unknown kind is not an absent object.
+//
+// The load-bearing difference from ResourceSpec: ResourceFound with zero Items IS
+// meaningful evidence — "this cluster serves the kind, this agent may read it, and there
+// are none here". That is the answer resource_spec structurally cannot give, because it
+// can only ask about names somebody already guessed.
+type ResourceList struct {
+	// Query echoes the request NORMALIZED to what was actually listed — the Kind in the
+	// casing the server serves it under, and no namespace for a cluster-scoped kind.
+	Query      ResourceListQuery
+	Outcome    ResourceSpecOutcome
+	APIVersion string
+	Items      []ResourceListItem
+	// Truncated reports that the server had more objects than were returned, so an
+	// absent name in Items is not evidence the object does not exist.
+	Truncated bool
+	// Detail carries the server's own message for a non-found outcome.
+	Detail string
+}
+
+// ResourceLister enumerates the objects of one kind in one namespace.
+//
+// It exists because resource_spec can only read a name somebody already knows, and a large
+// class of incidents is "which object is doing this to me" — which NetworkPolicy denies
+// this flow, which ValidatingWebhookConfiguration rejects this apply, which ScaledObject
+// governs this Deployment. Without enumeration a model can only guess names: a real
+// investigation spent 32 of its 58 tool calls guessing CiliumNetworkPolicy names, never
+// found the object, and published a card whose own Data gaps section said "resource_spec
+// reads named objects only (not lists)". It had confirmed the denial and still could not
+// name the policy.
+//
+// Implementations MUST apply the same refusals as ResourceSpecReader (Secret by kind AND
+// by resolved resource name) and MUST report RBAC denials as ResourceForbidden rather than
+// as an empty listing — an empty listing is evidence of absence and a denial is not.
+type ResourceLister interface {
+	ResourceList(ctx context.Context, q ResourceListQuery) (ResourceList, error)
+}
+
+// ResourceReader is the pair of reads one dynamic client plus discovery can serve:
+// enumerate a kind, then read one of the objects by name.
+//
+// They are one interface because they are one capability with one set of prerequisites,
+// and because registering the by-name half alone is the failure mode this pairing exists
+// to prevent — a model with resource_spec and no lister guesses names, and guesses wrong.
+type ResourceReader interface {
+	ResourceSpecReader
+	ResourceLister
+}
+
 // KindScoper answers whether a bare Kubernetes Kind is namespaced ON THIS CLUSTER.
 //
 // It exists so namespaced-ness can be carried as DATA (Workload.Scope) instead of


### PR DESCRIPTION
Closes the gap RunLore diagnosed in its own card.

## The problem, in its own words

An investigation into a denied readiness probe proved the denial from flow logs
(`POLICY_DENIED`, 76 drops) and still could not name the policy. From the published card:

> **Data gaps:** Could not identify the specific network policy object by name: `resource_spec`
> reads named objects only (not lists), so I could not enumerate all
> NetworkPolicy/CiliumNetworkPolicy objects in the `demo` namespace. I tried common names
> (checkout-ui, orders-api, runlore-demo, default-deny, de…

> **Open questions (needs a human):** Which specific network policy object is denying the
> checkout-ui→orders-api flow…

It spent **32 of its 58 tool calls** guessing `CiliumNetworkPolicy` names, got `ABSENT` for every
one, burned much of `max_tokens_per_investigation` doing it, and published at **55% confidence**
with object identification handed to a human. The object was called
`orders-api-allow-payments-only` — not a name a model guesses.

`resource_spec` can only answer about a name somebody already knows. A large class of incidents is
"WHICH object is doing this to me": which NetworkPolicy denies this flow, which
ValidatingWebhookConfiguration rejects this apply, which ScaledObject governs this Deployment.

## What this adds

- **`providers.ResourceLister`** (+ `ResourceListQuery`, `ResourceList`, `ResourceListItem`), and
  **`ResourceReader`** pairing it with `ResourceSpecReader`. They are one interface because they
  are one capability with one set of prerequisites — and because registering the by-name half
  alone is exactly the failure mode above.
- **`cluster.SpecReader.ResourceList`**, sharing kind resolution and refusals with the by-name
  reader through a new `resolveOne` helper, so the two cannot drift on which kinds are ambiguous
  or refused. `Secret` stays refused **by kind and by resolved resource name** — listing Secret
  names is still listing secrets, and the second check is what catches a `secrets` resource served
  under some other Kind.
- **`investigate.ResourceListTool`** (`list_resources`), registered alongside `resource_spec` on
  the same dynamic client + discovery.

## The one semantic difference from `resource_spec`

The outcome taxonomy is deliberately the same — collapsing "you may not read this" into "there are
none" is the fabrication this family of tools exists to prevent. With one addition:

| outcome | evidence about the objects? |
|---|---|
| **found, 0 items** | **YES** — serves the kind, may list it, there are none |
| found, N items | the names |
| forbidden / unknown kind / ambiguous / refused | **NO**, and says so explicitly |
| truncated page | **NO** — a name not shown is not proof it is absent |

A successful empty listing being *positive evidence* is the whole point: it is the answer guessing
names can never produce. Truncation is disclosed for the mirror-image reason.

Listings return **identities only** — read one with `resource_spec` once its name is known. That
keeps a busy namespace from spending the whole tool-output budget on one kind.

## Tests

Behaviour, not mocks, table-driven where it fits:

- an empty listing is evidence, a denial is not, and neither is an unknown/ambiguous/refused one
- a truncated listing never renders as evidence of absence
- the unguessable name is actually returned (`orders-api-allow-payments-only`)
- an RBAC denial is `forbidden`, never an empty namespace
- `Secret` refused both by kind and via a `secrets` resource served under another Kind
- an ambiguous kind lists nothing
- a namespaced kind without a namespace errors rather than silently going cluster-wide

## Quality gate

```
go build ./...        ok
go vet ./...          ok
go test ./...         ok   (full suite, including the refactored resource_spec path)
gofmt -l .            (nothing)
golangci-lint run     0 issues.
```

The `resolveOne` extraction is a refactor of existing behaviour; the pre-existing
`resource_spec` tests pass unchanged, which is what pins it.