### PR TITLE
feat(investigate): let cloud_what_changed ask for the failed calls only

### DIFF
--- a/internal/investigate/cloud_tools.go
+++ b/internal/investigate/cloud_tools.go
@@ -52,13 +52,7 @@ func (t CloudWhatChangedTool) Call(ctx context.Context, args string) (string, er
 	if err := json.Unmarshal([]byte(args), &in); err != nil {
 		return "", fmt.Errorf("parse args: %w", err)
 	}
-	since := in.SinceMinutes
-	if since <= 0 {
-		since = 90
-	}
-	end := time.Now()
-	start := end.Add(-time.Duration(since) * time.Minute)
-	window := providers.TimeWindow{Start: start, End: end}
+	window := windowSince(in.SinceMinutes, 90)
 	changes, err := t.Cloud.CloudChanges(ctx, providers.Selector{Name: in.Resource, FailedOnly: in.FailedOnly}, window)
 	if err != nil {
 		return "", err
@@ -79,50 +73,50 @@ func (t CloudWhatChangedTool) Call(ctx context.Context, args string) (string, er
 	// So a scoped miss retries unscoped rather than dead-ending. The banner says the
 	// filter was dropped, because silently widening a query the model asked to narrow
 	// would be worse than the dead end.
-	// Not when the scoped scan already spent its page budget: the widen would spend a
-	// second one, and LookupEvents is limited to ~2 TPS per account/region, so 40
-	// sequential pages can outlast the per-tool timeout and turn a partial answer into
-	// a hard dead end. A bounded scan is reported as bounded instead.
+	//
+	// Not when the scoped scan already spent its page budget, though: the widen would
+	// spend a second one, and LookupEvents is limited to ~2 TPS per account/region, so
+	// 40 sequential pages can outlast the per-tool timeout and turn a partial answer
+	// into a hard dead end. A bounded scan is reported as bounded instead.
+	events, note := splitNote(changes)
 	var widened bool
-	if !hasEvent(changes) && in.Resource != "" && scanNote(changes) == "" {
+	if len(events) == 0 && in.Resource != "" && note == "" {
 		all, aerr := t.Cloud.CloudChanges(ctx, providers.Selector{FailedOnly: in.FailedOnly}, window)
-		if aerr == nil && hasEvent(all) {
-			changes, widened = all, true
+		if allEvents, allNote := splitNote(all); aerr == nil && len(allEvents) > 0 {
+			events, note, widened = allEvents, allNote, true
 		}
 	}
 
-	if !hasEvent(changes) {
-		if in.FailedOnly {
-			// Say which filter produced the empty result. "No events" from a filtered
-			// lookup is not the same claim as "the control plane was quiet", and the
-			// schema asks the model not to read absence as evidence.
-			msg := "no FAILED AWS control-plane calls in the window (successful events were not listed — re-run without failed_only to see them)"
-			// A bounded scan did not establish absence at all — it stopped reading. Carry
-			// the provider's own note rather than reporting the quiet window it did not
-			// observe. Without this the sentinel was the whole result and this message
-			// never ran.
-			if note := scanNote(changes); note != "" {
-				msg += "\nNOTE: " + note
-			}
-			return msg, nil
+	if len(events) == 0 {
+		if !in.FailedOnly {
+			return "no mutating AWS events in the window", nil
 		}
-		return "no mutating AWS events in the window", nil
+		// Say which filter produced the empty result. "No events" from a filtered
+		// lookup is not the same claim as "the control plane was quiet", and the schema
+		// asks the model not to read absence as evidence. A bounded scan did not
+		// establish absence at all — it stopped reading — so it carries the provider's
+		// own note rather than the quiet window it never observed.
+		msg := "no FAILED AWS control-plane calls in the window (successful events were not listed — re-run without failed_only to see them)"
+		if note != "" {
+			msg += "\nNOTE: " + note
+		}
+		return msg, nil
 	}
+	if note != "" {
+		events = append(events, providers.ChangeNote(providers.EngineAWS, note))
+	}
+	changes = events
 	var b strings.Builder
 	if widened {
 		// Under failed_only a scoped miss means "no FAILURES for this resource", which
-		// is NOT evidence the name was wrong — the exact-match lecture below would send
-		// the model off inventing new names for a resource it had already identified
+		// is NOT evidence the name was wrong. The exact-match lecture would send the
+		// model off inventing new names for a resource it had already identified
 		// correctly, and then attribute other resources' failures to it.
+		banner := widenedBanner
 		if in.FailedOnly {
-			fmt.Fprintf(&b, "no FAILED calls against resource %q in the window — the name may still be "+
-				"correct, it simply had no rejected calls. Showing ALL rejected calls in the window, which "+
-				"may belong to OTHER resources:\n", in.Resource)
-		} else {
-			fmt.Fprintf(&b, "resource %q matched no CloudTrail events — ResourceName is an exact match on the "+
-				"full AWS resource name or ARN (e.g. a secret's full path \"apps/team/name\"), not a service or "+
-				"substring. Showing ALL mutating events in the window instead:\n", in.Resource)
+			banner = widenedFailedBanner
 		}
+		fmt.Fprintf(&b, banner, in.Resource)
 	}
 	renderRows(&b, len(changes), "more", func(i int) {
 		c := changes[i]
@@ -134,28 +128,34 @@ func (t CloudWhatChangedTool) Call(ctx context.Context, args string) (string, er
 	return b.String(), nil
 }
 
-// hasEvent reports whether changes holds at least one REAL event. CloudChanges may
-// append a trailing "(truncated)" sentinel describing the shape of the result, and
-// a sentinel-only slice is not empty — so testing len(changes) == 0 quietly stopped
-// treating an empty failure scan as empty, suppressing both the widen retry and the
-// no-failures message on exactly the busy cluster failed_only exists for.
-func hasEvent(changes []providers.Change) bool {
-	for _, c := range changes {
-		if c.Workload.Kind != "(truncated)" {
-			return true
-		}
-	}
-	return false
-}
+// widenedBanner and widenedFailedBanner explain a dropped resource scope. They say
+// different things because a scoped miss means different things: without the filter
+// the name did not match anything, with it the name may be perfectly right and simply
+// have no rejected calls.
+const (
+	widenedBanner = "resource %q matched no CloudTrail events — ResourceName is an exact match on the " +
+		"full AWS resource name or ARN (e.g. a secret's full path \"apps/team/name\"), not a service or " +
+		"substring. Showing ALL mutating events in the window instead:\n"
+	widenedFailedBanner = "no FAILED calls against resource %q in the window — the name may still be " +
+		"correct, it simply had no rejected calls. Showing ALL rejected calls in the window, which " +
+		"may belong to OTHER resources:\n"
+)
 
-// scanNote returns the sentinel's text, if the provider appended one.
-func scanNote(changes []providers.Change) string {
+// splitNote separates the real events from the provider's trailing note about the
+// shape of the result. CloudChanges may append one (see providers.ChangeNote), and a
+// note-only slice is NOT an empty one — testing len(changes) == 0 on the raw return
+// quietly stopped detecting an empty failure scan, which suppressed both the widen
+// retry and the no-failures message on exactly the busy cluster failed_only exists
+// for. One pass yields both answers.
+func splitNote(changes []providers.Change) (events []providers.Change, note string) {
 	for _, c := range changes {
-		if c.Workload.Kind == "(truncated)" {
-			return c.Workload.Name
+		if providers.IsChangeNote(c) {
+			note = c.Workload.Name
+			continue
 		}
+		events = append(events, c)
 	}
-	return ""
+	return events, note
 }
 
 // CloudResourceHealthTool exposes AWS-side resource health (EC2/ASG/EKS) to the model.

--- a/internal/investigate/cloud_tools.go
+++ b/internal/investigate/cloud_tools.go
@@ -28,12 +28,18 @@ func (t CloudWhatChangedTool) Description() string {
 		"the incident. Optional resource is an EXACT CloudTrail ResourceName — a full ARN, instance-id, " +
 		"ASG name, or a resource's full path (e.g. a Secrets Manager secret's \"apps/team/name\") — never a " +
 		"service name or substring; OMIT it to see every mutating event, which is the right move when you do " +
-		"not know the exact identifier. since_minutes default 90 (CloudTrail lags ~15m)."
+		"not know the exact identifier. Set failed_only=true when the incident IS a failed AWS operation and " +
+		"you do not know which resource it happened to (a failed backup/snapshot job, a rejected API call): " +
+		"results are capped at the NEWEST events, which on a Karpenter cluster are routine instance and tag " +
+		"churn, so the rejected call you are looking for is usually just past the cap. failed_only spends the " +
+		"cap on rejected calls instead and reports each one's error code. since_minutes default 90 " +
+		"(CloudTrail lags ~15m)."
 }
 
 // Schema returns the JSON schema for the arguments.
 func (t CloudWhatChangedTool) Schema() string {
-	return `{"type":"object","properties":{"resource":{"type":"string"},"since_minutes":{"type":"integer"}},"required":[]}`
+	return `{"type":"object","properties":{"resource":{"type":"string"},"since_minutes":{"type":"integer"},` +
+		`"failed_only":{"type":"boolean","description":"keep only control-plane calls that were REJECTED, reporting each error code; use when the incident is itself a failed AWS operation"}},"required":[]}`
 }
 
 // Call lists cloud changes over the window and renders them.
@@ -41,6 +47,7 @@ func (t CloudWhatChangedTool) Call(ctx context.Context, args string) (string, er
 	var in struct {
 		Resource     string `json:"resource"`
 		SinceMinutes int    `json:"since_minutes"`
+		FailedOnly   bool   `json:"failed_only"`
 	}
 	if err := json.Unmarshal([]byte(args), &in); err != nil {
 		return "", fmt.Errorf("parse args: %w", err)
@@ -52,7 +59,7 @@ func (t CloudWhatChangedTool) Call(ctx context.Context, args string) (string, er
 	end := time.Now()
 	start := end.Add(-time.Duration(since) * time.Minute)
 	window := providers.TimeWindow{Start: start, End: end}
-	changes, err := t.Cloud.CloudChanges(ctx, providers.Selector{Name: in.Resource}, window)
+	changes, err := t.Cloud.CloudChanges(ctx, providers.Selector{Name: in.Resource, FailedOnly: in.FailedOnly}, window)
 	if err != nil {
 		return "", err
 	}
@@ -74,13 +81,19 @@ func (t CloudWhatChangedTool) Call(ctx context.Context, args string) (string, er
 	// would be worse than the dead end.
 	var widened bool
 	if len(changes) == 0 && in.Resource != "" {
-		all, aerr := t.Cloud.CloudChanges(ctx, providers.Selector{}, window)
+		all, aerr := t.Cloud.CloudChanges(ctx, providers.Selector{FailedOnly: in.FailedOnly}, window)
 		if aerr == nil && len(all) > 0 {
 			changes, widened = all, true
 		}
 	}
 
 	if len(changes) == 0 {
+		if in.FailedOnly {
+			// Say which filter produced the empty result. "No events" from a filtered
+			// lookup is not the same claim as "the control plane was quiet", and the
+			// schema asks the model not to read absence as evidence.
+			return "no FAILED AWS control-plane calls in the window (successful events were not listed — re-run without failed_only to see them)", nil
+		}
 		return "no mutating AWS events in the window", nil
 	}
 	var b strings.Builder

--- a/internal/investigate/cloud_tools.go
+++ b/internal/investigate/cloud_tools.go
@@ -30,7 +30,7 @@ func (t CloudWhatChangedTool) Description() string {
 		"service name or substring; OMIT it to see every mutating event, which is the right move when you do " +
 		"not know the exact identifier. Set failed_only=true when the incident IS a failed AWS operation and " +
 		"you do not know which resource it happened to (a failed backup/snapshot job, a rejected API call): " +
-		"results are capped at the NEWEST events, which on a Karpenter cluster are routine instance and tag " +
+		"results are capped at the NEWEST events, which on a busy cluster are routine instance and tag " +
 		"churn, so the rejected call you are looking for is usually just past the cap. failed_only spends the " +
 		"cap on rejected calls instead and reports each one's error code. since_minutes default 90 " +
 		"(CloudTrail lags ~15m)."
@@ -39,7 +39,7 @@ func (t CloudWhatChangedTool) Description() string {
 // Schema returns the JSON schema for the arguments.
 func (t CloudWhatChangedTool) Schema() string {
 	return `{"type":"object","properties":{"resource":{"type":"string"},"since_minutes":{"type":"integer"},` +
-		`"failed_only":{"type":"boolean","description":"keep only control-plane calls that were REJECTED, reporting each error code; use when the incident is itself a failed AWS operation"}},"required":[]}`
+		`"failed_only":{"type":"boolean","description":"keep only MUTATING control-plane calls that were REJECTED, reporting each error code; use when the incident is itself a failed AWS write operation. Read-only calls are never listed by this tool, so a denied Describe/Get will NOT appear here"}},"required":[]}`
 }
 
 // Call lists cloud changes over the window and renders them.
@@ -79,28 +79,50 @@ func (t CloudWhatChangedTool) Call(ctx context.Context, args string) (string, er
 	// So a scoped miss retries unscoped rather than dead-ending. The banner says the
 	// filter was dropped, because silently widening a query the model asked to narrow
 	// would be worse than the dead end.
+	// Not when the scoped scan already spent its page budget: the widen would spend a
+	// second one, and LookupEvents is limited to ~2 TPS per account/region, so 40
+	// sequential pages can outlast the per-tool timeout and turn a partial answer into
+	// a hard dead end. A bounded scan is reported as bounded instead.
 	var widened bool
-	if len(changes) == 0 && in.Resource != "" {
+	if !hasEvent(changes) && in.Resource != "" && scanNote(changes) == "" {
 		all, aerr := t.Cloud.CloudChanges(ctx, providers.Selector{FailedOnly: in.FailedOnly}, window)
-		if aerr == nil && len(all) > 0 {
+		if aerr == nil && hasEvent(all) {
 			changes, widened = all, true
 		}
 	}
 
-	if len(changes) == 0 {
+	if !hasEvent(changes) {
 		if in.FailedOnly {
 			// Say which filter produced the empty result. "No events" from a filtered
 			// lookup is not the same claim as "the control plane was quiet", and the
 			// schema asks the model not to read absence as evidence.
-			return "no FAILED AWS control-plane calls in the window (successful events were not listed — re-run without failed_only to see them)", nil
+			msg := "no FAILED AWS control-plane calls in the window (successful events were not listed — re-run without failed_only to see them)"
+			// A bounded scan did not establish absence at all — it stopped reading. Carry
+			// the provider's own note rather than reporting the quiet window it did not
+			// observe. Without this the sentinel was the whole result and this message
+			// never ran.
+			if note := scanNote(changes); note != "" {
+				msg += "\nNOTE: " + note
+			}
+			return msg, nil
 		}
 		return "no mutating AWS events in the window", nil
 	}
 	var b strings.Builder
 	if widened {
-		fmt.Fprintf(&b, "resource %q matched no CloudTrail events — ResourceName is an exact match on the "+
-			"full AWS resource name or ARN (e.g. a secret's full path \"apps/team/name\"), not a service or "+
-			"substring. Showing ALL mutating events in the window instead:\n", in.Resource)
+		// Under failed_only a scoped miss means "no FAILURES for this resource", which
+		// is NOT evidence the name was wrong — the exact-match lecture below would send
+		// the model off inventing new names for a resource it had already identified
+		// correctly, and then attribute other resources' failures to it.
+		if in.FailedOnly {
+			fmt.Fprintf(&b, "no FAILED calls against resource %q in the window — the name may still be "+
+				"correct, it simply had no rejected calls. Showing ALL rejected calls in the window, which "+
+				"may belong to OTHER resources:\n", in.Resource)
+		} else {
+			fmt.Fprintf(&b, "resource %q matched no CloudTrail events — ResourceName is an exact match on the "+
+				"full AWS resource name or ARN (e.g. a secret's full path \"apps/team/name\"), not a service or "+
+				"substring. Showing ALL mutating events in the window instead:\n", in.Resource)
+		}
 	}
 	renderRows(&b, len(changes), "more", func(i int) {
 		c := changes[i]
@@ -110,6 +132,30 @@ func (t CloudWhatChangedTool) Call(ctx context.Context, args string) (string, er
 		}
 	})
 	return b.String(), nil
+}
+
+// hasEvent reports whether changes holds at least one REAL event. CloudChanges may
+// append a trailing "(truncated)" sentinel describing the shape of the result, and
+// a sentinel-only slice is not empty — so testing len(changes) == 0 quietly stopped
+// treating an empty failure scan as empty, suppressing both the widen retry and the
+// no-failures message on exactly the busy cluster failed_only exists for.
+func hasEvent(changes []providers.Change) bool {
+	for _, c := range changes {
+		if c.Workload.Kind != "(truncated)" {
+			return true
+		}
+	}
+	return false
+}
+
+// scanNote returns the sentinel's text, if the provider appended one.
+func scanNote(changes []providers.Change) string {
+	for _, c := range changes {
+		if c.Workload.Kind == "(truncated)" {
+			return c.Workload.Name
+		}
+	}
+	return ""
 }
 
 // CloudResourceHealthTool exposes AWS-side resource health (EC2/ASG/EKS) to the model.

--- a/internal/investigate/cloud_tools.go
+++ b/internal/investigate/cloud_tools.go
@@ -53,7 +53,8 @@ func (t CloudWhatChangedTool) Call(ctx context.Context, args string) (string, er
 		return "", fmt.Errorf("parse args: %w", err)
 	}
 	window := windowSince(in.SinceMinutes, 90)
-	changes, err := t.Cloud.CloudChanges(ctx, providers.Selector{Name: in.Resource, FailedOnly: in.FailedOnly}, window)
+	filter := providers.CloudChangeFilter{FailedOnly: in.FailedOnly}
+	changes, err := t.Cloud.CloudChanges(ctx, providers.Selector{Name: in.Resource}, window, filter)
 	if err != nil {
 		return "", err
 	}
@@ -81,7 +82,7 @@ func (t CloudWhatChangedTool) Call(ctx context.Context, args string) (string, er
 	events, note := splitNote(changes)
 	var widened bool
 	if len(events) == 0 && in.Resource != "" && note == "" {
-		all, aerr := t.Cloud.CloudChanges(ctx, providers.Selector{FailedOnly: in.FailedOnly}, window)
+		all, aerr := t.Cloud.CloudChanges(ctx, providers.Selector{}, window, filter)
 		if allEvents, allNote := splitNote(all); aerr == nil && len(allEvents) > 0 {
 			events, note, widened = allEvents, allNote, true
 		}

--- a/internal/investigate/cloud_tools_test.go
+++ b/internal/investigate/cloud_tools_test.go
@@ -65,10 +65,12 @@ type exactMatchCloud struct {
 	resourceName string             // the only scope that matches
 	changes      []providers.Change // returned when the scope matches, or unscoped
 	scopedCalls  []string           // every Selector.Name the tool asked for, in order
+	sels         []providers.Selector
 }
 
 func (f *exactMatchCloud) CloudChanges(_ context.Context, sel providers.Selector, _ providers.TimeWindow) ([]providers.Change, error) {
 	f.scopedCalls = append(f.scopedCalls, sel.Name)
+	f.sels = append(f.sels, sel)
 	if sel.Name == "" || sel.Name == f.resourceName {
 		return f.changes, nil
 	}
@@ -137,34 +139,17 @@ func TestCloudWhatChangedWidensOnScopedMiss(t *testing.T) {
 	})
 }
 
-// recordingCloud captures the selectors CloudChanges was called with.
-type recordingCloud struct {
-	changes []providers.Change
-	sels    []providers.Selector
-}
-
-func (r *recordingCloud) CloudChanges(_ context.Context, sel providers.Selector, _ providers.TimeWindow) ([]providers.Change, error) {
-	r.sels = append(r.sels, sel)
-	if sel.Name != "" {
-		return nil, nil // every scoped lookup misses, forcing the widen path
-	}
-	return r.changes, nil
-}
-func (r *recordingCloud) ResourceHealth(context.Context, providers.Selector, providers.TimeWindow) (providers.LogResult, error) {
-	return nil, nil
-}
-
 // TestCloudWhatChangedFailedOnly: the flag reaches the provider, and it SURVIVES the
 // unscoped widen. Without that, a scoped failure lookup that misses would widen into
 // an unfiltered cluster-wide query and bury the rejected call under exactly the
-// Karpenter churn the flag exists to skip past — the widen would undo the fix.
+// churn the flag exists to skip past — the widen would undo the fix.
 func TestCloudWhatChangedFailedOnly(t *testing.T) {
 	failed := providers.Change{
 		When: time.Unix(1700000000, 0).UTC(), ManagedBy: "rds.amazonaws.com",
 		Workload: providers.Workload{Kind: "AWS::RDS::DBCluster", Name: "aurora-serverless-postgres-old"},
 		Source:   providers.SourceRef{Path: "CreateDBClusterSnapshot by backup — FAILED: InvalidDBClusterStateFault"},
 	}
-	cloud := &recordingCloud{changes: []providers.Change{failed}}
+	cloud := &exactMatchCloud{resourceName: "aurora-serverless-postgres-old", changes: []providers.Change{failed}}
 	out, err := (CloudWhatChangedTool{Cloud: cloud}).Call(context.Background(),
 		`{"resource":"aurora-serverless-postgres","failed_only":true}`)
 	if err != nil {
@@ -181,17 +166,71 @@ func TestCloudWhatChangedFailedOnly(t *testing.T) {
 			t.Errorf("call %d dropped FailedOnly: %+v", i, sel)
 		}
 	}
+	// The widen banner must not lecture about exact-match names here. Under
+	// failed_only a scoped miss means "this resource had no REJECTED calls", which is
+	// no evidence the name was wrong — and sending the model off to invent new names
+	// is the dead end the widen exists to break, not to cause.
+	if strings.Contains(out, "not a service or substring") {
+		t.Errorf("failed_only widen misdiagnosed a correct name as an exact-match miss:\n%s", out)
+	}
+	if !strings.Contains(out, "may belong to OTHER resources") {
+		t.Errorf("a widened failure lookup must warn whose failures it is showing:\n%s", out)
+	}
 }
 
 // TestCloudWhatChangedFailedOnlyEmptyIsNotSilence: an empty FILTERED result must not
 // read as "the control plane was quiet". submit_findings tells the model that an
 // empty result is not evidence of absence; the tool has to hold up its end.
 func TestCloudWhatChangedFailedOnlyEmptyIsNotSilence(t *testing.T) {
-	out, err := (CloudWhatChangedTool{Cloud: &recordingCloud{}}).Call(context.Background(), `{"failed_only":true}`)
+	out, err := (CloudWhatChangedTool{Cloud: &exactMatchCloud{}}).Call(context.Background(), `{"failed_only":true}`)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(out, "FAILED") || !strings.Contains(out, "failed_only") {
 		t.Errorf("an empty filtered result must name the filter that produced it:\n%s", out)
+	}
+}
+
+// boundedScanCloud returns ONLY the provider's bounded-scan sentinel — the shape a
+// failure scan produces after spending its page budget on a busy cluster with no
+// failures in the window.
+type boundedScanCloud struct{ calls int }
+
+func (f *boundedScanCloud) CloudChanges(_ context.Context, _ providers.Selector, _ providers.TimeWindow) ([]providers.Change, error) {
+	f.calls++
+	return []providers.Change{{
+		Workload: providers.Workload{Kind: "(truncated)",
+			Name: "scan stopped after 20 pages of successful events; any FAILED calls older than that were not examined — narrow the window's END, or scope to a resource"},
+	}}, nil
+}
+func (f *boundedScanCloud) ResourceHealth(context.Context, providers.Selector, providers.TimeWindow) (providers.LogResult, error) {
+	return nil, nil
+}
+
+// TestCloudWhatChangedBoundedScanIsNotAnEvent: a sentinel-only result is not a
+// result. It is not empty either, so testing len(changes) == 0 rendered the sentinel
+// as if it were the answer — one bogus row, no failures, and neither the widen nor
+// the no-failures message ran. On the busy cluster failed_only was written for, that
+// is the NORMAL outcome.
+func TestCloudWhatChangedBoundedScanIsNotAnEvent(t *testing.T) {
+	cloud := &boundedScanCloud{}
+	out, err := (CloudWhatChangedTool{Cloud: cloud}).Call(context.Background(),
+		`{"resource":"aurora-prod","failed_only":true}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "0001-01-01") {
+		t.Errorf("the sentinel was rendered as an event row:\n%s", out)
+	}
+	if !strings.Contains(out, "no FAILED AWS control-plane calls") {
+		t.Errorf("a sentinel-only result must report as no failures found:\n%s", out)
+	}
+	// It must also NOT claim the window was quiet — the scan stopped reading.
+	if !strings.Contains(out, "scan stopped after") {
+		t.Errorf("a bounded scan must carry its own note rather than claiming absence:\n%s", out)
+	}
+	// And it must not spend a second 20-page budget on the widen.
+	if cloud.calls != 1 {
+		t.Errorf("a bounded scoped scan must not widen (40 pages against a ~2 TPS API): %d calls", cloud.calls)
 	}
 }

--- a/internal/investigate/cloud_tools_test.go
+++ b/internal/investigate/cloud_tools_test.go
@@ -136,3 +136,62 @@ func TestCloudWhatChangedWidensOnScopedMiss(t *testing.T) {
 		}
 	})
 }
+
+// recordingCloud captures the selectors CloudChanges was called with.
+type recordingCloud struct {
+	changes []providers.Change
+	sels    []providers.Selector
+}
+
+func (r *recordingCloud) CloudChanges(_ context.Context, sel providers.Selector, _ providers.TimeWindow) ([]providers.Change, error) {
+	r.sels = append(r.sels, sel)
+	if sel.Name != "" {
+		return nil, nil // every scoped lookup misses, forcing the widen path
+	}
+	return r.changes, nil
+}
+func (r *recordingCloud) ResourceHealth(context.Context, providers.Selector, providers.TimeWindow) (providers.LogResult, error) {
+	return nil, nil
+}
+
+// TestCloudWhatChangedFailedOnly: the flag reaches the provider, and it SURVIVES the
+// unscoped widen. Without that, a scoped failure lookup that misses would widen into
+// an unfiltered cluster-wide query and bury the rejected call under exactly the
+// Karpenter churn the flag exists to skip past — the widen would undo the fix.
+func TestCloudWhatChangedFailedOnly(t *testing.T) {
+	failed := providers.Change{
+		When: time.Unix(1700000000, 0).UTC(), ManagedBy: "rds.amazonaws.com",
+		Workload: providers.Workload{Kind: "AWS::RDS::DBCluster", Name: "aurora-serverless-postgres-old"},
+		Source:   providers.SourceRef{Path: "CreateDBClusterSnapshot by backup — FAILED: InvalidDBClusterStateFault"},
+	}
+	cloud := &recordingCloud{changes: []providers.Change{failed}}
+	out, err := (CloudWhatChangedTool{Cloud: cloud}).Call(context.Background(),
+		`{"resource":"aurora-serverless-postgres","failed_only":true}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "InvalidDBClusterStateFault") {
+		t.Errorf("the error code must reach the model:\n%s", out)
+	}
+	if len(cloud.sels) != 2 {
+		t.Fatalf("want a scoped call then an unscoped retry, got %d", len(cloud.sels))
+	}
+	for i, sel := range cloud.sels {
+		if !sel.FailedOnly {
+			t.Errorf("call %d dropped FailedOnly: %+v", i, sel)
+		}
+	}
+}
+
+// TestCloudWhatChangedFailedOnlyEmptyIsNotSilence: an empty FILTERED result must not
+// read as "the control plane was quiet". submit_findings tells the model that an
+// empty result is not evidence of absence; the tool has to hold up its end.
+func TestCloudWhatChangedFailedOnlyEmptyIsNotSilence(t *testing.T) {
+	out, err := (CloudWhatChangedTool{Cloud: &recordingCloud{}}).Call(context.Background(), `{"failed_only":true}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "FAILED") || !strings.Contains(out, "failed_only") {
+		t.Errorf("an empty filtered result must name the filter that produced it:\n%s", out)
+	}
+}

--- a/internal/investigate/cloud_tools_test.go
+++ b/internal/investigate/cloud_tools_test.go
@@ -16,7 +16,7 @@ type fakeCloud struct {
 	health  providers.LogResult
 }
 
-func (f fakeCloud) CloudChanges(context.Context, providers.Selector, providers.TimeWindow) ([]providers.Change, error) {
+func (f fakeCloud) CloudChanges(context.Context, providers.Selector, providers.TimeWindow, providers.CloudChangeFilter) ([]providers.Change, error) {
 	return f.changes, nil
 }
 func (f fakeCloud) ResourceHealth(context.Context, providers.Selector, providers.TimeWindow) (providers.LogResult, error) {
@@ -65,12 +65,12 @@ type exactMatchCloud struct {
 	resourceName string             // the only scope that matches
 	changes      []providers.Change // returned when the scope matches, or unscoped
 	scopedCalls  []string           // every Selector.Name the tool asked for, in order
-	sels         []providers.Selector
+	filters      []providers.CloudChangeFilter
 }
 
-func (f *exactMatchCloud) CloudChanges(_ context.Context, sel providers.Selector, _ providers.TimeWindow) ([]providers.Change, error) {
+func (f *exactMatchCloud) CloudChanges(_ context.Context, sel providers.Selector, _ providers.TimeWindow, f2 providers.CloudChangeFilter) ([]providers.Change, error) {
 	f.scopedCalls = append(f.scopedCalls, sel.Name)
-	f.sels = append(f.sels, sel)
+	f.filters = append(f.filters, f2)
 	if sel.Name == "" || sel.Name == f.resourceName {
 		return f.changes, nil
 	}
@@ -158,12 +158,12 @@ func TestCloudWhatChangedFailedOnly(t *testing.T) {
 	if !strings.Contains(out, "InvalidDBClusterStateFault") {
 		t.Errorf("the error code must reach the model:\n%s", out)
 	}
-	if len(cloud.sels) != 2 {
-		t.Fatalf("want a scoped call then an unscoped retry, got %d", len(cloud.sels))
+	if len(cloud.filters) != 2 {
+		t.Fatalf("want a scoped call then an unscoped retry, got %d", len(cloud.filters))
 	}
-	for i, sel := range cloud.sels {
-		if !sel.FailedOnly {
-			t.Errorf("call %d dropped FailedOnly: %+v", i, sel)
+	for i, f := range cloud.filters {
+		if !f.FailedOnly {
+			t.Errorf("call %d dropped FailedOnly: %+v", i, f)
 		}
 	}
 	// The widen banner must not lecture about exact-match names here. Under
@@ -196,7 +196,7 @@ func TestCloudWhatChangedFailedOnlyEmptyIsNotSilence(t *testing.T) {
 // failures in the window.
 type boundedScanCloud struct{ calls int }
 
-func (f *boundedScanCloud) CloudChanges(_ context.Context, _ providers.Selector, _ providers.TimeWindow) ([]providers.Change, error) {
+func (f *boundedScanCloud) CloudChanges(_ context.Context, _ providers.Selector, _ providers.TimeWindow, _ providers.CloudChangeFilter) ([]providers.Change, error) {
 	f.calls++
 	return []providers.Change{{
 		Workload: providers.Workload{Kind: "(truncated)",

--- a/internal/investigate/timeline_tool.go
+++ b/internal/investigate/timeline_tool.go
@@ -160,7 +160,7 @@ func (t IncidentTimelineTool) Call(ctx context.Context, args string) (string, er
 	// (cloud events are cluster/account-scoped), so we pass an empty selector and let
 	// the provider return the window's mutating events.
 	if t.Cloud != nil {
-		changes, err := t.Cloud.CloudChanges(ctx, providers.Selector{}, window)
+		changes, err := t.Cloud.CloudChanges(ctx, providers.Selector{}, window, providers.CloudChangeFilter{})
 		if err != nil {
 			notes = append(notes, fmt.Sprintf("(cloud changes error: %v)", err))
 		} else {

--- a/internal/providers/cloud/aws/aws_test.go
+++ b/internal/providers/cloud/aws/aws_test.go
@@ -92,7 +92,7 @@ func TestCloudChangesPagination(t *testing.T) {
 			ct := &fakeCT{pages: tc.pages}
 			c := &Client{ct: ct, maxEvents: tc.maxEvents}
 
-			changes, err := c.CloudChanges(context.Background(), providers.Selector{}, providers.TimeWindow{})
+			changes, err := c.CloudChanges(context.Background(), providers.Selector{}, providers.TimeWindow{}, providers.CloudChangeFilter{})
 			if err != nil {
 				t.Fatalf("CloudChanges: %v", err)
 			}
@@ -135,7 +135,7 @@ func TestCloudChanges(t *testing.T) {
 	}}}}
 	c := &Client{ct: ct, maxEvents: 25}
 
-	changes, err := c.CloudChanges(context.Background(), providers.Selector{Name: "i-0abc"}, providers.TimeWindow{Start: t0.Add(-time.Hour), End: t0})
+	changes, err := c.CloudChanges(context.Background(), providers.Selector{Name: "i-0abc"}, providers.TimeWindow{Start: t0.Add(-time.Hour), End: t0}, providers.CloudChangeFilter{})
 	if err != nil {
 		t.Fatalf("CloudChanges: %v", err)
 	}
@@ -175,7 +175,7 @@ func TestCloudChangesUnscoped(t *testing.T) {
 	}}}}
 	c := &Client{ct: ct, maxEvents: 25}
 
-	_, err := c.CloudChanges(context.Background(), providers.Selector{}, providers.TimeWindow{})
+	_, err := c.CloudChanges(context.Background(), providers.Selector{}, providers.TimeWindow{}, providers.CloudChangeFilter{})
 	if err != nil {
 		t.Fatalf("CloudChanges: %v", err)
 	}
@@ -211,7 +211,7 @@ func TestCloudChangesResourceScopedFiltersReadOnly(t *testing.T) {
 	}}}}
 	c := &Client{ct: ct, maxEvents: 25}
 
-	changes, err := c.CloudChanges(context.Background(), providers.Selector{Name: "i-0abc"}, providers.TimeWindow{})
+	changes, err := c.CloudChanges(context.Background(), providers.Selector{Name: "i-0abc"}, providers.TimeWindow{}, providers.CloudChangeFilter{})
 	if err != nil {
 		t.Fatalf("CloudChanges: %v", err)
 	}
@@ -240,7 +240,7 @@ func TestCloudChangesErrorCode(t *testing.T) {
 	}}}}
 	c := &Client{ct: ct, maxEvents: 25}
 
-	changes, err := c.CloudChanges(context.Background(), providers.Selector{Name: "i-0abc"}, providers.TimeWindow{})
+	changes, err := c.CloudChanges(context.Background(), providers.Selector{Name: "i-0abc"}, providers.TimeWindow{}, providers.CloudChangeFilter{})
 	if err != nil {
 		t.Fatalf("CloudChanges: %v", err)
 	}

--- a/internal/providers/cloud/aws/cloudtrail.go
+++ b/internal/providers/cloud/aws/cloudtrail.go
@@ -17,7 +17,18 @@ import (
 // CloudChanges returns recent MUTATING AWS control-plane events (CloudTrail
 // LookupEvents) in the window, normalized to the engine-agnostic Change model so
 // they join the same "what changed" timeline as GitOps diffs. When the selector
-// carries a Name, it scopes the lookup to that resource.
+// carries a Name, it scopes the lookup to that resource; when it sets FailedOnly,
+// only rejected calls are kept.
+//
+// FailedOnly exists because the result cap is applied to the NEWEST events, and on
+// a Karpenter cluster the newest mutating events are routine instance and tag
+// churn. Live: four investigations of a failing AWS Backup job concluded the
+// resource "could not be identified", each correctly reporting that the cluster-wide
+// lookup was full of Karpenter/SSM noise — while the CreateDBClusterSnapshot calls
+// that answered the question sat in CloudTrail just past the cap. Filtering first
+// spends the cap on events that can answer a "why did this fail" question.
+// CloudTrail accepts exactly one LookupAttribute, already spent on ResourceName or
+// ReadOnly, so the filter is client-side and the scan is bounded below.
 //
 // Note: CloudTrail is eventually consistent (~15 min), so a too-narrow window can
 // miss a just-made change — callers should use a generous lookback.
@@ -60,15 +71,20 @@ func (c *Client) CloudChanges(ctx context.Context, sel providers.Selector, w pro
 	p := cloudtrail.NewLookupEventsPaginator(c.ct, in)
 	var changes []providers.Change
 	truncated := false
+	pages := 0
 	for p.HasMorePages() {
 		out, err := p.NextPage(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("cloudtrail lookup: %w", err)
 		}
+		pages++
 		for i := range out.Events {
 			// When resource-scoped the server cannot also filter by ReadOnly, so
 			// drop read-only events here. e.ReadOnly is "true"/"false" (string).
 			if resourceScoped && deref(out.Events[i].ReadOnly) == "true" {
+				continue
+			}
+			if sel.FailedOnly && eventError(out.Events[i]) == "" {
 				continue
 			}
 			changes = append(changes, eventToChange(out.Events[i]))
@@ -76,6 +92,15 @@ func (c *Client) CloudChanges(ctx context.Context, sel providers.Selector, w pro
 		if len(changes) > c.maxEvents {
 			truncated = true
 			break // we already have more than the cap; further pages cannot change the kept top-N
+		}
+		// A failure scan has to look past the cap — failures are sparse, and the
+		// answer is typically behind pages of successful churn. Bound it anyway: a
+		// window with no failures at all would otherwise walk the whole retention
+		// period one page at a time. Hitting the budget is a partial view, so it
+		// reuses the truncation sentinel rather than reporting a clean empty result.
+		if sel.FailedOnly && pages >= maxFailureScanPages {
+			truncated = true
+			break
 		}
 	}
 	// Sort most-recent-first BEFORE capping, so the cap keeps the newest events
@@ -91,6 +116,28 @@ func (c *Client) CloudChanges(ctx context.Context, sel providers.Selector, w pro
 		changes = append(changes, truncatedChange(c.maxEvents))
 	}
 	return changes, nil
+}
+
+// maxFailureScanPages bounds the extra pagination a FailedOnly scan performs. A
+// CloudTrail page is <=50 events, so this is up to ~1000 events examined to find
+// the cap's worth of failures — enough to reach past a busy cluster's routine
+// churn, and small enough that a quiet window returns promptly.
+const maxFailureScanPages = 20
+
+// eventError returns the errorCode from an event's raw CloudTrail payload, or ""
+// when the call succeeded (successful calls omit the field). It is the single
+// reader of that payload: both the FailedOnly filter and the rendered "FAILED:"
+// annotation key on it, so the two can never disagree about what failed.
+func eventError(e cttypes.Event) string {
+	raw := deref(e.CloudTrailEvent)
+	if raw == "" {
+		return ""
+	}
+	var payload ctEventJSON
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return ""
+	}
+	return payload.ErrorCode
 }
 
 // truncatedChange is the sentinel appended when CloudChanges stops at its cap
@@ -141,13 +188,11 @@ func eventToChange(e cttypes.Event) providers.Change {
 	// raw CloudTrail JSON carries an errorCode — so the model sees failed calls
 	// (InsufficientInstanceCapacity, UnauthorizedOperation, etc.) not as successes.
 	path := deref(e.EventName) + " by " + deref(e.Username)
-	if raw := deref(e.CloudTrailEvent); raw != "" {
+	if code := eventError(e); code != "" {
+		path += " — FAILED: " + code
 		var payload ctEventJSON
-		if err := json.Unmarshal([]byte(raw), &payload); err == nil && payload.ErrorCode != "" {
-			path += " — FAILED: " + payload.ErrorCode
-			if payload.ErrorMessage != "" {
-				path += " (" + payload.ErrorMessage + ")"
-			}
+		if err := json.Unmarshal([]byte(deref(e.CloudTrailEvent)), &payload); err == nil && payload.ErrorMessage != "" {
+			path += " (" + payload.ErrorMessage + ")"
 		}
 	}
 	ch.Source = providers.SourceRef{Path: path}

--- a/internal/providers/cloud/aws/cloudtrail.go
+++ b/internal/providers/cloud/aws/cloudtrail.go
@@ -57,6 +57,11 @@ func (c *Client) CloudChanges(ctx context.Context, sel providers.Selector, w pro
 	}
 
 	in := &cloudtrail.LookupEventsInput{LookupAttributes: attrs}
+	// Ask for full pages. Without this the server picks the page size, so
+	// maxFailureScanPages would bound PAGES but not events — twenty short pages can
+	// examine a few dozen events rather than the ~1000 the budget is sized for, and
+	// the scan then gives up far short of the depth it reports.
+	in.MaxResults = ptr(int32(50))
 	if !w.Start.IsZero() {
 		in.StartTime = ptr(w.Start)
 	}
@@ -71,6 +76,7 @@ func (c *Client) CloudChanges(ctx context.Context, sel providers.Selector, w pro
 	p := cloudtrail.NewLookupEventsPaginator(c.ct, in)
 	var changes []providers.Change
 	truncated := false
+	scanBounded := false
 	pages := 0
 	for p.HasMorePages() {
 		out, err := p.NextPage(ctx)
@@ -84,7 +90,7 @@ func (c *Client) CloudChanges(ctx context.Context, sel providers.Selector, w pro
 			if resourceScoped && deref(out.Events[i].ReadOnly) == "true" {
 				continue
 			}
-			if sel.FailedOnly && eventError(out.Events[i]) == "" {
+			if code, _ := eventError(out.Events[i]); sel.FailedOnly && code == "" {
 				continue
 			}
 			changes = append(changes, eventToChange(out.Events[i]))
@@ -96,10 +102,18 @@ func (c *Client) CloudChanges(ctx context.Context, sel providers.Selector, w pro
 		// A failure scan has to look past the cap — failures are sparse, and the
 		// answer is typically behind pages of successful churn. Bound it anyway: a
 		// window with no failures at all would otherwise walk the whole retention
-		// period one page at a time. Hitting the budget is a partial view, so it
-		// reuses the truncation sentinel rather than reporting a clean empty result.
+		// period one page at a time.
+		//
+		// This is NOT the same condition as the cap binding above, and it does not
+		// reuse its sentinel. The cap means "more events matched than we kept, narrow
+		// the search"; the budget means "we stopped reading, widen or scope it". Same
+		// word, opposite advice — and for a sparse-failure scan the cap's advice sends
+		// the model away from an answer that is older, not newer.
 		if sel.FailedOnly && pages >= maxFailureScanPages {
-			truncated = true
+			// Only partial if there was actually more to read. A scan that happens to
+			// finish on its last allowed page is complete, and saying otherwise tells
+			// the model its one real answer might be missing a sibling.
+			scanBounded = p.HasMorePages()
 			break
 		}
 	}
@@ -112,8 +126,18 @@ func (c *Client) CloudChanges(ctx context.Context, sel providers.Selector, w pro
 	}
 	// Append the sentinel AFTER the sort+slice so it always lands last (a zero
 	// When would otherwise sort it among real events), signalling a partial view.
-	if truncated {
-		changes = append(changes, truncatedChange(c.maxEvents))
+	//
+	// Never on its own, though. A sentinel-only slice is not empty, so a caller
+	// testing len(changes) == 0 stops seeing an empty result: the failure scan that
+	// walked 20 pages of Karpenter churn and found nothing returned one bogus row,
+	// which suppressed both the "no failures found" message and the unscoped widen —
+	// on exactly the busy cluster the filter was written for.
+	if (truncated || scanBounded) && len(changes) > 0 {
+		if scanBounded {
+			changes = append(changes, scanBoundedChange(pages))
+		} else {
+			changes = append(changes, truncatedChange(c.maxEvents))
+		}
 	}
 	return changes, nil
 }
@@ -124,26 +148,48 @@ func (c *Client) CloudChanges(ctx context.Context, sel providers.Selector, w pro
 // churn, and small enough that a quiet window returns promptly.
 const maxFailureScanPages = 20
 
-// eventError returns the errorCode from an event's raw CloudTrail payload, or ""
-// when the call succeeded (successful calls omit the field). It is the single
-// reader of that payload: both the FailedOnly filter and the rendered "FAILED:"
-// annotation key on it, so the two can never disagree about what failed.
-func eventError(e cttypes.Event) string {
+// eventError returns the errorCode and errorMessage from an event's raw CloudTrail
+// payload; code is "" when the call succeeded (successful calls omit the field).
+//
+// It is the single reader of that payload — both the FailedOnly filter and the
+// rendered "FAILED:" annotation key on it, so the two can never disagree about what
+// failed. It returns the message too rather than leaving eventToChange to re-parse
+// the same JSON for it: on a 20-page failure scan that second parse ran over every
+// kept event, and a claim of single-readership that a sibling function quietly
+// breaks is worse than no claim.
+func eventError(e cttypes.Event) (code, message string) {
 	raw := deref(e.CloudTrailEvent)
 	if raw == "" {
-		return ""
+		return "", ""
 	}
 	var payload ctEventJSON
 	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
-		return ""
+		return "", ""
 	}
-	return payload.ErrorCode
+	return payload.ErrorCode, payload.ErrorMessage
 }
 
 // truncatedChange is the sentinel appended when CloudChanges stops at its cap
 // with more events upstream, so the model knows the timeline is partial. It is
 // not a real event: Kind "(truncated)" is the recognizable marker, and it is
 // appended last so cloud_tools renders it as a trailing note.
+// scanBoundedChange is the sentinel for a FailedOnly scan that spent its page
+// budget with more pages still to read. It is deliberately NOT truncatedChange:
+// nothing was truncated at the cap, and "narrow the window" — that sentinel's
+// advice — is the wrong move here, because a sparse failure is typically OLDER
+// than the newest events, not newer.
+func scanBoundedChange(pages int) providers.Change {
+	return providers.Change{
+		Engine: providers.EngineAWS,
+		Type:   providers.ChangeCloudAPI,
+		Workload: providers.Workload{
+			Kind: "(truncated)",
+			Name: fmt.Sprintf("scan stopped after %d pages of successful events; any FAILED calls older "+
+				"than that were not examined — narrow the window's END, or scope to a resource", pages),
+		},
+	}
+}
+
 func truncatedChange(limit int) providers.Change {
 	return providers.Change{
 		Engine: providers.EngineAWS,
@@ -188,11 +234,10 @@ func eventToChange(e cttypes.Event) providers.Change {
 	// raw CloudTrail JSON carries an errorCode — so the model sees failed calls
 	// (InsufficientInstanceCapacity, UnauthorizedOperation, etc.) not as successes.
 	path := deref(e.EventName) + " by " + deref(e.Username)
-	if code := eventError(e); code != "" {
+	if code, msg := eventError(e); code != "" {
 		path += " — FAILED: " + code
-		var payload ctEventJSON
-		if err := json.Unmarshal([]byte(deref(e.CloudTrailEvent)), &payload); err == nil && payload.ErrorMessage != "" {
-			path += " (" + payload.ErrorMessage + ")"
+		if msg != "" {
+			path += " (" + msg + ")"
 		}
 	}
 	ch.Source = providers.SourceRef{Path: path}

--- a/internal/providers/cloud/aws/cloudtrail.go
+++ b/internal/providers/cloud/aws/cloudtrail.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudtrail"
 	cttypes "github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
@@ -57,11 +58,6 @@ func (c *Client) CloudChanges(ctx context.Context, sel providers.Selector, w pro
 	}
 
 	in := &cloudtrail.LookupEventsInput{LookupAttributes: attrs}
-	// Ask for full pages. Without this the server picks the page size, so
-	// maxFailureScanPages would bound PAGES but not events — twenty short pages can
-	// examine a few dozen events rather than the ~1000 the budget is sized for, and
-	// the scan then gives up far short of the depth it reports.
-	in.MaxResults = ptr(int32(50))
 	if !w.Start.IsZero() {
 		in.StartTime = ptr(w.Start)
 	}
@@ -75,8 +71,11 @@ func (c *Client) CloudChanges(ctx context.Context, sel providers.Selector, w pro
 	// can tell the cap is *binding* (more existed) versus an exactly-full result.
 	p := cloudtrail.NewLookupEventsPaginator(c.ct, in)
 	var changes []providers.Change
-	truncated := false
-	scanBounded := false
+	// One value rather than two flags: the only question the loop answers is WHY it
+	// stopped, and the answer IS the note the caller gets. Empty means it read to the
+	// end. The cap and the budget are different stops carrying opposite advice, so
+	// they must not share a message.
+	stopNote := ""
 	pages := 0
 	for p.HasMorePages() {
 		out, err := p.NextPage(ctx)
@@ -90,13 +89,18 @@ func (c *Client) CloudChanges(ctx context.Context, sel providers.Selector, w pro
 			if resourceScoped && deref(out.Events[i].ReadOnly) == "true" {
 				continue
 			}
-			if code, _ := eventError(out.Events[i]); sel.FailedOnly && code == "" {
+			// Parsed once here and handed to eventToChange, which used to re-parse the
+			// identical payload for the message. Note this is an if-init-free spelling on
+			// purpose: `if code, _ := eventError(e); sel.FailedOnly && ...` runs the parse
+			// unconditionally, because Go evaluates the init statement before the guard.
+			code, msg := eventError(out.Events[i])
+			if sel.FailedOnly && code == "" {
 				continue
 			}
-			changes = append(changes, eventToChange(out.Events[i]))
+			changes = append(changes, eventToChange(out.Events[i], code, msg))
 		}
 		if len(changes) > c.maxEvents {
-			truncated = true
+			stopNote = truncatedNote(c.maxEvents)
 			break // we already have more than the cap; further pages cannot change the kept top-N
 		}
 		// A failure scan has to look past the cap — failures are sparse, and the
@@ -104,16 +108,14 @@ func (c *Client) CloudChanges(ctx context.Context, sel providers.Selector, w pro
 		// window with no failures at all would otherwise walk the whole retention
 		// period one page at a time.
 		//
-		// This is NOT the same condition as the cap binding above, and it does not
-		// reuse its sentinel. The cap means "more events matched than we kept, narrow
-		// the search"; the budget means "we stopped reading, widen or scope it". Same
-		// word, opposite advice — and for a sparse-failure scan the cap's advice sends
-		// the model away from an answer that is older, not newer.
+		// See scanBoundedNote for why this does not reuse the cap's message.
 		if sel.FailedOnly && pages >= maxFailureScanPages {
 			// Only partial if there was actually more to read. A scan that happens to
 			// finish on its last allowed page is complete, and saying otherwise tells
 			// the model its one real answer might be missing a sibling.
-			scanBounded = p.HasMorePages()
+			if p.HasMorePages() {
+				stopNote = scanBoundedNote()
+			}
 			break
 		}
 	}
@@ -121,23 +123,19 @@ func (c *Client) CloudChanges(ctx context.Context, sel providers.Selector, w pro
 	// regardless of the API's return order.
 	sort.SliceStable(changes, func(i, j int) bool { return changes[i].When.After(changes[j].When) })
 	if len(changes) > c.maxEvents {
-		truncated = true
+		if stopNote == "" {
+			stopNote = truncatedNote(c.maxEvents)
+		}
 		changes = changes[:c.maxEvents]
 	}
-	// Append the sentinel AFTER the sort+slice so it always lands last (a zero
-	// When would otherwise sort it among real events), signalling a partial view.
-	//
-	// Never on its own, though. A sentinel-only slice is not empty, so a caller
-	// testing len(changes) == 0 stops seeing an empty result: the failure scan that
-	// walked 20 pages of Karpenter churn and found nothing returned one bogus row,
-	// which suppressed both the "no failures found" message and the unscoped widen —
-	// on exactly the busy cluster the filter was written for.
-	if (truncated || scanBounded) && len(changes) > 0 {
-		if scanBounded {
-			changes = append(changes, scanBoundedChange(pages))
-		} else {
-			changes = append(changes, truncatedChange(c.maxEvents))
-		}
+	// Appended AFTER the sort+slice so it always lands last (a zero When would
+	// otherwise sort it among real events). It is appended even when nothing else
+	// matched: "the scan stopped reading" is the one thing a caller must never read
+	// as "the window was quiet", and that is precisely the case with no other row to
+	// carry it. A note-only slice is therefore not an empty one — callers separate
+	// the two with providers.IsChangeNote.
+	if stopNote != "" {
+		changes = append(changes, providers.ChangeNote(providers.EngineAWS, stopNote))
 	}
 	return changes, nil
 }
@@ -149,17 +147,17 @@ func (c *Client) CloudChanges(ctx context.Context, sel providers.Selector, w pro
 const maxFailureScanPages = 20
 
 // eventError returns the errorCode and errorMessage from an event's raw CloudTrail
-// payload; code is "" when the call succeeded (successful calls omit the field).
-//
-// It is the single reader of that payload — both the FailedOnly filter and the
-// rendered "FAILED:" annotation key on it, so the two can never disagree about what
-// failed. It returns the message too rather than leaving eventToChange to re-parse
-// the same JSON for it: on a 20-page failure scan that second parse ran over every
-// kept event, and a claim of single-readership that a sibling function quietly
-// breaks is worse than no claim.
+// payload; code is "" when the call succeeded. Single reader of that payload — the
+// FailedOnly filter and the rendered "FAILED:" annotation both key on it, so the two
+// cannot disagree about what failed.
 func eventError(e cttypes.Event) (code, message string) {
 	raw := deref(e.CloudTrailEvent)
-	if raw == "" {
+	// A successful call omits errorCode entirely, which is almost every event on a
+	// failure scan sized to examine ~1000 of them. A substring test costs no
+	// allocation; unmarshalling a multi-KB document to learn the same thing costs two
+	// and an order of magnitude more time. A hit inside requestParameters just falls
+	// through to the real parse, so this cannot produce a false negative.
+	if raw == "" || !strings.Contains(raw, `"errorCode"`) {
 		return "", ""
 	}
 	var payload ctEventJSON
@@ -167,38 +165,6 @@ func eventError(e cttypes.Event) (code, message string) {
 		return "", ""
 	}
 	return payload.ErrorCode, payload.ErrorMessage
-}
-
-// truncatedChange is the sentinel appended when CloudChanges stops at its cap
-// with more events upstream, so the model knows the timeline is partial. It is
-// not a real event: Kind "(truncated)" is the recognizable marker, and it is
-// appended last so cloud_tools renders it as a trailing note.
-// scanBoundedChange is the sentinel for a FailedOnly scan that spent its page
-// budget with more pages still to read. It is deliberately NOT truncatedChange:
-// nothing was truncated at the cap, and "narrow the window" — that sentinel's
-// advice — is the wrong move here, because a sparse failure is typically OLDER
-// than the newest events, not newer.
-func scanBoundedChange(pages int) providers.Change {
-	return providers.Change{
-		Engine: providers.EngineAWS,
-		Type:   providers.ChangeCloudAPI,
-		Workload: providers.Workload{
-			Kind: "(truncated)",
-			Name: fmt.Sprintf("scan stopped after %d pages of successful events; any FAILED calls older "+
-				"than that were not examined — narrow the window's END, or scope to a resource", pages),
-		},
-	}
-}
-
-func truncatedChange(limit int) providers.Change {
-	return providers.Change{
-		Engine: providers.EngineAWS,
-		Type:   providers.ChangeCloudAPI,
-		Workload: providers.Workload{
-			Kind: "(truncated)",
-			Name: fmt.Sprintf("results truncated at %d — more events matched; narrow the window or resource", limit),
-		},
-	}
 }
 
 // ctEventJSON is the minimal shape of the raw CloudTrail JSON payload we need
@@ -210,8 +176,24 @@ type ctEventJSON struct {
 	ErrorMessage string `json:"errorMessage"`
 }
 
+// truncatedNote is what the CAP says: more events matched than were kept, so the
+// answer is among the newest and the search should be narrowed.
+func truncatedNote(limit int) string {
+	return fmt.Sprintf("results truncated at %d — more events matched; narrow the window or resource", limit)
+}
+
+// scanBoundedNote is what the BUDGET says, which is the opposite advice. Nothing was
+// truncated at the cap; the scan simply stopped reading, and a sparse failure is
+// typically OLDER than the newest events — so "narrow the window" would push it
+// further out of reach. The page count is the constant rather than a variable:
+// this note exists only at the moment the budget is reached.
+func scanBoundedNote() string {
+	return fmt.Sprintf("scan stopped after %d pages of successful events; any FAILED calls older "+
+		"than that were not examined — narrow the window's END, or scope to a resource", maxFailureScanPages)
+}
+
 // eventToChange maps a CloudTrail event to an engine-agnostic Change.
-func eventToChange(e cttypes.Event) providers.Change {
+func eventToChange(e cttypes.Event, code, msg string) providers.Change {
 	ch := providers.Change{
 		Engine:    providers.EngineAWS,
 		Type:      providers.ChangeCloudAPI,
@@ -234,7 +216,7 @@ func eventToChange(e cttypes.Event) providers.Change {
 	// raw CloudTrail JSON carries an errorCode — so the model sees failed calls
 	// (InsufficientInstanceCapacity, UnauthorizedOperation, etc.) not as successes.
 	path := deref(e.EventName) + " by " + deref(e.Username)
-	if code, msg := eventError(e); code != "" {
+	if code != "" {
 		path += " — FAILED: " + code
 		if msg != "" {
 			path += " (" + msg + ")"

--- a/internal/providers/cloud/aws/cloudtrail.go
+++ b/internal/providers/cloud/aws/cloudtrail.go
@@ -33,7 +33,7 @@ import (
 //
 // Note: CloudTrail is eventually consistent (~15 min), so a too-narrow window can
 // miss a just-made change — callers should use a generous lookback.
-func (c *Client) CloudChanges(ctx context.Context, sel providers.Selector, w providers.TimeWindow) ([]providers.Change, error) {
+func (c *Client) CloudChanges(ctx context.Context, sel providers.Selector, w providers.TimeWindow, f providers.CloudChangeFilter) ([]providers.Change, error) {
 	// CloudTrail LookupEvents accepts exactly ONE LookupAttribute per request.
 	// When a resource name is given, scope by ResourceName and filter read-only
 	// events client-side (the Event carries a ReadOnly field). When no resource
@@ -91,10 +91,10 @@ func (c *Client) CloudChanges(ctx context.Context, sel providers.Selector, w pro
 			}
 			// Parsed once here and handed to eventToChange, which used to re-parse the
 			// identical payload for the message. Note this is an if-init-free spelling on
-			// purpose: `if code, _ := eventError(e); sel.FailedOnly && ...` runs the parse
+			// purpose: `if code, _ := eventError(e); f.FailedOnly && ...` runs the parse
 			// unconditionally, because Go evaluates the init statement before the guard.
 			code, msg := eventError(out.Events[i])
-			if sel.FailedOnly && code == "" {
+			if f.FailedOnly && code == "" {
 				continue
 			}
 			changes = append(changes, eventToChange(out.Events[i], code, msg))
@@ -109,7 +109,7 @@ func (c *Client) CloudChanges(ctx context.Context, sel providers.Selector, w pro
 		// period one page at a time.
 		//
 		// See scanBoundedNote for why this does not reuse the cap's message.
-		if sel.FailedOnly && pages >= maxFailureScanPages {
+		if f.FailedOnly && pages >= maxFailureScanPages {
 			// Only partial if there was actually more to read. A scan that happens to
 			// finish on its last allowed page is complete, and saying otherwise tells
 			// the model its one real answer might be missing a sibling.

--- a/internal/providers/cloud/aws/cloudtrail_failed_test.go
+++ b/internal/providers/cloud/aws/cloudtrail_failed_test.go
@@ -68,7 +68,7 @@ func TestCloudChangesFailedOnly(t *testing.T) {
 		t.Fatalf("FailedOnly must surface the failed call; got %d changes: %+v", len(got), got)
 	}
 	for _, ch := range got {
-		if ch.Workload.Kind == "(truncated)" {
+		if providers.IsChangeNote(ch) {
 			continue
 		}
 		if !strings.Contains(ch.Source.Path, "FAILED") {
@@ -109,11 +109,17 @@ func TestCloudChangesFailedOnlyBoundsItsScan(t *testing.T) {
 	if ct.call != maxFailureScanPages {
 		t.Errorf("the failure scan made %d LookupEvents calls, want exactly %d", ct.call, maxFailureScanPages)
 	}
-	// And the RESULT of a budget-exhausted scan matters as much as its cost: a
-	// sentinel-only slice is not empty, so callers testing len(changes) == 0 stopped
-	// seeing an empty scan as empty. It must come back genuinely empty.
-	if len(got) != 0 {
-		t.Errorf("a failure scan that found nothing must return no rows, got %d: %+v", len(got), got)
+	// The RESULT of a budget-exhausted scan matters as much as its cost. It must carry
+	// the note — "we stopped reading" is the one thing a caller must never read as
+	// "the window was quiet" — and NOTHING else, since no real failure was found.
+	if n := len(got); n != 1 {
+		t.Fatalf("want the bounded-scan note and no events, got %d rows: %+v", n, got)
+	}
+	if !providers.IsChangeNote(got[0]) {
+		t.Errorf("a scan that found no failures returned an event row: %+v", got[0])
+	}
+	if !strings.Contains(got[0].Workload.Name, "scan stopped after") {
+		t.Errorf("the note must say the scan stopped reading: %q", got[0].Workload.Name)
 	}
 }
 
@@ -144,7 +150,7 @@ func TestCloudChangesFailedOnlyScanNoteNotTruncation(t *testing.T) {
 	}
 	var note string
 	for _, ch := range got {
-		if ch.Workload.Kind == "(truncated)" {
+		if providers.IsChangeNote(ch) {
 			note = ch.Workload.Name
 		}
 	}
@@ -181,10 +187,8 @@ func TestCloudChangesFailedOnlyCompleteScanIsNotPartial(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CloudChanges(FailedOnly): %v", err)
 	}
-	for _, ch := range got {
-		if ch.Workload.Kind == "(truncated)" {
-			t.Errorf("a complete scan was reported as partial: %q", ch.Workload.Name)
-		}
+	if n := countTruncated(got); n != 0 {
+		t.Errorf("a complete scan was reported as partial: %+v", got)
 	}
 	if !containsPath(got, "InvalidDBClusterStateFault") {
 		t.Errorf("the answer on the last page must survive; got %+v", got)

--- a/internal/providers/cloud/aws/cloudtrail_failed_test.go
+++ b/internal/providers/cloud/aws/cloudtrail_failed_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudtrail"
+	cttypes "github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// ctFailedEvent builds a CloudTrail event whose raw payload carries an errorCode —
+// the shape of a control-plane call that was attempted and rejected.
+func ctFailedEvent(id, name, code, msg string, t time.Time) cttypes.Event {
+	e := ctEvent(id, name, t)
+	e.CloudTrailEvent = ptr(`{"errorCode":"` + code + `","errorMessage":"` + msg + `"}`)
+	return e
+}
+
+// TestCloudChangesFailedOnly reproduces the BackupJobFailed dead end.
+//
+// Four investigations across three days concluded "the failing RDS resource could
+// not be identified", each reporting the same blocker: the lookup returns the most
+// recent mutating events cluster-wide, and at 25 those are all Karpenter and SSM
+// churn. The failing CreateDBClusterSnapshot calls were in CloudTrail the whole
+// time — just past the cap. Filtering to failures applies the cap to the events
+// that answer a "why did this fail" question instead of to the noise ahead of them.
+func TestCloudChangesFailedOnly(t *testing.T) {
+	t0 := time.Date(2026, 8, 23, 3, 55, 0, 0, time.UTC)
+	// Noise first (newest), the answer buried behind it — the live ordering.
+	noise := make([]cttypes.Event, 0, 30)
+	for i := range 30 {
+		id := fmt.Sprintf("noise-%d", i)
+		noise = append(noise, ctEvent(id, "CreateTags", t0.Add(-time.Duration(i)*time.Second)))
+	}
+	answer := ctFailedEvent("snap", "CreateDBClusterSnapshot", "InvalidDBClusterStateFault",
+		"Can't create a snapshot because the database cluster aurora-serverless-postgres-old isn't currently in the available state.",
+		t0.Add(-40*time.Minute))
+
+	pages := []*cloudtrail.LookupEventsOutput{
+		{Events: noise, NextToken: ptr("page2")},
+		{Events: []cttypes.Event{answer}},
+	}
+
+	// Control: without the filter the answer is past the cap, exactly as observed.
+	c := &Client{ct: &fakeCT{pages: pages}, maxEvents: 25}
+	got, err := c.CloudChanges(context.Background(), providers.Selector{}, providers.TimeWindow{})
+	if err != nil {
+		t.Fatalf("CloudChanges: %v", err)
+	}
+	if containsEvent(got, "CreateDBClusterSnapshot") {
+		t.Fatalf("fixture does not reproduce the bug: the answer was inside the cap")
+	}
+
+	// With the filter, the failed call is the whole result.
+	c = &Client{ct: &fakeCT{pages: pages}, maxEvents: 25}
+	got, err = c.CloudChanges(context.Background(), providers.Selector{FailedOnly: true}, providers.TimeWindow{})
+	if err != nil {
+		t.Fatalf("CloudChanges(FailedOnly): %v", err)
+	}
+	if !containsEvent(got, "CreateDBClusterSnapshot") {
+		t.Fatalf("FailedOnly must surface the failed call; got %d changes: %+v", len(got), got)
+	}
+	for _, ch := range got {
+		if ch.Workload.Kind == "(truncated)" {
+			continue
+		}
+		if !strings.Contains(ch.Source.Path, "FAILED") {
+			t.Errorf("FailedOnly returned a successful event: %q", ch.Source.Path)
+		}
+	}
+	// And the error code the on-call needs is carried through.
+	if !containsPath(got, "InvalidDBClusterStateFault") {
+		t.Errorf("the error code must reach the caller; got %+v", got)
+	}
+}
+
+// TestCloudChangesFailedOnlyBoundsItsScan: failures are rare, so the filter must
+// keep paginating past the cap to find them — but not without limit, or a quiet
+// window walks the entire retention period one page at a time.
+func TestCloudChangesFailedOnlyBoundsItsScan(t *testing.T) {
+	t0 := time.Date(2026, 8, 23, 3, 55, 0, 0, time.UTC)
+	// Every page is noise and there is always another one.
+	page := func(i int) *cloudtrail.LookupEventsOutput {
+		return &cloudtrail.LookupEventsOutput{
+			Events:    []cttypes.Event{ctEvent(fmt.Sprintf("n-%d", i), "CreateTags", t0)},
+			NextToken: ptr("more"),
+		}
+	}
+	pages := make([]*cloudtrail.LookupEventsOutput, 0, 500)
+	for i := range 500 {
+		pages = append(pages, page(i))
+	}
+	ct := &fakeCT{pages: pages}
+	c := &Client{ct: ct, maxEvents: 25}
+	if _, err := c.CloudChanges(context.Background(), providers.Selector{FailedOnly: true}, providers.TimeWindow{}); err != nil {
+		t.Fatalf("CloudChanges(FailedOnly): %v", err)
+	}
+	if ct.call > 50 {
+		t.Errorf("the failure scan is unbounded: made %d LookupEvents calls", ct.call)
+	}
+	if ct.call < 2 {
+		t.Errorf("the failure scan must look past the first page, made %d calls", ct.call)
+	}
+}
+
+func containsEvent(changes []providers.Change, name string) bool {
+	return containsPath(changes, name)
+}
+
+func containsPath(changes []providers.Change, substr string) bool {
+	for _, c := range changes {
+		if strings.Contains(c.Source.Path, substr) || strings.Contains(c.Workload.Name, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/providers/cloud/aws/cloudtrail_failed_test.go
+++ b/internal/providers/cloud/aws/cloudtrail_failed_test.go
@@ -54,7 +54,7 @@ func TestCloudChangesFailedOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CloudChanges: %v", err)
 	}
-	if containsEvent(got, "CreateDBClusterSnapshot") {
+	if containsPath(got, "CreateDBClusterSnapshot") {
 		t.Fatalf("fixture does not reproduce the bug: the answer was inside the cap")
 	}
 
@@ -64,7 +64,7 @@ func TestCloudChangesFailedOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CloudChanges(FailedOnly): %v", err)
 	}
-	if !containsEvent(got, "CreateDBClusterSnapshot") {
+	if !containsPath(got, "CreateDBClusterSnapshot") {
 		t.Fatalf("FailedOnly must surface the failed call; got %d changes: %+v", len(got), got)
 	}
 	for _, ch := range got {
@@ -99,19 +99,96 @@ func TestCloudChangesFailedOnlyBoundsItsScan(t *testing.T) {
 	}
 	ct := &fakeCT{pages: pages}
 	c := &Client{ct: ct, maxEvents: 25}
-	if _, err := c.CloudChanges(context.Background(), providers.Selector{FailedOnly: true}, providers.TimeWindow{}); err != nil {
+	got, err := c.CloudChanges(context.Background(), providers.Selector{FailedOnly: true}, providers.TimeWindow{})
+	if err != nil {
 		t.Fatalf("CloudChanges(FailedOnly): %v", err)
 	}
-	if ct.call > 50 {
-		t.Errorf("the failure scan is unbounded: made %d LookupEvents calls", ct.call)
+	// Pinned to the constant, not to a loose ceiling. An earlier revision asserted
+	// `> 50`, which passed for any budget from 2 to 50 — so raising the constant to a
+	// 2.5x latency regression against a ~2 TPS API was invisible to CI.
+	if ct.call != maxFailureScanPages {
+		t.Errorf("the failure scan made %d LookupEvents calls, want exactly %d", ct.call, maxFailureScanPages)
 	}
-	if ct.call < 2 {
-		t.Errorf("the failure scan must look past the first page, made %d calls", ct.call)
+	// And the RESULT of a budget-exhausted scan matters as much as its cost: a
+	// sentinel-only slice is not empty, so callers testing len(changes) == 0 stopped
+	// seeing an empty scan as empty. It must come back genuinely empty.
+	if len(got) != 0 {
+		t.Errorf("a failure scan that found nothing must return no rows, got %d: %+v", len(got), got)
 	}
 }
 
-func containsEvent(changes []providers.Change, name string) bool {
-	return containsPath(changes, name)
+// TestCloudChangesFailedOnlyScanNoteNotTruncation: when the budget runs out with
+// real failures in hand, the note must describe what actually happened. The cap's
+// sentinel says "more events matched; narrow the window", which is both false (the
+// cap never bound) and backwards — a sparse failure is OLDER than the newest events,
+// so narrowing the window moves it further out of reach.
+func TestCloudChangesFailedOnlyScanNoteNotTruncation(t *testing.T) {
+	t0 := time.Date(2026, 8, 23, 3, 55, 0, 0, time.UTC)
+	pages := make([]*cloudtrail.LookupEventsOutput, 0, 500)
+	// One real failure up front, then endless churn, so the scan ends on its budget.
+	pages = append(pages, &cloudtrail.LookupEventsOutput{
+		Events: []cttypes.Event{ctFailedEvent("snap", "CreateDBClusterSnapshot",
+			"InvalidDBClusterStateFault", "cluster is stopped", t0)},
+		NextToken: ptr("more"),
+	})
+	for i := range 500 {
+		pages = append(pages, &cloudtrail.LookupEventsOutput{
+			Events:    []cttypes.Event{ctEvent(fmt.Sprintf("n-%d", i), "CreateTags", t0)},
+			NextToken: ptr("more"),
+		})
+	}
+	c := &Client{ct: &fakeCT{pages: pages}, maxEvents: 25}
+	got, err := c.CloudChanges(context.Background(), providers.Selector{FailedOnly: true}, providers.TimeWindow{})
+	if err != nil {
+		t.Fatalf("CloudChanges(FailedOnly): %v", err)
+	}
+	var note string
+	for _, ch := range got {
+		if ch.Workload.Kind == "(truncated)" {
+			note = ch.Workload.Name
+		}
+	}
+	if note == "" {
+		t.Fatalf("a bounded scan must say so; got %+v", got)
+	}
+	if strings.Contains(note, "truncated at") {
+		t.Errorf("a bounded scan reused the CAP's sentinel, whose advice is backwards here: %q", note)
+	}
+	if !strings.Contains(note, "older") {
+		t.Errorf("the note must say what was not examined: %q", note)
+	}
+}
+
+// TestCloudChangesFailedOnlyCompleteScanIsNotPartial: a scan that finishes on its
+// last allowed page is COMPLETE. Reporting it as partial tells the model its one
+// real answer might be missing a sibling that does not exist.
+func TestCloudChangesFailedOnlyCompleteScanIsNotPartial(t *testing.T) {
+	t0 := time.Date(2026, 8, 23, 3, 55, 0, 0, time.UTC)
+	pages := make([]*cloudtrail.LookupEventsOutput, 0, maxFailureScanPages)
+	for i := range maxFailureScanPages - 1 {
+		pages = append(pages, &cloudtrail.LookupEventsOutput{
+			Events:    []cttypes.Event{ctEvent(fmt.Sprintf("n-%d", i), "CreateTags", t0)},
+			NextToken: ptr("more"),
+		})
+	}
+	// The last page carries the answer and NO NextToken — there is nothing more.
+	pages = append(pages, &cloudtrail.LookupEventsOutput{
+		Events: []cttypes.Event{ctFailedEvent("snap", "CreateDBClusterSnapshot",
+			"InvalidDBClusterStateFault", "cluster is stopped", t0)},
+	})
+	c := &Client{ct: &fakeCT{pages: pages}, maxEvents: 25}
+	got, err := c.CloudChanges(context.Background(), providers.Selector{FailedOnly: true}, providers.TimeWindow{})
+	if err != nil {
+		t.Fatalf("CloudChanges(FailedOnly): %v", err)
+	}
+	for _, ch := range got {
+		if ch.Workload.Kind == "(truncated)" {
+			t.Errorf("a complete scan was reported as partial: %q", ch.Workload.Name)
+		}
+	}
+	if !containsPath(got, "InvalidDBClusterStateFault") {
+		t.Errorf("the answer on the last page must survive; got %+v", got)
+	}
 }
 
 func containsPath(changes []providers.Change, substr string) bool {

--- a/internal/providers/cloud/aws/cloudtrail_failed_test.go
+++ b/internal/providers/cloud/aws/cloudtrail_failed_test.go
@@ -50,7 +50,7 @@ func TestCloudChangesFailedOnly(t *testing.T) {
 
 	// Control: without the filter the answer is past the cap, exactly as observed.
 	c := &Client{ct: &fakeCT{pages: pages}, maxEvents: 25}
-	got, err := c.CloudChanges(context.Background(), providers.Selector{}, providers.TimeWindow{})
+	got, err := c.CloudChanges(context.Background(), providers.Selector{}, providers.TimeWindow{}, providers.CloudChangeFilter{})
 	if err != nil {
 		t.Fatalf("CloudChanges: %v", err)
 	}
@@ -60,7 +60,7 @@ func TestCloudChangesFailedOnly(t *testing.T) {
 
 	// With the filter, the failed call is the whole result.
 	c = &Client{ct: &fakeCT{pages: pages}, maxEvents: 25}
-	got, err = c.CloudChanges(context.Background(), providers.Selector{FailedOnly: true}, providers.TimeWindow{})
+	got, err = c.CloudChanges(context.Background(), providers.Selector{}, providers.TimeWindow{}, providers.CloudChangeFilter{FailedOnly: true})
 	if err != nil {
 		t.Fatalf("CloudChanges(FailedOnly): %v", err)
 	}
@@ -99,7 +99,7 @@ func TestCloudChangesFailedOnlyBoundsItsScan(t *testing.T) {
 	}
 	ct := &fakeCT{pages: pages}
 	c := &Client{ct: ct, maxEvents: 25}
-	got, err := c.CloudChanges(context.Background(), providers.Selector{FailedOnly: true}, providers.TimeWindow{})
+	got, err := c.CloudChanges(context.Background(), providers.Selector{}, providers.TimeWindow{}, providers.CloudChangeFilter{FailedOnly: true})
 	if err != nil {
 		t.Fatalf("CloudChanges(FailedOnly): %v", err)
 	}
@@ -144,7 +144,7 @@ func TestCloudChangesFailedOnlyScanNoteNotTruncation(t *testing.T) {
 		})
 	}
 	c := &Client{ct: &fakeCT{pages: pages}, maxEvents: 25}
-	got, err := c.CloudChanges(context.Background(), providers.Selector{FailedOnly: true}, providers.TimeWindow{})
+	got, err := c.CloudChanges(context.Background(), providers.Selector{}, providers.TimeWindow{}, providers.CloudChangeFilter{FailedOnly: true})
 	if err != nil {
 		t.Fatalf("CloudChanges(FailedOnly): %v", err)
 	}
@@ -183,7 +183,7 @@ func TestCloudChangesFailedOnlyCompleteScanIsNotPartial(t *testing.T) {
 			"InvalidDBClusterStateFault", "cluster is stopped", t0)},
 	})
 	c := &Client{ct: &fakeCT{pages: pages}, maxEvents: 25}
-	got, err := c.CloudChanges(context.Background(), providers.Selector{FailedOnly: true}, providers.TimeWindow{})
+	got, err := c.CloudChanges(context.Background(), providers.Selector{}, providers.TimeWindow{}, providers.CloudChangeFilter{FailedOnly: true})
 	if err != nil {
 		t.Fatalf("CloudChanges(FailedOnly): %v", err)
 	}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -1382,6 +1382,32 @@ type LogLine struct {
 	Fields  map[string]string
 }
 
+// changeNoteKind marks a Change that is not an event but a note about the result —
+// why the timeline is partial. It is spelled "(truncated)" for compatibility with
+// the marker cloud providers already emitted before ChangeNote existed.
+const changeNoteKind = "(truncated)"
+
+// ChangeNote builds the sentinel a Change-producing provider appends when the view
+// it returns is partial, so the model knows not to read the list as complete. It is
+// the Change-shaped counterpart of TruncationLine, and exists here for the same
+// reason: the marker is a cross-package contract, and a consumer that has to
+// recognise it by matching a string literal has no compiler behind it.
+//
+// It carries no When, so it sorts and reads as a non-event, and IsChangeNote is the
+// only supported way to recognise it.
+func ChangeNote(engine Engine, msg string) Change {
+	return Change{
+		Engine:   engine,
+		Type:     ChangeCloudAPI,
+		Workload: Workload{Kind: changeNoteKind, Name: msg},
+	}
+}
+
+// IsChangeNote reports whether c is a ChangeNote rather than a real event. Callers
+// that count or render events must skip these; callers that want to surface the
+// caveat read c.Workload.Name.
+func IsChangeNote(c Change) bool { return c.Workload.Kind == changeNoteKind }
+
 // TruncationLine is the sentinel appended when a logs/flow query stops at its cap
 // with more entries upstream, so the model knows the view is partial. It carries no
 // Time or Fields, so it cannot be mistaken for a real entry. Every capping provider

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -415,6 +415,12 @@ type Selector struct {
 	Namespace string
 	Kind      string
 	Name      string
+	// FailedOnly keeps only events that the provider reports as failed calls.
+	// Cloud control-plane lookups return the most recent MUTATING events, which on
+	// a Karpenter cluster are overwhelmingly routine churn; a "why did this fail"
+	// question wants the rejected calls, and those are usually older than the
+	// result cap. Honoured by CloudProvider.CloudChanges; ignored elsewhere.
+	FailedOnly bool
 }
 
 // ---- provider interfaces -----------------------------------------------------

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -415,12 +415,6 @@ type Selector struct {
 	Namespace string
 	Kind      string
 	Name      string
-	// FailedOnly keeps only events that the provider reports as failed calls.
-	// Cloud control-plane lookups return the most recent MUTATING events, which on
-	// a Karpenter cluster are overwhelmingly routine churn; a "why did this fail"
-	// question wants the rejected calls, and those are usually older than the
-	// result cap. Honoured by CloudProvider.CloudChanges; ignored elsewhere.
-	FailedOnly bool
 }
 
 // ---- provider interfaces -----------------------------------------------------
@@ -1057,11 +1051,28 @@ type OwnerWalker interface {
 // (EKS Pod Identity / IRSA) — not Steampipe and not a bundled CLI (both break the
 // single-binary property). Steampipe / cloud MCP servers stay optional MCP
 // extensions. Cloud is opt-in (config.cloud.provider).
+// CloudChangeFilter narrows which control-plane events CloudChanges keeps. It is a
+// parameter of that ONE method rather than a field on Selector, because Selector
+// answers "which object" and every other consumer of it — the GitOps providers'
+// Changes, the three flow providers' Drops, ResourceHealth — would silently drop a
+// filter they never honour. A caller asking to narrow and a callee quietly not
+// narrowing is the defect LookupReason exists to prevent one layer up.
+//
+// The zero value keeps everything, so a caller that does not care says nothing.
+type CloudChangeFilter struct {
+	// FailedOnly keeps only events the provider recorded as REJECTED calls. Cloud
+	// lookups return the most recent MUTATING events, which on a busy cluster are
+	// overwhelmingly routine instance and tag churn; a "why did this fail" question
+	// wants the rejected calls, and those are usually older than the result cap.
+	FailedOnly bool
+}
+
 type CloudProvider interface {
 	// CloudChanges returns recent mutating cloud control-plane events (AWS:
 	// CloudTrail) in the window, normalized to the engine-agnostic Change model so
-	// they join the same "what changed" timeline as GitOps diffs.
-	CloudChanges(ctx context.Context, sel Selector, w TimeWindow) ([]Change, error)
+	// they join the same "what changed" timeline as GitOps diffs. f narrows WHICH of
+	// those events are kept; the zero value keeps all of them.
+	CloudChanges(ctx context.Context, sel Selector, w TimeWindow, f CloudChangeFilter) ([]Change, error)
 	// ResourceHealth returns cloud-side state/health for resources backing the
 	// selector (EC2 instance status, ASG capacity/activities, EKS nodegroup), as
 	// normalized lines for the model.

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -1043,14 +1043,6 @@ type OwnerWalker interface {
 	WorkloadOwnership(ctx context.Context, namespace, labelSelector, podName string) (OwnerChain, error)
 }
 
-// CloudProvider abstracts read-only cloud-side context for an incident. It adds
-// the AWS-layer "what changed" lens (mutating control-plane events) and cloud
-// resource health (instances/ASGs/nodegroups) that the in-cluster signals can't see.
-//
-// Implemented with native cloud SDKs (aws-sdk-go-v2) and in-cluster identity
-// (EKS Pod Identity / IRSA) — not Steampipe and not a bundled CLI (both break the
-// single-binary property). Steampipe / cloud MCP servers stay optional MCP
-// extensions. Cloud is opt-in (config.cloud.provider).
 // CloudChangeFilter narrows which control-plane events CloudChanges keeps. It is a
 // parameter of that ONE method rather than a field on Selector, because Selector
 // answers "which object" and every other consumer of it — the GitOps providers'
@@ -1067,6 +1059,14 @@ type CloudChangeFilter struct {
 	FailedOnly bool
 }
 
+// CloudProvider abstracts read-only cloud-side context for an incident. It adds
+// the AWS-layer "what changed" lens (mutating control-plane events) and cloud
+// resource health (instances/ASGs/nodegroups) that the in-cluster signals can't see.
+//
+// Implemented with native cloud SDKs (aws-sdk-go-v2) and in-cluster identity
+// (EKS Pod Identity / IRSA) — not Steampipe and not a bundled CLI (both break the
+// single-binary property). Steampipe / cloud MCP servers stay optional MCP
+// extensions. Cloud is opt-in (config.cloud.provider).
 type CloudProvider interface {
 	// CloudChanges returns recent mutating cloud control-plane events (AWS:
 	// CloudTrail) in the window, normalized to the engine-agnostic Change model so


### PR DESCRIPTION
Four `BackupJobFailed` investigations across three days concluded that the failing RDS resource **"could not be identified"**, at **\$2.37**.

Each one correctly reported its own blocker: `cloud_what_changed` returns the most recent *mutating* events cluster-wide, and at the 25-event cap those are entirely Karpenter and SSM churn. The `CreateDBClusterSnapshot` calls that answered the question — failing daily with `InvalidDBClusterStateFault` against a cluster that had been renamed and stopped by hand — were **in CloudTrail the whole time, just past the cap**. The fifth investigation only found them by guessing the exact resource name out of a `discover_metrics` dimension listing.

## Filter, don't raise the cap

The cap is applied to the **newest** events, so raising it mostly buys more churn. `Selector.FailedOnly` keeps only calls CloudTrail recorded with an `errorCode`, so the cap is spent on events that can answer a *"why did this fail"* question.

CloudTrail accepts exactly **one** `LookupAttribute`, and it is already spent on `ResourceName` or `ReadOnly` — so the filter is client-side, and the scan pages **past** the cap to find sparse failures. Bounded at 20 pages (~1000 events) so a quiet window still returns promptly, reporting the existing truncation sentinel when it stops early.

`eventError` becomes the single reader of the raw CloudTrail payload — both the filter and the rendered `— FAILED: <code>` annotation key on it, so the two can never disagree about what failed.

## Two things that would have quietly undone it

- **The unscoped-widen retry preserves the filter.** Without that, a scoped failure lookup that misses widens into an unfiltered cluster-wide query and buries the rejected call under exactly the Karpenter churn the flag exists to skip past.
- **An empty filtered result names its filter.** `submit_findings` tells the model an empty result is not evidence of absence; the tool holds up its end:

  ```
  no FAILED AWS control-plane calls in the window (successful events were not listed —
  re-run without failed_only to see them)
  ```

## Tests replay the dead end

`TestCloudChangesFailedOnly` builds the live ordering — 30 `CreateTags` events newest, the failing snapshot call behind them — and **asserts the control first**: without the filter the answer is past the cap, exactly as observed. Only then does it assert the filter surfaces it with its error code. `TestCloudChangesFailedOnlyBoundsItsScan` pins the page budget from both sides: it must look past page one, and it must not walk the retention period.

Fixes **F3**.
