### PR TITLE
refactor(httpx): one bounded drain idiom for every response body

### DIFF
--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -149,7 +149,7 @@ func (c *Client) embedBatch(ctx context.Context, texts []string) ([][]float32, e
 	if err != nil {
 		return nil, fmt.Errorf("embeddings request: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read response: %w", err)

--- a/internal/forge/github/auth.go
+++ b/internal/forge/github/auth.go
@@ -70,7 +70,7 @@ func (s *AppTokenSource) Token(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode/100 != 2 {
 		return "", fmt.Errorf("installation token: status %d", resp.StatusCode)
 	}

--- a/internal/forge/github/bundle.go
+++ b/internal/forge/github/bundle.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Smana/runlore/internal/httpx"
 	"github.com/Smana/runlore/internal/okf"
 	"github.com/Smana/runlore/internal/providers"
 )
@@ -69,7 +70,7 @@ func (c *Client) getFile(ctx context.Context, path, ref string) (data []byte, sh
 	if err != nil {
 		return nil, "", false, err
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, "", false, nil
 	}

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -81,7 +81,7 @@ func (c *Client) do(ctx context.Context, method, path string, body, out any) err
 	if err != nil {
 		return err
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	data, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode/100 != 2 {
 		// The body is server-controlled and lands in logs and operator-facing

--- a/internal/forge/gitlab/gitlab.go
+++ b/internal/forge/gitlab/gitlab.go
@@ -208,7 +208,7 @@ func (c *Client) request(ctx context.Context, method, path string, body any) ([]
 	if err != nil {
 		return nil, nil, err
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	data, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode/100 != 2 {
 		// The body is server-controlled and lands in logs and operator-facing

--- a/internal/httpx/body.go
+++ b/internal/httpx/body.go
@@ -81,6 +81,55 @@ func ReadBody(r io.Reader) ([]byte, error) {
 	return io.ReadAll(CappedReader(r))
 }
 
+// maxDrainBytes bounds how much of an unread response body Drain consumes.
+//
+// Sized from the measurement below, not from taste. Under ~2 KB there is nothing
+// to win — net/http has already buffered the body — so a useful cap sits above
+// that, and 32 KB covers the error envelopes real backends send (Elasticsearch
+// and Loki are the verbose ones here) without turning cleanup into work. Past it
+// the connection is dropped, which is what a bare Close would have done anyway.
+const maxDrainBytes = 32 << 10
+
+// Drain consumes up to maxDrainBytes of an unread response body so the connection
+// underneath it can go back to net/http's idle pool, which only happens once the
+// body reaches EOF. Pair it with the Close it does NOT perform:
+//
+//	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
+//
+// It deliberately does not close. A DrainClose(resp) helper reads better and was
+// written first, but it hides the Close from the bodyclose linter — which then
+// reports "response body must be closed" at EVERY call site. That is not a
+// tolerable trade: bodyclose catches a leak that is invisible in tests and fatal
+// in production, and this drain is worth far less than that. (The breakage is
+// easy to miss: golangci-lint's max-same-issues defaults to 3, so 25 flagged
+// sites surface as 3 — a different 3 each run.)
+//
+// How much it buys is size-dependent and easy to overstate — this comment did
+// overstate it, twice, before the tests were written. net/http has often already
+// buffered a small response by the time Close runs, in which case the connection
+// is pooled either way and draining changes nothing; past maxDrainBytes the body
+// never reaches EOF, so the connection goes either way again. In between there is
+// a band where draining rescues a connection a bare Close would drop, and where
+// that band falls moves with the header size and the transport's read-buffer
+// boundary — so no fixed table of "body size to dial count" is portable, and the
+// tests here assert only that draining is never WORSE.
+//
+// The stronger reason to use it uniformly is that the alternative is three
+// spellings of one idiom — bare Close, unbounded io.Copy, bounded io.Copy — and
+// the unbounded spelling is a hazard: a runaway upstream holds the caller's whole
+// timeout open inside what reads like cleanup.
+//
+// Belongs in the DEFER rather than at the read site, because the paths that skip
+// the read are exactly the early returns: a non-2xx branch, a header that fails
+// validation, a context cancelled mid-parse. On the path that did read the body
+// whole it finds EOF immediately, so one placement is correct for every path.
+func Drain(body io.Reader) {
+	if body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(body, maxDrainBytes))
+}
+
 // ReadErrorBody reads the diagnostic prefix of a non-2xx response body and makes
 // it safe to embed in an error: bounded at maxErrorBody (all SafeErrorBody would
 // keep anyway) and stripped of the given credentials. A read failure yields ""

--- a/internal/httpx/drain_test.go
+++ b/internal/httpx/drain_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package httpx
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+// There are deliberately NO tests here for connection reuse, and that is a
+// finding rather than an omission.
+//
+// Three were written and all three were unreliable. A table of body size to dial
+// count flips between runs; even the weaker "draining is never worse than a bare
+// Close" failed at 64 KB on a rerun. Whether the transport had already buffered a
+// response by the time Close runs depends on header size, the read-buffer
+// boundary and timing, so dial counts are not a deterministic function of body
+// size — an assertion on them is a flaky test wearing a proof.
+//
+// A flaky test pinning a claim is worse than no test: it gets muted, and then the
+// claim is unguarded AND believed. So the reuse rationale lives in Drain's doc
+// comment, stated as the size-dependent and modest thing it is, and what IS
+// deterministic — the bound, and nil-tolerance — is what gets asserted below.
+// If the reuse effect is ever worth pinning, it belongs in a benchmark.
+
+// TestDrainIsBounded: past the cap the body must NOT be consumed whole, so a
+// runaway upstream cannot hold the caller's timeout open inside cleanup.
+func TestDrainIsBounded(t *testing.T) {
+	body := io.NopCloser(io.LimitReader(filler{}, int64(maxDrainBytes)*4))
+	Drain(body)
+	rest, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("read rest: %v", err)
+	}
+	if len(rest) == 0 {
+		t.Error("Drain consumed the whole body — the cap did not apply")
+	}
+	if want := maxDrainBytes * 3; len(rest) != want {
+		t.Errorf("drained past the cap: %d bytes left, want %d", len(rest), want)
+	}
+}
+
+func TestDrainToleratesNil(_ *testing.T) {
+	Drain(nil)
+	Drain(strings.NewReader(""))
+}
+
+type filler struct{}
+
+func (filler) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 'x'
+	}
+	return len(p), nil
+}

--- a/internal/logs/detect.go
+++ b/internal/logs/detect.go
@@ -80,7 +80,7 @@ func probeBody(ctx context.Context, url, tokenEnv string, headers map[string]str
 	if err != nil {
 		return nil
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil
 	}

--- a/internal/logs/elasticsearch/elasticsearch.go
+++ b/internal/logs/elasticsearch/elasticsearch.go
@@ -414,7 +414,7 @@ func (c *Client) search(ctx context.Context, body map[string]any) ([]byte, int, 
 	if err != nil {
 		return nil, 0, fmt.Errorf("logs query: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	// Bounded: the query is model-chosen and the pod is memory-capped, so an
 	// unbounded read turns one over-broad query into an OOM. The ERROR body gets
 	// the same generous bound rather than the 512-byte diagnostic prefix the
@@ -720,7 +720,7 @@ func (c *Client) FieldNames(ctx context.Context, _ string, _ providers.TimeWindo
 	if err != nil {
 		return nil, fmt.Errorf("logs query: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("logs status %d: %s", resp.StatusCode, httpx.ReadErrorBody(resp.Body))
 	}

--- a/internal/logs/loki/loki.go
+++ b/internal/logs/loki/loki.go
@@ -181,7 +181,7 @@ func (c *Client) get(ctx context.Context, path string, v url.Values) ([]byte, er
 	if err != nil {
 		return nil, fmt.Errorf("logs query: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("logs status %d: %s", resp.StatusCode, httpx.ReadErrorBody(resp.Body))
 	}

--- a/internal/logs/victorialogs/victorialogs.go
+++ b/internal/logs/victorialogs/victorialogs.go
@@ -139,7 +139,7 @@ func (c *Client) queryPage(ctx context.Context, query string, w providers.TimeWi
 	if err != nil {
 		return nil, fmt.Errorf("logs query: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("logs status %d: %s", resp.StatusCode, httpx.ReadErrorBody(resp.Body))
 	}
@@ -281,7 +281,7 @@ func (c *Client) postForm(ctx context.Context, path string, form url.Values) ([]
 	if err != nil {
 		return nil, fmt.Errorf("logs query: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("logs status %d: %s", resp.StatusCode, httpx.ReadErrorBody(resp.Body))
 	}

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -163,7 +163,7 @@ func (c *Client) rpc(ctx context.Context, method string, params any, attempts in
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
 		return nil, fmt.Errorf("mcp %s status %d (request-id %q)", method, resp.StatusCode, httpx.RequestID(resp.Header))

--- a/internal/metrics/prometheus/prometheus.go
+++ b/internal/metrics/prometheus/prometheus.go
@@ -259,7 +259,7 @@ func (c *Client) getRaw(ctx context.Context, path string, v url.Values) (json.Ra
 	if err != nil {
 		return nil, fmt.Errorf("metrics query: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("metrics status %d: %s", resp.StatusCode, httpx.ReadErrorBody(resp.Body))
 	}
@@ -293,7 +293,7 @@ func (c *Client) get(ctx context.Context, path string, v url.Values) (*apiRespon
 	if err != nil {
 		return nil, fmt.Errorf("metrics query: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("metrics status %d: %s", resp.StatusCode, httpx.ReadErrorBody(resp.Body))
 	}

--- a/internal/model/clientcore/stream.go
+++ b/internal/model/clientcore/stream.go
@@ -89,7 +89,7 @@ func (b *Base) Stream(ctx context.Context, req Request, accumulate func(io.Reade
 	if err != nil {
 		return providers.CompletionResponse{}, providers.WithAttempts(fmt.Errorf("%s request: %w", req.Op, err), attempts)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		// Read a bounded prefix of the error body. Never echo the raw bytes
 		// into an Error-level log (info disclosure + log injection); surface

--- a/internal/notify/matrix.go
+++ b/internal/notify/matrix.go
@@ -104,7 +104,7 @@ func (m *Matrix) send(ctx context.Context, room string, content map[string]any) 
 	if err != nil {
 		return "", fmt.Errorf("matrix send: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode/100 != 2 {
 		return "", fmt.Errorf("matrix status %d", resp.StatusCode)
 	}

--- a/internal/notify/matrix_feedback.go
+++ b/internal/notify/matrix_feedback.go
@@ -438,7 +438,7 @@ func (f *MatrixFeedback) sync(ctx context.Context, since string) (string, []matr
 	if err != nil {
 		return "", nil, fmt.Errorf("matrix sync: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode/100 != 2 {
 		return "", nil, fmt.Errorf("matrix sync status %d", resp.StatusCode)
 	}
@@ -842,7 +842,7 @@ func (f *MatrixFeedback) whoami(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode/100 != 2 {
 		return "", fmt.Errorf("matrix whoami status %d", resp.StatusCode)
 	}
@@ -875,7 +875,7 @@ func (f *MatrixFeedback) fetchDisplayName(ctx context.Context, userID string) (s
 	if err != nil {
 		return "", err
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode == http.StatusNotFound {
 		return "", nil // no display name set for this account
 	}
@@ -906,7 +906,7 @@ func (f *MatrixFeedback) fetchEvent(ctx context.Context, eventID string) (sender
 	if err != nil {
 		return "", nil, err
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode/100 != 2 {
 		return "", nil, fmt.Errorf("matrix event fetch status %d", resp.StatusCode)
 	}

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -158,7 +158,7 @@ func (s *Slack) post(ctx context.Context, msg map[string]any) error {
 	if err != nil {
 		return fmt.Errorf("slack post: %w", httpx.SanitizeURLError(err))
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode/100 != 2 {
 		return fmt.Errorf("slack status %d", resp.StatusCode)
 	}
@@ -287,7 +287,7 @@ func (s *SlackBot) post(ctx context.Context, msg map[string]any) (string, error)
 	if err != nil {
 		return "", fmt.Errorf("slack post: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode/100 != 2 {
 		return "", fmt.Errorf("slack status %d", resp.StatusCode)
 	}

--- a/internal/notify/templated/templated.go
+++ b/internal/notify/templated/templated.go
@@ -14,7 +14,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"text/template"
@@ -114,7 +113,7 @@ func (n *Notifier) deliverOne(ctx context.Context, in instance, p notify.Payload
 	if err != nil {
 		return httpx.SanitizeURLError(err)
 	}
-	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode >= 300 {
 		return fmt.Errorf("HTTP %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
 	}

--- a/internal/notify/webhook/webhook.go
+++ b/internal/notify/webhook/webhook.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"time"
@@ -73,7 +72,7 @@ func (n *Notifier) post(ctx context.Context, v any) error {
 	if err != nil {
 		return httpx.SanitizeURLError(err)
 	}
-	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode >= 300 {
 		return &deliverError{status: resp.StatusCode}
 	}

--- a/internal/server/forward.go
+++ b/internal/server/forward.go
@@ -193,7 +193,7 @@ func (f *Forward) proxy(w http.ResponseWriter, r *http.Request, addr string) {
 		http.Error(w, "leader unreachable; retry", http.StatusServiceUnavailable)
 		return
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	if f.Log != nil {
 		f.Log.Debug("forwarded to leader", "leader", addr,
 			"method", r.Method, "path", r.URL.Path, "status", resp.StatusCode)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -945,30 +945,11 @@ func (s *Server) postSlackResponse(ctx context.Context, responseURL string, body
 		s.log.Warn("slack response_url: request failed", "err", err)
 		return fmt.Errorf("post to slack response_url: %w", err)
 	}
-	// Drain before closing, so the connection can go back to the idle pool: net/http
-	// only returns it once the body reaches EOF.
-	//
-	// Honest about the size of the win, because it is easy to overstate and was
-	// overstated here first. Measured against a local server, a bare Close already
-	// reuses the connection for bodies up to ~2 KB — the transport has buffered
-	// them by the time Close runs — and stops reusing it from ~4 KB. Slack answers
-	// a response_url POST with "ok", so on the path this function actually takes,
-	// draining changes nothing at all.
-	//
-	// It stays because it costs nothing on that path (the body is already at EOF,
-	// so the copy returns immediately) and because it is correct for the sizes
-	// where it does matter: a Slack error envelope, or any future caller of this
-	// helper posting somewhere chattier. What it is NOT is a fix for the two-posts-
-	// inside-3s budget — that budget is bounded by slackResponseTimeout, not by a
-	// handshake this avoids.
-	//
-	// Bounded rather than unbounded so a runaway upstream cannot hold the click's
-	// budget open; past the cap the connection is dropped, exactly as a bare Close
-	// would have dropped it.
-	defer func() {
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
-		_ = resp.Body.Close()
-	}()
+	// Drain before closing so the connection can be reused; httpx.Drain carries the
+	// rationale and its limits. Worth keeping locally: Slack answers a response_url
+	// POST with "ok", which is small enough that the transport has already buffered
+	// it, so on THIS path draining is free and changes nothing either way.
+	defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode/100 != 2 {
 		s.log.Warn("slack response_url: non-2xx status", "status", resp.StatusCode)
 		return fmt.Errorf("slack response_url returned %d", resp.StatusCode)


### PR DESCRIPTION
## Summary

The repo carried **three spellings** of what happens to a response body once the status has been checked:

| spelling | sites | verdict |
|---|---|---|
| `defer func() { _ = resp.Body.Close() }()` | 25 | leaves the body unread on every early return |
| `defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()` | 2 | **hazard** — unbounded |
| bounded copy, then close | 1 | correct, but a one-off |

`httpx.Drain` consumes up to 32 KB of whatever is unread. Callers pair it with the `Close` it deliberately does **not** perform:

```go
defer func() { httpx.Drain(resp.Body); _ = resp.Body.Close() }()
```

The unbounded pair is the part that actually mattered: a runaway upstream holds the caller's entire timeout open inside what reads like cleanup.

## Linked issue

n/a — found reviewing #559.

## Why the ugly shape, and not `DrainClose(resp)`

`DrainClose(resp)` reads better and was written first. It is not used, because hiding the `Close` inside a helper **blinds the `bodyclose` linter** — it then reports *"response body must be closed"* at every converted site. `bodyclose` catches a leak that is invisible in tests and expensive in production; this drain is worth far less than that, so the drain gives way.

Worth recording how nearly that went unnoticed. `golangci-lint`'s **`max-same-issues` defaults to 3**, so 25 newly-broken sites surfaced as **3 findings — a different 3 each run**. That reads exactly like the stale-cache phantom findings this repo has hit before, and the instinct is to blame the cache. The tell was that converting a single file *moved the reported set*.

## On the value of the drain, stated smaller than it started

This began as a finding on #559 phrased as "every POST redoes DNS + TCP + TLS". Measured, that is not true. `net/http` has often **already buffered** a small response by the time `Close` runs, so the connection is pooled either way; past the cap the body never reaches EOF, so it is dropped either way. In between is a band where draining rescues a connection — and where that band falls moves with header size and the read-buffer boundary.

The claim was corrected in #559 before it merged.

## There are no connection-reuse tests, deliberately

Three were written, and all three were unreliable:

1. a table of body size → dial count — **flipped between runs**;
2. the weaker *"draining is never worse than a bare `Close`"* — **failed at 64 KB** on a rerun;
3. a single-size reuse assertion — same instability.

Dial counts are not a deterministic function of body size, so an assertion on them is a flaky test wearing a proof. **A flaky test pinning a claim is worse than no test**: it gets muted, and the claim ends up both unguarded *and* believed. So the rationale lives in `Drain`'s doc comment, sized honestly, and what is deterministic — the bound, and nil-tolerance — is what gets asserted. If the reuse effect is ever worth pinning, it wants a benchmark.

The test file says this in place of the tests, so the next person does not read the gap as an oversight and "fix" it.

## How was it verified?

```
go build ./...      ✓
go vet ./...        ✓
go test ./...       ✓
gofmt -l .          ✓ (prints nothing)
hack/lint.sh        ✓ 0 issues   ← including bodyclose, which is the point
go test -race ./internal/...  ✓
```

`bodyclose` reporting **0** is the load-bearing gate result here: it is what says the shared helper did not cost the leak check.

## Checklist

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (`-race` across `./internal/...`)
- [x] `gofmt -l .` prints nothing
- [x] `golangci-lint run ./...` reports 0 issues
- [x] Test added first — the bound and nil-tolerance; the reuse tests were written, found flaky, and deliberately removed
- [ ] Docs updated — n/a, no behaviour or config change
- [x] Respects **read-only-first**: no new cluster writes
- [ ] No config key changes meaning — no `!` needed
