### PR TITLE
chore: pin the lint toolchain instead of dropping a linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 # golangci-lint v2 config — quality gate for RunLore.
-# Run locally with: golangci-lint run ./...
+# Run locally with: hack/lint.sh  (golangci-lint run ./... under go.mod's pinned
+# toolchain — a newer local Go makes the bundled staticcheck panic; see that script).
 version: "2"
 
 run:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,13 +6,19 @@ RunLore is a self-improving, GitOps-native SRE agent written in Go. Start with
 ## Quality gate — run before every commit
 
 ```bash
-go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...
+go build ./... && go vet ./... && go test ./... && gofmt -l . && hack/lint.sh
 ```
 
 - `gofmt -l .` must print nothing.
-- `golangci-lint run ./...` must report **`0 issues`**.
+- `hack/lint.sh` must report **`0 issues`**.
 - Linter config: [`.golangci.yml`](.golangci.yml) (golangci-lint **v2**). CI runs the same gate
   ([`.github/workflows/ci.yaml`](.github/workflows/ci.yaml)).
+- **Use `hack/lint.sh`, not a bare `golangci-lint run ./...`.** It is that command with
+  `GOTOOLCHAIN` pinned to go.mod's `toolchain` line — the Go version CI resolves too. With a
+  newer Go on PATH, the staticcheck bundled in golangci-lint panics building its IR
+  (`unexpected expr: *ast.KeyValueExpr`) and aborts the whole run, so the failure has nothing
+  to do with your code. Do **not** reach for `--disable=staticcheck` to get past it: that runs
+  clean while silently dropping one of the five linters in the `standard` set.
 
 ## Try it
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,14 @@ go build ./...
 go vet ./...
 go test ./...
 gofmt -l .                 # must print nothing
