### PR TITLE
fix(chart): grant list on resourceSpecRules, or list_resources ships denied

### DIFF
--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -575,6 +575,34 @@ rbac:
   # on the ServiceAccount. Read it as "what you are about to grant", not as "examples you
   # may enable".
   #
+  # `get` AND `list`, because TWO tools read through these rules and they need
+  # different verbs. resource_spec reads one object BY NAME (`get`); list_resources
+  # ENUMERATES a kind (`list`), and it is registered automatically alongside
+  # resource_spec — pairing them is deliberate, see investigate.go.
+  #
+  # Granting `get` alone therefore ships list_resources permanently denied: the tool
+  # is offered to the model, the model calls it, and the answer is "forbidden" for
+  # every kind. The agent reports that as a DATA GAP rather than an error, so it
+  # reasons around the missing evidence and nothing in the logs says why. Observed on
+  # a real cluster in 2026-08: three separate investigations reported gaps that were
+  # all this one missing verb.
+  #
+  # ── ADDING A RULE REPLACES THIS LIST. IT DOES NOT MERGE. ────────────────────────
+  #
+  # This is a YAML list, so Helm `--set-file`/values overlays and Kustomize patches
+  # REPLACE it wholesale. Writing:
+  #
+  #   rbac:
+  #     resourceSpecRules:
+  #       - apiGroups: ["cloud.example.com"]      # <- your CRD
+  #         resources: ["widgets"]
+  #         verbs: ["get", "list"]
+  #
+  # does not add an eleventh rule; it leaves you with ONE, and silently drops the ten
+  # below. Everything the agent could previously read — Deployments, Services, PVCs,
+  # HPAs, the scrape CRs — becomes "forbidden", with no error at install time and no
+  # warning at runtime. To extend, COPY the whole list and append.
+  #
   # TO DECLINE THE WHOLE GRANT:
   #
   #   rbac:
@@ -603,40 +631,40 @@ rbac:
   resourceSpecRules:
     - apiGroups: [""]
       resources: ["services", "persistentvolumeclaims", "persistentvolumes", "nodes", "namespaces"]
-      verbs: ["get"]
+      verbs: ["get", "list"]
     - apiGroups: ["apps"]
       resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
-      verbs: ["get"]
+      verbs: ["get", "list"]
     - apiGroups: ["batch"]
       resources: ["jobs", "cronjobs"]
-      verbs: ["get"]
+      verbs: ["get", "list"]
     - apiGroups: ["networking.k8s.io"]
       resources: ["ingresses", "networkpolicies", "ingressclasses"]
-      verbs: ["get"]
+      verbs: ["get", "list"]
     - apiGroups: ["autoscaling"]
       resources: ["horizontalpodautoscalers"]
-      verbs: ["get"]
+      verbs: ["get", "list"]
     - apiGroups: ["policy"]
       resources: ["poddisruptionbudgets"]
-      verbs: ["get"]
+      verbs: ["get", "list"]
     # storageclasses is NOT here on purpose: it has no .spec and no .status, so the read
     # comes back empty. "A PVC bound to a vanished storage class" is answered from the
     # PVC's own spec/status, which IS granted above.
     - apiGroups: ["storage.k8s.io"]
       resources: ["volumeattachments"]
-      verbs: ["get"]
+      verbs: ["get", "list"]
     - apiGroups: ["apiextensions.k8s.io"]
       resources: ["customresourcedefinitions"]
-      verbs: ["get"]
+      verbs: ["get", "list"]
     # Scrape/alert CRs: the case this tool was built for was a VMServiceScrape whose
     # namespaceSelector named a namespace that did not exist. A rule naming an API group
     # the cluster does not serve is inert, so both operators are listed by default.
     - apiGroups: ["operator.victoriametrics.com"]
       resources: ["vmservicescrapes", "vmpodscrapes", "vmscrapeconfigs", "vmrules", "vmagents", "vmalerts"]
-      verbs: ["get"]
+      verbs: ["get", "list"]
     - apiGroups: ["monitoring.coreos.com"]
       resources: ["servicemonitors", "podmonitors", "prometheusrules", "probes"]
