### PR TITLE
fix(gcp): allow the GKE metadata server by address, and warn when cloud config is inert

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ additive. Full setup detail in **[Data sources](https://runlore.io/docs/concepts
 | **Metrics** | VictoriaMetrics · Prometheus *(PromQL)* | `metrics.url` |
 | **Logs** | VictoriaLogs *(LogsQL)* | `logs.url` |
 | **Network flows** | Cilium Hubble · AWS VPC Flow Logs · GCP Firewall Logs | `network.provider` |
-| **Cloud** | AWS — CloudTrail + EC2 / ASG / EKS · GCP — [Cloud Audit Logs + GKE / MIG / Compute](https://runlore.io/docs/integrations/data-sources/gcp-cloud/) (unverified on live GKE) | `cloud.provider` |
+| **Cloud** | AWS — CloudTrail + EC2 / ASG / EKS · GCP — [Cloud Audit Logs + GKE / MIG / Compute](https://runlore.io/docs/integrations/data-sources/gcp-cloud/) (starts on live GKE; lens responses unobserved) | `cloud.provider` |
 | **Kubernetes** | client-go — pod status, events, controller logs | *(in-cluster)* |
 | **LLM** | Anthropic · Google Gemini · any OpenAI-compatible *(vLLM, Ollama, OpenRouter…)* | `model.provider` |
 | **Triggers** *(sources)* | Alertmanager webhook · GitOps failures · PagerDuty webhook *(new)* | `sources.*` |

--- a/deploy/helm/runlore/templates/networkpolicy.yaml
+++ b/deploy/helm/runlore/templates/networkpolicy.yaml
@@ -101,32 +101,22 @@ spec:
     {{- with .Values.networkPolicy.extraEgress }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-{{- if or .Values.networkPolicy.awsPodIdentity .Values.networkPolicy.gcpWorkloadIdentity }}
+{{- if .Values.networkPolicy.awsPodIdentity }}
 ---
-# Cloud in-cluster identity: allow the node-local credential endpoint.
+# EKS Pod Identity: allow the credential endpoint on the node's host network.
 #
-# Both clouds need the same thing, which is why this is ONE policy rather than two. The
-# credential endpoint runs on the node host network at a link-local address on :80 —
-# 169.254.170.23 for EKS Pod Identity, 169.254.169.254 for the GKE metadata server (and
-# Azure IMDS, when that arrives). Cilium classifies all of them as the "host" entity,
-# which a Kubernetes NetworkPolicy ipBlock cannot match, so the credential fetch is
-# silently DROPPED and no ipBlock rule can fix it. A CiliumNetworkPolicy toEntities:
-# [host] is the supported way to allow it, and "the node's host entity on :80" is
-# already cloud-independent — the two policies this replaced had byte-identical specs
-# and differed only in name.
+# The Pod Identity agent genuinely runs on the node host network at 169.254.170.23:80,
+# and Cilium classifies it as the "host" entity — which a Kubernetes NetworkPolicy
+# ipBlock cannot match, so without this the credential fetch is silently DROPPED and no
+# ipBlock rule can fix it.
 #
-# The failure does not look like a network failure, on either cloud. With no token the
-# cloud SDK reports a CREDENTIALS error, and RunLore's preflight answers a credentials
-# error with an IAM binding command — so the operator adds a binding that is already
-# correct, the symptom does not move, and nothing anywhere mentions egress.
-#
-# Enable when cloud.provider is set AND the cluster runs Cilium. Either toggle turns it
-# on; they are kept separate because they are the operator-facing API and their
-# documentation legitimately differs.
+# The failure does not look like a network failure. With no token the AWS SDK reports a
+# CREDENTIALS error, so the operator goes looking at IAM while nothing anywhere mentions
+# egress.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: {{ include "runlore.fullname" . }}-cloud-identity-host-egress
+  name: {{ include "runlore.fullname" . }}-aws-pod-identity
   labels:
     {{- include "runlore.labels" . | nindent 4 }}
 spec:
@@ -135,6 +125,48 @@ spec:
       {{- include "runlore.selectorLabels" . | nindent 6 }}
   egress:
     - toEntities: [host]
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+{{- end }}
+{{- if .Values.networkPolicy.gcpWorkloadIdentity }}
+---
+# GKE Workload Identity: allow the metadata server by ADDRESS, not by the host entity.
+#
+# This is a separate policy from the AWS one above, and the difference is load-bearing
+# rather than cosmetic. Both endpoints are link-local addresses on :80, which is why
+# these two were once merged into a single `toEntities: [host]` rule — reasoning that
+# "the node's host entity on :80" covered both clouds. It does not. Cilium does NOT
+# classify 169.254.169.254 as the host entity on GKE, so that rule matched nothing and
+# every metadata call was dropped. Measured on GKE Standard 1.35.6-gke.1710000 with
+# self-managed Cilium, from a pod carrying these same labels (#562):
+#
+#   toEntities: [host]              -> curl 169.254.169.254/... timed out
+#   toCIDR: [169.254.169.254/32]    -> returned the project id
+#
+# Adding the toCIDR rule was the only change between a startup that logged
+# `source:"unresolved"` and one that logged `source:"metadata-server"`.
+#
+# Do not re-merge these two policies. The endpoints look interchangeable and are not.
+#
+# The failure is worse than a plain drop, because it does not present as a network
+# problem: autodetection fails, RunLore reports `gcp: project is required (set
+# cloud.gcp.project)`, and an operator who follows that hardcodes the three values and
+# "fixes" the symptom — while ADC still cannot mint a token for the API calls that come
+# later, and nothing in the chain has mentioned egress.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "runlore.fullname" . }}-gcp-workload-identity
+  labels:
+    {{- include "runlore.labels" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      {{- include "runlore.selectorLabels" . | nindent 6 }}
+  egress:
+    - toCIDR: ["169.254.169.254/32"]
       toPorts:
         - ports:
             - port: "80"

--- a/deploy/helm/runlore/templates/rbac.yaml
+++ b/deploy/helm/runlore/templates/rbac.yaml
@@ -40,8 +40,11 @@ rules:
   # Limit(1) and happens once at startup.
   #
   # Node objects carry no secret material, but this is still a cluster-wide grant for a
-  # fallback: if a live GKE run reports identity_source=metadata-server, tier 3 is not
-  # needed on that cluster and this rule can go with it.
+  # fallback. The first live run (GKE Standard 1.35.6, #562) reported
+  # source=metadata-server, so tier 3 contributed nothing there. Kept anyway: one cluster
+  # in one mode does not cover "every GKE version and mode", and AUTOPILOT is untested —
+  # the mode most likely to expose a different metadata surface. An Autopilot run that
+  # also reports metadata-server retires tier 3 and this rule together.
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["list"]

--- a/deploy/helm/runlore/values-full.yaml
+++ b/deploy/helm/runlore/values-full.yaml
@@ -165,11 +165,13 @@ networkPolicy:
     - namespaceSelector:
         matchLabels: { kubernetes.io/metadata.name: monitoring }
   # Cilium only: the cloud credential endpoint (EKS Pod Identity 169.254.170.23:80, or
-  # the GKE metadata server 169.254.169.254:80) runs on the node host network, which a
-  # plain NetworkPolicy cannot match — the credential fetch is then silently dropped and
-  # the cloud tools never authenticate. Both toggles render the same policy; set the one
-  # matching config.cloud.provider. This is the CREDENTIAL fetch only; the cloud API
-  # calls it authorises need the 443 rule in extraEgress above.
+  # the GKE metadata server 169.254.169.254:80) is unreachable under a plain
+  # NetworkPolicy — the credential fetch is then silently dropped and the cloud tools
+  # never authenticate. Each toggle renders its OWN policy and the rules differ:
+  # toEntities:[host] for AWS, toCIDR:169.254.169.254/32 for GKE, where Cilium does NOT
+  # classify the metadata server as the host entity (#562). Set the one matching
+  # config.cloud.provider. This is the CREDENTIAL fetch only; the cloud API calls it
+  # authorises need the 443 rule in extraEgress above.
   awsPodIdentity: true
   gcpWorkloadIdentity: false
 

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -688,22 +688,28 @@ networkPolicy:
   #         matchLabels:
   #           kubernetes.io/metadata.name: monitoring
   ingressFrom: []
-  # Cloud in-cluster identity, Cilium only. Either toggle renders the SAME
-  # CiliumNetworkPolicy (…-cloud-identity-host-egress): egress to the node's host entity
-  # on :80, where both clouds' credential endpoints live — 169.254.170.23 for EKS Pod
-  # Identity, 169.254.169.254 for the GKE metadata server. Cilium classifies those as the
-  # "host" entity, which a plain NetworkPolicy ipBlock cannot match, so the credential
-  # fetch is silently dropped. Other CNIs match the link-local address with an ordinary
-  # ipBlock, which `strict: false` already permits.
+  # Cloud in-cluster identity, Cilium only. Each toggle renders its OWN
+  # CiliumNetworkPolicy, and the two rules are NOT interchangeable:
   #
-  # Worth enabling deliberately rather than discovering. With no token the cloud SDK
-  # reports a CREDENTIALS error, and RunLore's preflight answers a credentials error with
-  # an IAM binding command — so the operator adds a binding that was already right, the
-  # symptom does not move, and nothing in the chain mentions egress.
+  #   awsPodIdentity      -> toEntities: [host]           (169.254.170.23, EKS Pod Identity)
+  #   gcpWorkloadIdentity -> toCIDR: 169.254.169.254/32   (the GKE metadata server)
   #
-  # Kept as two keys because they document two different clouds; set the one that matches
-  # cloud.provider. This is the CREDENTIAL fetch only — the cloud API calls it authorises
-  # are ordinary 443 egress and need their own rule under `egress` in strict mode.
+  # Both endpoints are link-local addresses on :80, which is why these once shared a
+  # single `toEntities: [host]` rule. That was wrong: Cilium does NOT classify
+  # 169.254.169.254 as the host entity on GKE, so the shared rule matched nothing and
+  # every metadata call was dropped. Measured on GKE Standard 1.35.6 with self-managed
+  # Cilium — `toEntities: [host]` timed out, `toCIDR` returned the project id (#562).
+  # Set the one that matches cloud.provider; do not assume the other would also work.
+  #
+  # Worth enabling deliberately rather than discovering, because on neither cloud does
+  # the failure look like a network failure. With no token the cloud SDK reports a
+  # CREDENTIALS error, and on GCP autodetection then fails with "project is required
+  # (set cloud.gcp.project)" — which reads as a config problem, so the operator hardcodes
+  # the three values, "fixes" the symptom, and still has no token for the API calls that
+  # come later. Nothing in that chain mentions egress.
+  #
+  # This is the CREDENTIAL fetch only — the cloud API calls it authorises are ordinary
+  # 443 egress and need their own rule under `egress` in strict mode.
   awsPodIdentity: false
   gcpWorkloadIdentity: false
 

--- a/internal/app/cloud_wiring_test.go
+++ b/internal/app/cloud_wiring_test.go
@@ -255,3 +255,57 @@ func TestAnUnknownProviderNamesTheSupportedOnesFromTheFactoryTable(t *testing.T)
 		}
 	}
 }
+
+// TestCloudProviderWithoutAModelIsNotSilent pins the fix for the silence a first live
+// GKE install hit (#562).
+//
+// Every investigation tool is wired inside BuildModelAndTools, and BuildDeps returns nil
+// before reaching it when no model is configured. So `cloud: {provider: gcp}` on an
+// install that had not yet configured a model produced NO GCP log line at all — not the
+// resolved-identity line, not a preflight verdict, not even "cloud tools disabled". The
+// operator's reasonable conclusion was that the cloud block had been ignored.
+//
+// The asymmetry is what makes it a defect rather than a missing nicety: every other
+// outcome for that block says something. A typo warns, an unreachable metadata server
+// warns, a denied binding warns and prints a command. Only the case that is nobody's
+// fault is silent.
+func TestCloudProviderWithoutAModelIsNotSilent(t *testing.T) {
+	var buf bytes.Buffer
+
+	cfg := &config.Config{}
+	cfg.Cloud.Provider = config.CloudGCP // deliberately set, and inert without a model
+
+	if deps := BuildDeps(context.Background(), cfg, nil, nil, nil, captureLog(&buf)); deps != nil {
+		t.Fatal("BuildDeps returned deps with no model configured")
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, `"level":"WARN"`) {
+		t.Errorf("a deliberately-set cloud.provider was silently inert:\n%s", out)
+	}
+	// Naming the key is what separates this from a generic "no model" line: the operator
+	// is looking for the fate of the block they wrote, not for a model warning.
+	if !strings.Contains(out, "cloud.provider="+config.CloudGCP) {
+		t.Errorf("the warning does not name the key that was set, so it does not answer the "+
+			"question the operator actually has:\n%s", out)
+	}
+	// And the fix has to be in the line, or the operator has a symptom and no next move.
+	if !strings.Contains(out, "model.provider") {
+		t.Errorf("the warning does not name what to set to enable the tools:\n%s", out)
+	}
+}
+
+// TestNoDatasourceConfiguredStaysQuietWithoutAModel: running without a model is a
+// supported mode — the GitOps watch alone is useful, and the issue above reports it
+// flagging four real failures before any model existed. It must not warn about a
+// datasource nobody configured.
+func TestNoDatasourceConfiguredStaysQuietWithoutAModel(t *testing.T) {
+	var buf bytes.Buffer
+
+	if deps := BuildDeps(context.Background(), &config.Config{}, nil, nil, nil, captureLog(&buf)); deps != nil {
+		t.Fatal("BuildDeps returned deps with no model configured")
+	}
+	if out := buf.String(); strings.Contains(out, `"level":"WARN"`) {
+		t.Errorf("a model-less install with no cloud block warned about one:\n%s", out)
+	}
+}

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -581,11 +581,40 @@ type Deps struct {
 // their read-only paths). Call it once; pass the result everywhere.
 func BuildDeps(ctx context.Context, cfg *config.Config, gp providers.GitOpsProvider, metrics *telemetry.Metrics, ledger *outcome.Ledger, log *slog.Logger) *Deps {
 	if !ModelConfigured(cfg) {
+		warnDatasourcesWithoutModel(cfg, log)
 		return nil
 	}
 	model, tools, recall, cat := BuildModelAndTools(ctx, cfg, gp, metrics, log)
 	wireRecall(recall, metrics, ledger, log)
 	return &Deps{Model: model, Tools: tools, Recall: recall, Catalog: cat}
+}
+
+// warnDatasourcesWithoutModel warns when a datasource is configured but no model is, so
+// nothing that datasource feeds is ever registered.
+//
+// BuildDeps returns nil the moment ModelConfigured is false, and EVERY investigation
+// tool is wired inside BuildModelAndTools, below that line. The result was total
+// silence: a first install with `cloud: {provider: gcp}` and no model logged nothing
+// whatsoever about GCP — no resolved-identity line, no preflight verdict, not even
+// "cloud tools disabled" — and the operator reasonably read that as the cloud block
+// being ignored (#562). Every other outcome for that block, including outright failure,
+// says something; only the one that is nobody's fault says nothing.
+//
+// Scoped to keys an operator sets DELIBERATELY and then waits for a startup line from.
+// The broader "tell me which tools are unconfigured" signal is #467; this is its inverse
+// — configured, and inert for a reason nothing states.
+func warnDatasourcesWithoutModel(cfg *config.Config, log *slog.Logger) {
+	var configured []string
+	if cfg.Cloud.Provider != "" {
+		configured = append(configured, "cloud.provider="+cfg.Cloud.Provider)
+	}
+	if len(configured) == 0 {
+		return
+	}
+	log.Warn("datasource configured but no model is: none of its tools are registered, because "+
+		"every investigation tool is wired behind a configured model. Set model.provider "+
+		"(anthropic/gemini) or model.base_url to enable them.",
+		"configured", configured)
 }
 
 // recurrenceGateWanted reports whether the suppression gate must exist at all.

--- a/internal/docsguard/cloud_identity_netpol_test.go
+++ b/internal/docsguard/cloud_identity_netpol_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package docsguard
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const netpolPath = "../../deploy/helm/runlore/templates/networkpolicy.yaml"
+
+// ciliumEgressRule is one entry of a CiliumNetworkPolicy's egress[].
+type ciliumEgressRule struct {
+	ToEntities []string `yaml:"toEntities"`
+	ToCIDR     []string `yaml:"toCIDR"`
+}
+
+type ciliumPolicyDoc struct {
+	Kind     string `yaml:"kind"`
+	Metadata struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		Egress []ciliumEgressRule `yaml:"egress"`
+	} `yaml:"spec"`
+}
+
+// ciliumPolicies parses every CiliumNetworkPolicy document out of the chart template,
+// keyed by the literal suffix of its name.
+//
+// The template is read and parsed rather than rendered with `helm template`, matching
+// gitops_rbac_test.go: the gate runs on a Go toolchain with no helm binary. Only the
+// CiliumNetworkPolicy documents are parsed — the NetworkPolicy document above them is
+// dense with range/toYaml actions whose blanked remains are not worth reasoning about,
+// and nothing here asserts anything about it.
+func ciliumPolicies(t *testing.T) map[string]ciliumPolicyDoc {
+	t.Helper()
+	b, err := os.ReadFile(netpolPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", netpolPath, err)
+	}
+	out := map[string]ciliumPolicyDoc{}
+	for _, raw := range strings.Split(string(b), "\n---\n") {
+		if !strings.Contains(raw, "kind: CiliumNetworkPolicy") {
+			continue
+		}
+		var doc ciliumPolicyDoc
+		if err := yaml.Unmarshal([]byte(helmAction.ReplaceAllString(raw, "")), &doc); err != nil {
+			t.Fatalf("parse CiliumNetworkPolicy document: %v\n%s", err, raw)
+		}
+		out[strings.TrimPrefix(doc.Metadata.Name, "-")] = doc
+	}
+	return out
+}
+
+// TestCloudIdentityPoliciesAreNotInterchangeable pins the fix for #562, and exists
+// because the bug it pins was introduced by a refactor that looked obviously correct.
+//
+// Both clouds' credential endpoints are link-local addresses served on :80 by the node,
+// so the two policies read as duplicates and were merged into one `toEntities: [host]`
+// rule. They are not duplicates. Cilium classifies 169.254.170.23 (the EKS Pod Identity
+// agent, which genuinely runs on the node host network) as the host entity, and does NOT
+// classify GKE's 169.254.169.254 that way — so the merged rule matched nothing on GKE and
+// every metadata call was dropped.
+//
+// That failure is invisible from the chart and nearly invisible from the logs: RunLore
+// reports "project is required (set cloud.gcp.project)", which reads as a config problem,
+// so the operator hardcodes the scope, the symptom disappears, and ADC still cannot mint
+// a token. Nothing in the chain mentions egress. A unit test is the only cheap place this
+// is ever going to be caught — the expensive place is a live GKE cluster, which is where
+// it was caught the first time.
+func TestCloudIdentityPoliciesAreNotInterchangeable(t *testing.T) {
+	policies := ciliumPolicies(t)
+
+	if len(policies) != 2 {
+		t.Fatalf("expected two separate cloud-identity policies, got %d: %v\n"+
+			"One policy for both clouds is exactly the #562 regression: the two endpoints "+
+			"look interchangeable and are not.", len(policies), keysOf(policies))
+	}
+
+	gcp, ok := policies["gcp-workload-identity"]
+	if !ok {
+		t.Fatalf("no gcp-workload-identity policy; have %v", keysOf(policies))
+	}
+	aws, ok := policies["aws-pod-identity"]
+	if !ok {
+		t.Fatalf("no aws-pod-identity policy; have %v", keysOf(policies))
+	}
+
+	// GCP: the metadata server must be allowed by ADDRESS. toEntities:[host] does not
+	// match it, which is the whole defect.
+	var gcpCIDRs []string
+	for _, r := range gcp.Spec.Egress {
+		gcpCIDRs = append(gcpCIDRs, r.ToCIDR...)
+		if len(r.ToEntities) > 0 {
+			t.Errorf("the GKE policy allows egress by entity %v. Cilium does not classify "+
+				"169.254.169.254 as any node entity, so this matches nothing and the token "+
+				"fetch is silently dropped (#562)", r.ToEntities)
+		}
+	}
+	if !contains(gcpCIDRs, "169.254.169.254/32") {
+		t.Errorf("the GKE policy does not allow 169.254.169.254/32; ADC cannot reach the "+
+			"metadata server and autodetection reports a misleading 'project is required'. "+
+			"Allowed: %v", gcpCIDRs)
+	}
+
+	// AWS: toEntities:[host] is CORRECT here and must not be "fixed" to match GCP. The
+	// Pod Identity agent really does run on the node's host network.
+	var awsEntities []string
+	for _, r := range aws.Spec.Egress {
+		awsEntities = append(awsEntities, r.ToEntities...)
+	}
+	if !contains(awsEntities, "host") {
+		t.Errorf("the EKS policy no longer allows the host entity (%v). 169.254.170.23 IS on "+
+			"the node host network, which no ipBlock or toCIDR rule can match — this is the "+
+			"one case where toEntities is the right answer", awsEntities)
+	}
+}
+
+func keysOf(m map[string]ciliumPolicyDoc) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func contains(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/providers/cloud/gcp/identity.go
+++ b/internal/providers/cloud/gcp/identity.go
@@ -16,9 +16,9 @@ import (
 //
 // The first two exist on every Compute Engine instance. The two cluster attributes are
 // GKE-specific: the control plane stamps them onto each node's instance metadata, and
-// the GKE metadata server is what re-serves them to a Pod. Whether it re-serves
-// cluster-location across every GKE version and mode is the open question this
-// package's tier 3 exists to cover.
+// the GKE metadata server is what re-serves them to a Pod. It does re-serve
+// cluster-location on GKE Standard 1.35.6 (#562); whether it does so across every GKE
+// version and mode — Autopilot above all — is the open question tier 3 still covers.
 const (
 	metaProjectID   = "project/project-id"
 	metaProjectNum  = "project/numeric-project-id"
@@ -206,6 +206,14 @@ func ResolveIdentity(ctx context.Context, cfg Identity, nodes NodeLookup, log *s
 // the zero-configuration promise should not rest on an untested assumption. A live GKE
 // startup log line reporting source=metadata-server settles that; source=node-provider-id
 // says this tier earned its place.
+//
+// STATUS: the first live run (GKE Standard 1.35.6-gke.1710000, zonal, self-managed
+// Cilium — #562) reported source=metadata-server, so tier 3 contributed nothing there.
+// That is one version in one mode, and the criterion above is "every GKE version and
+// mode". AUTOPILOT is the reading still wanted: it is the mode most likely to expose a
+// different metadata surface, and it is the one where an operator has the least
+// visibility of the node layer to fall back on. An Autopilot run reporting
+// metadata-server retires this block by the removal recipe below.
 //
 // It is WIRED: internal/app passes a NodeLookup backed by the cluster reader, so that
 // log line can actually be produced. It was briefly not, and the difference matters —

--- a/website/content/docs/concepts/data-sources.md
+++ b/website/content/docs/concepts/data-sources.md
@@ -15,7 +15,7 @@ assumed).
 | Metrics | `query_metrics`, `query_metrics_range`, `alert_rule` | `MetricsProvider` (+ optional `AlertRuleReader`) | VictoriaMetrics, Prometheus (PromQL) | `metrics.url` |
 | Logs | `query_logs`, `logs_error_summary`, `discover_log_fields` | `LogsProvider` | VictoriaLogs (LogsQL) · Grafana Loki (LogQL) · Elasticsearch/OpenSearch (`_search` DSL) | `logs.url` (+ optional `logs.provider`) |
 | Network flows | `network_drops` | `NetworkProvider` | Cilium Hubble · AWS VPC Flow Logs · GCP Firewall Logs | `network.provider` |
-| Cloud control plane | `cloud_*` | `CloudProvider` | AWS (CloudTrail + EC2/ASG/EKS) · GCP ([Cloud Audit Logs + GKE/MIG/Compute]({{< relref "/docs/integrations/data-sources/gcp-cloud.md" >}}) — not yet verified on a live cluster) | `cloud.provider` |
+| Cloud control plane | `cloud_*` | `CloudProvider` | AWS (CloudTrail + EC2/ASG/EKS) · GCP ([Cloud Audit Logs + GKE/MIG/Compute]({{< relref "/docs/integrations/data-sources/gcp-cloud.md" >}}) — starts on live GKE; lens responses unobserved) | `cloud.provider` |
 | Kubernetes | `pod_status`, `kube_events`, `controller_logs`, `pod_logs`, `resource_spec` | `KubeReader`/`LogReader`/`ResourceSpecReader` | client-go | (in-cluster) |
 | Knowledge | `kb_search` | catalog index | bleve BM25 | `catalog.*` |
 | Source repos | `source_diff` | built-in (go-git) | any git host over HTTPS (GitHub App auth) | `source_repos.allow` |

--- a/website/content/docs/concepts/design.md
+++ b/website/content/docs/concepts/design.md
@@ -312,13 +312,15 @@ Interfaces live in `internal/providers/providers.go`. "For the moment" impls:
 | Notifier | `Notifier` | **Slack**, **Matrix** | PagerDuty, incident.io |
 | Issue | `IssueProvider` | **GitHub** (App auth) | GitLab (access token) |
 
-> ¹ **GCP is implemented but not yet verified on a live GKE cluster.** Both lenses, three-tier
-> identity resolution and the Workload Identity preflight are unit-tested against `httptest`
-> fixtures — but those fixtures were hand-written from the API reference rather than captured from
-> real responses, so the shapes are plausible rather than observed. See [GCP cloud control
-> plane]({{< relref "/docs/integrations/data-sources/gcp-cloud.md" >}}) for what the live run is
-> expected to settle, including whether the GKE metadata server exposes `cluster-location` to Pods
-> across every GKE version and mode — the one open question the design records.
+> ¹ **GCP starts and authenticates on live GKE; its lenses' responses are still unobserved.**
+> A first run on GKE Standard 1.35.6 with self-managed Cilium
+> ([#562](https://github.com/Smana/runlore/issues/562)) confirmed three-tier identity resolution
+> (the metadata server answered, so tier 3 contributed nothing) and that a Workload Identity
+> direct principal binding passes the preflight. What remains unobserved is a real Cloud Logging
+> or Container API payload: the tests run against `httptest` fixtures hand-written from the API
+> reference, so response shapes are plausible rather than captured. See [GCP cloud control
+> plane]({{< relref "/docs/integrations/data-sources/gcp-cloud.md" >}}) for what is settled and
+> what is not — Autopilot, which decides whether the node-tier fallback survives, is untested.
 
 > **Cloud via native SDKs.** The AWS impl (`internal/providers/cloud/aws`, `aws-sdk-go-v2`) is **read-only**:
 > `CloudChanges` = CloudTrail `LookupEvents` (mutating events → the engine-agnostic `Change` model, so
@@ -329,13 +331,17 @@ Interfaces live in `internal/providers/providers.go`. "For the moment" impls:
 > `CloudChanges` = Cloud Audit Logs `entries.list` over the `activity`/`system_event` streams,
 > `ResourceHealth` = GKE/MIG/Compute Engine describes, auth a Workload Identity **direct principal
 > binding** (no GSA, no ServiceAccount annotation). Both lenses are implemented and
-> `wireCloudProvider` wires the provider into `serve`; what is missing is a run against a live
-> cluster (see the footnote above). Azure would follow the same shape too, once started. Steampipe and cloud
+> `wireCloudProvider` wires the provider into `serve`; what is missing is an investigation that
+> actually calls the lenses on a live cluster (see the footnote above). Azure would follow the same shape too, once started. Steampipe and cloud
 > MCP servers remain available as optional MCP extensions.
 >
-> On Cilium clusters the Pod Identity credential endpoint is a host-network target (`169.254.170.23:80`),
-> which a Kubernetes NetworkPolicy can't match — the chart's `networkPolicy.awsPodIdentity` renders a
-> `CiliumNetworkPolicy` (`toEntities: [host]`) to allow it.
+> On Cilium clusters the credential endpoint needs its own `CiliumNetworkPolicy`, and the two clouds
+> need *different* rules. `networkPolicy.awsPodIdentity` renders `toEntities: [host]` — the EKS Pod
+> Identity agent (`169.254.170.23:80`) really does run on the node host network, which a Kubernetes
+> NetworkPolicy can't match. `networkPolicy.gcpWorkloadIdentity` renders
+> `toCIDR: 169.254.169.254/32` instead, because Cilium does **not** classify the GKE metadata server
+> as the `host` entity: a shared rule was tried, matched nothing, and dropped every metadata call
+> ([#562](https://github.com/Smana/runlore/issues/562)).
 
 **Why the GitOps abstraction is real, not hand-wavy** — both engines reduce to *revision history +
 git diff*:

--- a/website/content/docs/integrations/_index.md
+++ b/website/content/docs/integrations/_index.md
@@ -74,7 +74,7 @@ it would have unlocked.
   {{< hextra/feature-card link="data-sources/aws-cloud/" icon="cloud-download" title="AWS cloud control plane"
     subtitle="CloudTrail + EC2/ASG/EKS — what changed outside GitOps." >}}
   {{< hextra/feature-card link="data-sources/gcp-cloud/" icon="cloud-download" title="GCP cloud control plane"
-    subtitle="Cloud Audit Logs + GKE/MIG/Compute. Not yet verified on a live cluster." >}}
+    subtitle="Cloud Audit Logs + GKE/MIG/Compute. Starts on live GKE; lens responses unobserved." >}}
   {{< hextra/feature-card link="data-sources/source-repos/" icon="link" title="Source repos"
     subtitle="Turns a manifest bump into the actual code diff behind it." >}}
   {{< hextra/feature-card link="data-sources/mcp/" icon="puzzle" title="MCP"

--- a/website/content/docs/integrations/data-sources/gcp-cloud.md
+++ b/website/content/docs/integrations/data-sources/gcp-cloud.md
@@ -4,17 +4,17 @@ weight: 311
 integration: {kind: cloud, id: gcp}
 ---
 
-> **Status: implemented, not yet verified on a live GKE cluster.** Both lenses,
-> identity resolution and the Workload Identity preflight are implemented and unit-tested
-> against `httptest` fixtures hand-written from the API reference. `cloud.provider: gcp`
-> registers the cloud tools and logs the resolved project, location, cluster and the tier
-> autodetection resolved them from.
+> **Status: starts and authenticates on a live GKE cluster; the two lenses' responses are
+> still unobserved.** A first run on GKE Standard 1.35.6 with self-managed Cilium
+> ([#562](https://github.com/Smana/runlore/issues/562)) confirmed startup end to end —
+> the metadata server resolves all three scope fields, a Workload Identity direct
+> principal binding is accepted, and the preflight passes, registering both tools.
 >
-> What has *not* happened is a run against a real cluster. The fixtures were written from
-> documentation rather than captured from live responses, so the shapes are plausible
-> rather than observed — see [Live validation](#live-validation) for what that leaves open.
-> This is the same "functional but less exercised" posture the project uses elsewhere, and
-> it is a weaker claim than the AWS provider's.
+> What is still *not* observed is a real Cloud Logging or Container API payload. The unit
+> tests run against `httptest` fixtures hand-written from the API reference, so the
+> response shapes remain plausible rather than captured — see
+> [Live validation](#live-validation) for which questions that leaves open. This is still
+> a weaker claim than the AWS provider's.
 
 ## What it gives you
 
@@ -114,11 +114,18 @@ resolved triple alone cannot be checked, because autodetection landing on a same
 a neighbouring region answers confidently about the wrong cluster and is indistinguishable from a
 quiet one.
 
-It also settles whether tier 3 is needed at all. `source=metadata-server` proves the GKE metadata
-server proxies `instance/attributes/cluster-location` to Pods on your cluster, which means the
-node fallback contributed nothing and can be removed along with the `nodes` RBAC rule it needs;
-`source=node-provider-id` proves it earned its place. If you run this on GKE, that one field is
-the most useful thing you can report back.
+It also settles whether tier 3 is needed on your cluster. `source=metadata-server` means the
+metadata server answered and the node fallback contributed nothing; `source=node-provider-id`
+means the fallback earned its place. On GKE Standard 1.35.6 it reported `metadata-server`
+([#562](https://github.com/Smana/runlore/issues/562)). **The reading still wanted is an
+Autopilot one** — that is the mode most likely to expose a different metadata surface, and it
+decides whether tier 3 and its cluster-wide `nodes` RBAC grant can be dropped. If you run this
+on Autopilot, that one field is the most useful thing you can report back.
+
+If autodetection fails outright — `source="unresolved"` and a `project is required` error — on a
+Cilium cluster, read [Cilium clusters need one extra toggle](#cilium-clusters-need-one-extra-toggle)
+before setting `cloud.gcp.*`. A blocked metadata server presents as a config problem, and
+hardcoding the values hides it without fixing the token path.
 
 ## Autopilot
 
@@ -158,10 +165,8 @@ reported plainly, with no hedge at all.
 
 ## Cilium clusters need one extra toggle
 
-ADC fetches its Workload Identity token from the GKE metadata server on the node host
-network (`169.254.169.254:80`). Cilium classifies that as the `host` entity, which a
-Kubernetes NetworkPolicy `ipBlock` cannot match — so on Cilium the token fetch is
-silently dropped:
+ADC fetches its Workload Identity token from the GKE metadata server at
+`169.254.169.254:80`, and on Cilium that fetch is dropped unless you allow it:
 
 <!-- docsguard:ignore Helm chart values, not a runlore.yaml — networkPolicy is a chart key, outside .Values.config -->
 
@@ -170,46 +175,78 @@ networkPolicy:
   gcpWorkloadIdentity: true   # Cilium only
 ```
 
-Worth setting deliberately rather than discovering, because the failure does not look
-like a network failure. With no token the Google client reports a *credentials* error,
-and RunLore's preflight answers a credentials error with an IAM binding command — so you
-add a binding that was already correct, the symptom does not move, and nothing in the
-chain mentions egress.
+**This toggle is not interchangeable with `awsPodIdentity`, and the reason is worth
+knowing if you write your own policy.** The two once shared a single
+`toEntities: [host]` rule, on the reasoning that both clouds' credential endpoints are
+link-local addresses served by the node. That is false on GKE: Cilium does **not**
+classify `169.254.169.254` as the `host` entity, so the shared rule matched nothing.
+A/B tested on GKE Standard 1.35.6 with self-managed Cilium, from a pod carrying
+RunLore's own labels ([#562](https://github.com/Smana/runlore/issues/562)):
 
-Other CNIs match the link-local address with an ordinary `ipBlock`, which the default
+| egress rule | `curl http://169.254.169.254/computeMetadata/v1/project/project-id` |
+|---|---|
+| `toEntities: [host]` | **timed out** |
+| `toCIDR: [169.254.169.254/32]` | returned the project id |
+
+So `gcpWorkloadIdentity` renders `toCIDR`, and `awsPodIdentity` keeps `toEntities:
+[host]`, which is correct there — the EKS Pod Identity agent really does run on the node
+host network.
+
+Worth setting deliberately rather than discovering, because the failure does not present
+as a network failure at any point. With no token, autodetection finds nothing and RunLore
+reports:
+
+```
+gcp: could not resolve project, location or cluster … source="unresolved"
+cloud provider unavailable; cloud tools disabled  err="gcp: project is required (autodetection found none; set cloud.gcp.project)"
+```
+
+That reads as a configuration problem. Follow it, hardcode all three values, and the
+symptom goes away while ADC still cannot mint a token for the API calls that come later —
+which then fail as a *credentials* error, which the preflight answers with an IAM binding
+command, sending you to fix a binding that was already correct. Nothing anywhere in that
+chain mentions egress. **If autodetection fails on a Cilium cluster, check this toggle
+before you touch `cloud.gcp.*`.**
+
+Non-Cilium CNIs match the link-local address with an ordinary `ipBlock`, which the default
 `strict: false` already permits. In strict mode you must additionally allow 443 to
 `logging.googleapis.com`, `container.googleapis.com` and `compute.googleapis.com` — the
 toggle above covers only the token fetch, not the API calls it authenticates.
 
 ## Live validation
 
-Not yet run. The unit tests use `httptest` fixtures hand-written from the API reference,
-so every shape below is plausible rather than observed — this section records what a run
-against a real cluster is expected to settle.
+First run: GKE Standard 1.35.6-gke.1710000, zonal `europe-west4-a`, self-managed Cilium
+([#562](https://github.com/Smana/runlore/issues/562)). Two of the six questions are
+settled; the rest need an investigation that actually calls the lenses.
 
-1. **Which tier resolves the scope.** The startup line reports `identity_source`. Seeing
-   `metadata-server` there is proof the Kubernetes-node fallback contributed nothing — and
-   that fallback is provisional precisely because it is not established that the GKE
-   metadata server exposes `instance/attributes/cluster-location` to Pods across every GKE
-   version and mode. If tier 2 proves reliable, the node tier is deleted rather than kept
-   as dead weight.
-2. **Whether `protoPayload.status.code!=0` matches an absent field.** A successful audit
-   entry omits `status` entirely. If Cloud Logging's `!=` over-matches, `failed_only`
-   becomes correct-but-slow — it pages through successes — rather than wrong, because a
-   local re-check drops any entry that arrives with a zero status.
-3. **Whether a stockout actually surfaces.** Request a rare machine type in a node pool and
-   confirm `listErrors` reports it. This is the highest-value line the provider emits.
-4. **Whether Autopilot answers the node-layer lookups at all.** They are attempted rather
-   than skipped, and an empty answer is caveated — the live run says which of those two
-   paths a real Autopilot cluster takes.
-5. **Which `StatusCondition` field GKE populates** on a degraded pool: `canonicalCode`,
-   the deprecated `code`, or both. All three are handled; only a live response says which
-   is observed.
-6. **That the printed IAM binding works when pasted.** Unbind a role, trigger the preflight,
-   and paste the command it prints. The project *number* in the `principal://` string is the
-   part most often wrong, and gcloud accepts the id without ever matching.
+**1. Which tier resolves the scope — settled: `metadata-server`.** All three fields came
+from tier 2, so the Kubernetes-node fallback contributed nothing on that cluster. It also
+settles the sub-question this page flagged as unestablished: the GKE metadata server
+*does* proxy `instance/attributes/cluster-location` to Pods.
 
-Once run, the fixtures should be replaced with captured responses.
+That is one cluster, and one mode. Tier 3 stays for now rather than being deleted on it —
+the bar stated here was "across every GKE version and mode", and **Autopilot in
+particular is still untested**, which is exactly the mode most likely to differ in what
+its metadata server exposes. If an Autopilot run also reports `source=metadata-server`,
+tier 3 and the `nodes` RBAC rule it needs should go together.
+
+**6. That the printed IAM binding works when pasted — settled for the positive half.**
+Three roles bound to the direct principal using the project **number** produced a passing
+preflight, so `cloud provider enabled` is itself evidence that a binding in that exact
+shape is accepted. The negative path was not exercised: no role was unbound to make the
+preflight *print* its command, so the generated text remains unverified.
+
+**2, 3, 5 — still open.** They need real `cloud_what_changed` / `cloud_resource_health`
+calls. On that run the tools registered (`tools: 13`, `incident_timeline cloud:true`) and
+an investigation was accepted, but no evidence was emitted before teardown. Nothing was
+observed either way about `protoPayload.status.code!=0` over an absent field, whether a
+stockout surfaces through `listErrors`, or which `StatusCondition` field GKE populates.
+
+**4. Whether Autopilot answers the node-layer lookups — not applicable.** That cluster was
+Standard.
+
+Until 2, 3 and 5 are answered, the fixtures stay hand-written from the API reference and
+should be replaced with captured responses once a real payload is seen.
 
 ## Reference
 


### PR DESCRIPTION
## Summary

Both defects from the first live GKE run ([#562](https://github.com/Smana/runlore/issues/562)), plus the doc corrections the run forced. Environment: GKE Standard 1.35.6-gke.1710000, zonal, self-managed Cilium, image at `e0c75f20`.

## Defect 1 — the GKE metadata server was never permitted

**This one is a regression I introduced in #561.** Commit `f2f35d45` merged the two per-cloud CiliumNetworkPolicies into one, on an explicit and wrong premise:

> Cilium classifies all of them as the "host" entity […] the two policies this replaced had byte-identical specs and differed only in name.

Byte-identical specs, yes. Interchangeable, no. Cilium classifies `169.254.170.23` (the EKS Pod Identity agent, which genuinely runs on the node host network) as the `host` entity, and does **not** classify GKE's `169.254.169.254` that way. The merged rule matched nothing on GKE.

| egress rule | `curl 169.254.169.254/computeMetadata/v1/project/project-id` |
|---|---|
| `toEntities: [host]` — what shipped | **timed out** |
| `toCIDR: [169.254.169.254/32]` | returned the project id |

Split back into two policies, using **the names that shipped in v0.15.0** — `-aws-pod-identity` and `-gcp-workload-identity`. The merged name `-cloud-identity-host-egress` never made a release, so no deployment sees a rename. AWS keeps `toEntities: [host]`; that is correct there and must not be "fixed" to match GCP.

### Why this deserved a test rather than just a fix

The failure never presents as a network problem. Autodetection fails, RunLore says `project is required (set cloud.gcp.project)`, and an operator who follows that hardcodes the three values, "fixes" the symptom, and still has no token for the API calls that come later. Nothing in the chain mentions egress.

So `internal/docsguard/cloud_identity_netpol_test.go` parses the chart and asserts the two policies stay distinct. Mutation-tested against all three ways this breaks:

| mutation | caught |
|---|---|
| GCP reverted to `toEntities: [host]` (the shipped bug) | ✓ |
| the two policies re-merged into one | ✓ |
| AWS "fixed" to `toCIDR` to match GCP | ✓ |

A unit test is the only cheap place to catch this. The expensive place is a live GKE cluster, which is where it was caught the first time.

## Defect 2 — `cloud.provider` silently inert without a model

Every investigation tool is wired inside `BuildModelAndTools`, and `BuildDeps` returns `nil` before reaching it when no model is configured. So `cloud: {provider: gcp}` on a model-less install logged **nothing whatsoever** about GCP — no identity line, no preflight verdict, not even "cloud tools disabled".

The asymmetry is what makes it a defect rather than a missing nicety: a typo warns, an unreachable metadata server warns, a denied binding warns *and prints a command*. Only the case that is nobody's fault was silent.

`warnDatasourcesWithoutModel` follows `warnSilenceWithoutFeedback` in the same file. It names the key that was set and what to set to enable it — a generic "no model configured" line would not answer the question the operator actually has. Running model-less stays quiet when no datasource is configured; that is a supported mode, and the issue reports it flagging four real failures before any model existed.

## Tier 3 stays, with the evidence recorded

The run settled live-validation item 1: `source=metadata-server`, all three fields resolved, so the node fallback contributed nothing. `gcp-cloud.md` promised deletion on exactly that reading.

Keeping it anyway. The stated bar was "across every GKE version and mode", and this is one version in one mode — **Autopilot is untested**, and it is both the mode most likely to expose a different metadata surface and the one where an operator has least visibility of the node layer to fall back on. `identity.go`'s tier-3 banner and the `nodes` RBAC comment now record the measurement and name an Autopilot run as what retires them. The removal recipe was already written and is unchanged.

## Docs

The false Cilium claim was asserted in four places — `gcp-cloud.md`, `design.md`, `values.yaml`, `values-full.yaml` — and is corrected in all of them, with the A/B result rather than a bare assertion. `gcp-cloud.md` also gains a pointer from the autodetection-failure symptom back to the toggle, since that is the path an operator actually walks.

Status downgraded honestly rather than upgraded: **"starts and authenticates on live GKE; the two lenses' responses are still unobserved"** — items 2, 3 and 5 need an investigation that actually calls the lenses, and no real Cloud Logging or Container API payload has been seen. The fixtures stay hand-written until one is.

## How was it verified?

```
go build ./...                    ✓
go vet ./...                      ✓
gofmt -l .                        ✓ (prints nothing)
go test ./...                     ✓
go test -race ./internal/...      ✓
hack/lint.sh                      ✓ 0 issues
helm lint deploy/helm/runlore     ✓ 0 failed
helm template — all 3 toggle combinations render as intended
```

Not verified: the fix on a live GKE cluster. The A/B in #562 establishes that `toCIDR` reaches the metadata server from a pod under these labels, and the chart now renders exactly that rule — but nobody has yet installed this chart on GKE and watched it resolve. Worth a re-run before the next release.

## Linked issue

Closes #562.

## Checklist

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (`-race` across `./internal/...`)
- [x] `gofmt -l .` prints nothing
- [x] `golangci-lint run ./...` reports 0 issues
- [x] Test added first — and mutation-tested against the exact regression it pins
- [x] Docs updated — the disproven claim corrected in all four places that asserted it
- [x] Respects **read-only-first** — no new cluster writes; the RBAC grant is unchanged
- [ ] No config key changes meaning — `gcpWorkloadIdentity` keeps its meaning; only the rule it renders changes