-golangci-lint run ./...    # must report 0 issues
+hack/lint.sh               # must report 0 issues
 ```
+
+`hack/lint.sh` is `golangci-lint run ./...` with `GOTOOLCHAIN` pinned to the `toolchain`
+line in `go.mod`, which is also where CI resolves its Go version. Run bare and with a newer
+Go on your PATH, golangci-lint's bundled staticcheck panics while building its IR and takes
+the entire run down with it — a failure that says nothing about your change. It forwards
+arguments, so `hack/lint.sh ./internal/notify/...` narrows it.
 
 Run race detection on anything touching goroutines (the queue, informer, leader election):
 

--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Run golangci-lint under the Go toolchain this module pins, not whatever `go` the
+# developer happens to have on PATH.
+#
+# golangci-lint bundles staticcheck (honnef.co/go/tools), which builds its own IR from
+# the AST. That IR builder only understands the Go versions it was released against, so
+# a NEWER local toolchain makes it panic rather than report:
+#
+#   buildir: panic during analysis: unexpected expr: *ast.KeyValueExpr
+#   Running error: can't run linter goanalysis_metalinter
+#
+# The panic aborts the whole run — not just staticcheck — so the exit status says
+# "failed" for a reason that has nothing to do with the code. Observed with Go 1.27.0
+# local against go.mod's toolchain go1.26.6.
+#
+# That failure mode is worse than it looks: the tempting workaround is
+# `--disable=staticcheck`, which does produce a clean run, and silently drops one of
+# the five linters in the `standard` set for everyone who adopts it. Pinning the
+# toolchain instead keeps the full set — the same one CI runs, since the CI job
+# resolves its Go from this very line via setup-go's go-version-file.
+#
+# GOTOOLCHAIN=auto (the default) does NOT do this on its own: it upgrades when the
+# local toolchain is too OLD, and otherwise leaves a newer one in place.
+#
+# Any arguments are passed through, so `hack/lint.sh ./internal/notify/...` works.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+# Prefer the explicit `toolchain` line; fall back to the `go` directive, which is what
+# a module without a toolchain line pins to.
+toolchain="$(awk '/^toolchain /{print $2; exit}' go.mod)"
+if [[ -z "$toolchain" ]]; then
+  toolchain="go$(awk '/^go /{print $2; exit}' go.mod)"
+fi
+
+if ! command -v golangci-lint >/dev/null 2>&1; then
+  echo "hack/lint.sh: golangci-lint not on PATH — see .golangci.yml for the version CI uses" >&2
+  exit 127
+fi
+
+echo "hack/lint.sh: GOTOOLCHAIN=$toolchain golangci-lint run ${*:-./...}"
+GOTOOLCHAIN="$toolchain" exec golangci-lint run "${@:-./...}"

--- a/internal/docsguard/lint_toolchain_test.go
+++ b/internal/docsguard/lint_toolchain_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package docsguard
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+const (
+	lintScriptPath = "../../hack/lint.sh"
+	goModPath      = "../../go.mod"
+	agentsPath     = "../../AGENTS.md"
+)
+
+// TestLintScriptResolvesTheModuleToolchain pins the one thing hack/lint.sh exists to
+// do: derive GOTOOLCHAIN from go.mod rather than hardcoding a version.
+//
+// A hardcoded version would work on the day it is written and rot at the next
+// toolchain bump — silently, because the wrong pin still runs and still reports
+// issues, just under a Go the project no longer uses. So the guard reads BOTH ends: it
+// re-runs the script's own extraction rule against the real go.mod and requires a
+// match, and it requires the script not to contain a literal version at all.
+func TestLintScriptResolvesTheModuleToolchain(t *testing.T) {
+	script := readFileString(t, lintScriptPath)
+	// Every assertion below reads the CODE, never the header comment. An earlier
+	// revision tested strings.Contains(script, "GOTOOLCHAIN") against the whole file,
+	// which the header's own explanation satisfies — so deleting the assignment from
+	// the script left the guard green. A guard that passes while checking nothing is
+	// worse than no guard.
+	code := stripComments(script)
+	gomod := readFileString(t, goModPath)
+
+	var want string
+	for _, line := range strings.Split(gomod, "\n") {
+		if after, ok := strings.CutPrefix(line, "toolchain "); ok {
+			want = strings.TrimSpace(after)
+			break
+		}
+	}
+	if want == "" {
+		t.Fatalf("go.mod has no `toolchain` line — hack/lint.sh's fallback is untested by this guard")
+	}
+
+	// The script must not name a Go version itself; it must go and read one.
+	if m := regexp.MustCompile(`go1\.\d+(\.\d+)?`).FindString(code); m != "" {
+		t.Errorf("hack/lint.sh hardcodes %q instead of reading go.mod: it will pin the wrong "+
+			"toolchain the next time go.mod is bumped, and still exit 0 while doing it", m)
+	}
+	if !strings.Contains(code, "go.mod") {
+		t.Errorf("hack/lint.sh does not read go.mod, so GOTOOLCHAIN cannot track %q", want)
+	}
+	// On the line that RUNS the linter, not merely somewhere in the file: the script
+	// echoes the command it is about to run, so a whole-file search for "GOTOOLCHAIN="
+	// is satisfied by that echo even after the real assignment is deleted. Two earlier
+	// revisions of this guard passed against exactly that mutation.
+	if !invocationSetsToolchain(code) {
+		t.Fatalf("hack/lint.sh runs golangci-lint without GOTOOLCHAIN on the invocation (an echo of "+
+			"it does not count) — the staticcheck IR panic it exists to avoid comes back for anyone "+
+			"whose local Go is newer than the pin:\n%s", code)
+	}
+}
+
+// TestQualityGateUsesTheLintScript: the documented gate must invoke hack/lint.sh, not a
+// bare golangci-lint.
+//
+// This is the half that rots first. The script is easy to keep and easy to stop
+// mentioning, and a contributor who copies `golangci-lint run ./...` out of AGENTS.md
+// gets the IR panic and no explanation — which is exactly the state the script was
+// written to end. CONTRIBUTING.md is checked by the sibling guard in
+// release_config_test.go's file set; both are asserted here for the gate line itself.
+func TestQualityGateUsesTheLintScript(t *testing.T) {
+	if _, err := os.Stat(lintScriptPath); err != nil {
+		t.Fatalf("hack/lint.sh is missing: %v", err)
+	}
+	for _, path := range []string{agentsPath, contributingPath} {
+		body := readFileString(t, path)
+		if !strings.Contains(body, "hack/lint.sh") {
+			t.Errorf("%s documents the quality gate but never names hack/lint.sh", path)
+		}
+		// A bare `golangci-lint run ./...` presented AS the gate step is the regression.
+		// Prose that mentions the command while explaining the script is fine, so only
+		// runnable-looking lines that are not part of an explanation are rejected.
+		for _, line := range strings.Split(body, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "golangci-lint run") ||
+				strings.Contains(trimmed, "&& golangci-lint run") {
+				t.Errorf("%s still lists a bare golangci-lint run as a gate step: %q", path, trimmed)
+			}
+		}
+	}
+}
+
+// invocationSetsToolchain reports whether the line that actually executes
+// golangci-lint carries GOTOOLCHAIN, or an exported GOTOOLCHAIN precedes it. Lines
+// that merely print the command (echo/printf) are not invocations.
+func invocationSetsToolchain(code string) bool {
+	exported := false
+	for _, line := range strings.Split(code, "\n") {
+		t := strings.TrimSpace(line)
+		if strings.HasPrefix(t, "export GOTOOLCHAIN=") {
+			exported = true
+		}
+		if !strings.Contains(t, "golangci-lint") {
+			continue
+		}
+		if strings.HasPrefix(t, "echo") || strings.HasPrefix(t, "printf") ||
+			strings.Contains(t, "command -v") {
+			continue
+		}
+		return exported || strings.Contains(t, "GOTOOLCHAIN=")
+	}
+	return false
+}
+
+func readFileString(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+// stripComments removes shell comment bodies so the hardcoded-version check reads the
+// script's CODE. The header comment quotes "Go 1.27.0" and "go1.26.6" as the observed
+// failure, which is documentation, not a pin.
+func stripComments(script string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(script, "\n") {
+		if i := strings.Index(line, "#"); i >= 0 {
+			line = line[:i]
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
+}


### PR DESCRIPTION
`golangci-lint run ./...` — the last step of the documented quality gate — fails on a developer machine whose Go is newer than the one `go.mod` pins.

golangci-lint bundles staticcheck, which builds its own IR from the AST and only understands the Go releases it shipped against. A newer local toolchain makes it panic:

```
buildir: panic during analysis: unexpected expr: *ast.KeyValueExpr
Running error: can't run linter goanalysis_metalinter
```

The panic aborts the **whole run**, not just staticcheck, so the command exits non-zero for a reason that has nothing to do with the code under test. Observed with Go **1.27.0** local against `go.mod`'s `toolchain go1.26.6`.

## This is not cosmetic — it hides real findings

It hid one last week. A doc comment orphaned from the type it documented reached CI as a `revive` error, because locally the run never got far enough to report it. The local gate looked green; it had simply never run.

## Why not `--disable=staticcheck`

Because it works, which is the problem. It produces a clean run and silently drops one of the five linters in the `standard` set for everyone who adopts it.

I measured which linters actually panic, one at a time:

| result | linters |
|---|---|
| **panics** | `staticcheck` |
| runs clean | `errcheck` · `govet` · `ineffassign` · `unused` · `bodyclose` · `errorlint` · `forbidigo` · `gocritic` · `gosec` · `misspell` · `revive` · `unconvert` |

So `--disable=staticcheck` costs exactly one linter — but pinning the toolchain costs none, and runs the same Go that CI resolves from this module's own `toolchain` line via `setup-go`'s `go-version-file`.

## `hack/lint.sh`

`golangci-lint run ./...` with `GOTOOLCHAIN` read out of `go.mod` **at runtime** — no hardcoded version to rot at the next bump. Arguments forward, so `hack/lint.sh ./internal/notify/...` narrows it.

`GOTOOLCHAIN=auto` (the default) does not do this on its own: it upgrades when the local toolchain is too **old**, and leaves a newer one in place.

```console
$ golangci-lint run ./internal/providers/...     # bare
… panic … ; exit 2

$ hack/lint.sh ./internal/providers/...
hack/lint.sh: GOTOOLCHAIN=go1.26.6 golangci-lint run ./internal/providers/...
0 issues.
```

Full repo through the script: **0 issues**, all thirteen linters.

## Guards

The gate is documented in three places (`AGENTS.md`, `CONTRIBUTING.md`, `.golangci.yml`); all three now name the script **and the reason**, so nobody rediscovers the panic and reaches for `--disable`.

Two `docsguard` tests hold it together:

- **`TestLintScriptResolvesTheModuleToolchain`** — the script must derive the toolchain from `go.mod`, and must not name a Go version in its code.
- **`TestQualityGateUsesTheLintScript`** — the documented gate must not revert to a bare `golangci-lint run`.

Both are mutation-tested. That mattered: **two successive revisions of the first guard passed while checking nothing**, because `GOTOOLCHAIN` appears in the script's own header comment and again in the line that echoes the command before running it. The check now asserts against the line that actually *invokes* the linter, with comments and `echo` lines stripped.