-      verbs: ["get"]
+      verbs: ["get", "list"]
 
 # Default-deny NetworkPolicy: restrict ingress to the webhook/health port and egress
 # to DNS + HTTPS + the Kubernetes API. Tighten egress to your model/git/observability

--- a/website/content/docs/security/security-model.md
+++ b/website/content/docs/security/security-model.md
@@ -112,11 +112,19 @@ The chart's RBAC is scoped tightly (`deploy/helm/runlore/templates/rbac.yaml`):
   silent drift); leaving both at the defaults limits raw-log reads to the incident namespace plus
   `flux-system`. The app guard must stay a superset of the RBAC namespaces, or `pod_logs` is blocked at
   the app layer for namespaces RBAC would otherwise permit.
-- **`resource_spec`'s read-only kind allowlist:** `rbac.resourceSpecRules` grants `get` on the
-  spec-bearing kinds the tool reads (Services, workloads, NetworkPolicies, HPAs, PVCs, PVs, Nodes,
-  scrape CRs …). **It ships populated — this is a default grant, not an opt-in menu**: a stock
+- **`resource_spec` and `list_resources`' read-only kind allowlist:** `rbac.resourceSpecRules`
+  grants `get` **and `list`** on the spec-bearing kinds these tools read (Services, workloads,
+  NetworkPolicies, HPAs, PVCs, PVs, Nodes, scrape CRs …). Both verbs are needed because two tools
+  share the rules: `resource_spec` reads one object by name (`get`), while `list_resources`
+  enumerates a kind (`list`) and is registered automatically alongside it. Granting `get` alone
+  leaves `list_resources` permanently denied — and the agent reports that as a **data gap rather
+  than an error**, so it reasons around the missing evidence and nothing says why.
+  **Adding a rule REPLACES this list rather than merging into it** — a values overlay or Kustomize
+  patch that names one CRD leaves you with that one rule and silently drops the shipped ten, with
+  no install-time error. To extend, copy the whole list and append.
+  **It ships populated — this is a default grant, not an opt-in menu**: a stock
   install adds 10 rules — 28 resource types, 23 of them granted nowhere else — of cluster-wide
-  `get`, on top of the ClusterRole's 9 base rules. Set
+  `get` and `list`, on top of the ClusterRole's 9 base rules. Set
   `rbac.resourceSpecRules: []` to decline it in full (that costs you `resource_spec` and nothing
   else — `workload_ownership`'s owner-chain kinds are granted separately and unconditionally, so
   narrowing this list can never silently truncate an owner chain). Kinds with **neither `.spec` nor


### PR DESCRIPTION
fix(chart): grant list on resourceSpecRules, or list_resources ships denied

Two tools read through `rbac.resourceSpecRules` and they need different verbs.
`resource_spec` reads one object BY NAME (`get`). `list_resources` ENUMERATES a
kind (`list`), and it is registered automatically alongside resource_spec —
investigate.go pairs them deliberately, because "registering the by-name reader
without the lister is what forces a model to guess names".

The shipped rules granted `get` only. So every stock install offers the model a
tool that is permanently forbidden: it is advertised, called, and denied for
every kind.

The failure is quiet, which is why it survived. The agent reports a denial as a
DATA GAP, not an error — so it reasons around the missing evidence and produces a
plausible answer with an unexamined hole in it, and nothing in the logs says why.
Seen on a live cluster in August 2026: three separate investigations reported
gaps ("cannot read ExternalSecret objects", "cannot read the CNPG Cluster",
"cannot confirm whether the bucket exists") that were all this one missing verb.

Also documents the trap that makes this worse to fix by hand: **adding a rule
REPLACES the list rather than merging into it.** It is a YAML list, so a values
overlay or Kustomize patch naming one CRD leaves you with that one rule and
silently drops the shipped ten — no install-time error, no runtime warning, and
everything the agent could previously read becomes "forbidden". An operator
hitting the missing-verb bug above and adding their own rule to fix it lands
straight in this one. Documented in values.yaml and in the security model.

  helm lint            0 charts failed (values.schema.json included)
  helm template        renders get + list on all 10 rules
